### PR TITLE
CLR hosting using C# AOT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
       run: dotnet pack --no-build --configuration Release
 
     - name: Test
+      env:
+        NODE_API_DOTNET_TRACE: 1
       run: dotnet test --no-build --configuration Release --logger trx --results-directory "test-${{ matrix.dotnet-version }}-node${{ matrix.node-version }}"
 
     - name: Upload test logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        os: [ windows-latest, ubuntu-latest ]
         dotnet-version: [ 7.0.x ]
         node-version: [ 18.x ]
       fail-fast: false  # Don't cancel other jobs when one job fails

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest ]
+        os: [ ubuntu-latest ]
         dotnet-version: [ 7.0.x ]
         node-version: [ 18.x ]
       fail-fast: false  # Don't cancel other jobs when one job fails
@@ -48,6 +48,11 @@ jobs:
 
     - name: pack
       run: dotnet pack --no-build --configuration Release
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+          limit-access-to-actor: true
 
     - name: Test
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch: # Enable manually starting a build
 
 permissions:
   checks: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
         dotnet-version: [ 7.0.x ]
         node-version: [ 18.x ]
       fail-fast: false  # Don't cancel other jobs when one job fails
@@ -49,10 +49,11 @@ jobs:
     - name: pack
       run: dotnet pack --no-build --configuration Release
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      with:
-          limit-access-to-actor: true
+    # Uncomment to enable an SSH session for debugging
+    # - name: Setup tmate session
+    #  uses: mxschmitt/action-tmate@v3
+    #  with:
+    #      limit-access-to-actor: true
 
     - name: Test
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         os: [ windows-latest, ubuntu-latest ]
         dotnet-version: [ 7.0.x ]
         node-version: [ 18.x ]
+      fail-fast: false  # Don't cancel other jobs when one job fails
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest ]
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
         dotnet-version: [ 7.0.x ]
         node-version: [ 18.x ]
       fail-fast: false  # Don't cancel other jobs when one job fails

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    // Don't show the "Required assets are missing..." dialog on startup. We'll manage tasks.json / launch.json manually.
+    "csharp.suppressBuildAssetsNotification": true
+}

--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -105,10 +105,15 @@ public class ModuleGenerator : ISourceGenerator
         s += "{";
 
         s += $"[UnmanagedCallersOnly(EntryPoint = \"{ModuleRegisterFunctionName}\")]";
+        s += $"public static napi_value _{ModuleInitializeMethodName}(napi_env env, napi_value exports)";
+        s += $"{s.Indent}=> Initialize(env, exports);";
+        s += "";
         s += $"public static napi_value {ModuleInitializeMethodName}(napi_env env, napi_value exports)";
         s += "{";
         s += "try";
         s += "{";
+        s += "JSNativeApi.Interop.Initialize();";
+        s += "";
         s += "using var scope = new JSValueScope(env);";
         s += "var exportsValue = new JSValue(scope, exports);";
         s++;

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -18,8 +18,20 @@ internal static partial class HostFxr
     {
         if (Handle == default)
         {
+            NativeHost.Trace("> HostFxr.Initialize()");
+
             string hostfxrPath = GetHostFxrPath();
+            NativeHost.Trace("    HostFxr path: ");
+
+            if (!File.Exists(hostfxrPath))
+            {
+                throw new FileNotFoundException(
+                    ".NET runtime host library not found.", hostfxrPath);
+            }
+
             Handle = NativeLibrary.Load(hostfxrPath);
+
+            NativeHost.Trace("> HostFxr.Initialize()");
         }
     }
 

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -21,7 +21,7 @@ internal static partial class HostFxr
             NativeHost.Trace("> HostFxr.Initialize()");
 
             string hostfxrPath = GetHostFxrPath();
-            NativeHost.Trace("    HostFxr path: ");
+            NativeHost.Trace("    HostFxr path: " + hostfxrPath);
 
             if (!File.Exists(hostfxrPath))
             {
@@ -31,7 +31,7 @@ internal static partial class HostFxr
 
             Handle = NativeLibrary.Load(hostfxrPath);
 
-            NativeHost.Trace("> HostFxr.Initialize()");
+            NativeHost.Trace("< HostFxr.Initialize()");
         }
     }
 

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -100,7 +100,7 @@ internal static partial class HostFxr
 
     [DllImport(nameof(HostFxr), CallingConvention = CallingConvention.Cdecl)]
     public static extern unsafe hostfxr_status hostfxr_initialize_for_runtime_config(
-        byte* runtimeConfigPath, // UTF-16 on Windows, UTF-8 elsewhere
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string runtimeConfigPath, // UTF-16 on Windows, UTF-8 elsewhere
         hostfxr_initialize_parameters* initializeParameters,
         out hostfxr_handle hostContextHandle);
 

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -25,6 +25,7 @@ internal static partial class HostFxr
 
             if (!File.Exists(hostfxrPath))
             {
+                NativeHost.Trace("    HostFxr not found!");
                 throw new FileNotFoundException(
                     ".NET runtime host library not found.", hostfxrPath);
             }

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -1,0 +1,141 @@
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace NodeApi.Hosting;
+
+/// <summary>
+/// P/Invoke declarations and supporting code for the CLR hosting APIs defined in
+/// https://github.com/dotnet/runtime/blob/main/src/native/corehost/hostfxr.h
+/// </summary>
+internal static partial class HostFxr
+{
+    private static nint s_libraryHandle;
+
+    public static void Initialize()
+    {
+        if (s_libraryHandle == default)
+        {
+            string hostfxrPath = GetHostFxrPath();
+            s_libraryHandle = NativeLibrary.Load(hostfxrPath);
+
+            // Register a callback to use hostfxr from the specific path, not regular search paths.
+            NativeLibrary.SetDllImportResolver(
+              typeof(HostFxr).Assembly,
+              (libraryName, _, _) =>
+              {
+                  return libraryName switch
+                  {
+                      nameof(HostFxr) => s_libraryHandle,
+                      nameof(NodeApi) => NativeLibrary.GetMainProgramHandle(),
+                      _ => default,
+                  };
+              });
+        }
+    }
+
+    public static string GetHostFxrPath()
+    {
+        // TODO: Port logic to find hostfxr path from
+        // https://github.com/dotnet/runtime/blob/main/src/native/corehost/nethost/nethost.cpp
+
+        string hostfxrPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            @"dotnet\host\fxr\7.0.0\hostfxr.dll");
+        return hostfxrPath;
+    }
+
+    public record struct hostfxr_handle(nint Handle);
+
+    public enum hostfxr_delegate_type
+    {
+        com_activation,
+        load_in_memory_assembly,
+        winrt_activation,
+        com_register,
+        com_unregister,
+        load_assembly_and_get_function_pointer,
+        get_function_pointer,
+    }
+
+    // TODO: String marshalling below needs to be UFTF16 on Windows but UTF8 on non-Windows!
+
+    // Note this is CORECLR_DELEGATE_CALLTYPE, which is stdcall on Windows.
+    // See https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h
+    // The returned function pointer must be converted to a specific delegate via
+    // Marshal.GetDelegateForFunctionPointer().
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    public delegate hostfxr_status load_assembly_and_get_function_pointer(
+        [MarshalAs(UnmanagedType.LPWStr)] string assemblyPath,
+        [MarshalAs(UnmanagedType.LPWStr)] string typeName,
+        [MarshalAs(UnmanagedType.LPWStr)] string methodName,
+        nint delegateType,
+        nint reserved,
+        out nint functionPointer);
+
+    [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial hostfxr_status hostfxr_initialize_for_runtime_config(
+        [MarshalAs(UnmanagedType.LPWStr)] string runtimeConfigPath,
+        nint initializeParameters,
+        out hostfxr_handle hostContextHandle);
+
+    [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial hostfxr_status hostfxr_get_runtime_delegate(
+        hostfxr_handle hostContextHandle,
+        hostfxr_delegate_type delegateType,
+        [MarshalAs(UnmanagedType.FunctionPtr)] out load_assembly_and_get_function_pointer function);
+
+    [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial hostfxr_status hostfxr_close(hostfxr_handle hostContextHandle);
+
+    public enum hostfxr_status : uint
+    {
+        // Success
+        Success = 0,
+        Success_HostAlreadyInitialized = 0x00000001,
+        Success_DifferentRuntimeProperties = 0x00000002,
+
+        // Failure
+        InvalidArgFailure = 0x80008081,
+        CoreHostLibLoadFailure = 0x80008082,
+        CoreHostLibMissingFailure = 0x80008083,
+        CoreHostEntryPointFailure = 0x80008084,
+        CoreHostCurHostFindFailure = 0x80008085,
+        // unused                           = 0x80008086,
+        CoreClrResolveFailure = 0x80008087,
+        CoreClrBindFailure = 0x80008088,
+        CoreClrInitFailure = 0x80008089,
+        CoreClrExeFailure = 0x8000808a,
+        ResolverInitFailure = 0x8000808b,
+        ResolverResolveFailure = 0x8000808c,
+        LibHostCurExeFindFailure = 0x8000808d,
+        LibHostInitFailure = 0x8000808e,
+        // unused                           = 0x8000808f,
+        LibHostExecModeFailure = 0x80008090,
+        LibHostSdkFindFailure = 0x80008091,
+        LibHostInvalidArgs = 0x80008092,
+        InvalidConfigFile = 0x80008093,
+        AppArgNotRunnable = 0x80008094,
+        AppHostExeNotBoundFailure = 0x80008095,
+        FrameworkMissingFailure = 0x80008096,
+        HostApiFailed = 0x80008097,
+        HostApiBufferTooSmall = 0x80008098,
+        LibHostUnknownCommand = 0x80008099,
+        LibHostAppRootFindFailure = 0x8000809a,
+        SdkResolverResolveFailure = 0x8000809b,
+        FrameworkCompatFailure = 0x8000809c,
+        FrameworkCompatRetry = 0x8000809d,
+        // unused                           = 0x8000809e,
+        BundleExtractionFailure = 0x8000809f,
+        BundleExtractionIOError = 0x800080a0,
+        LibHostDuplicateProperty = 0x800080a1,
+        HostApiUnsupportedVersion = 0x800080a2,
+        HostInvalidState = 0x800080a3,
+        HostPropertyNotFound = 0x800080a4,
+        CoreHostIncompatibleConfig = 0x800080a5,
+        HostApiUnsupportedScenario = 0x800080a6,
+        HostFeatureDisabled = 0x800080a7,
+    }
+}

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -96,8 +96,10 @@ internal static partial class HostFxr
         nint reserved,
         out nint functionPointer);
 
+#pragma warning disable SYSLIB1054 // Use LibraryImport instead of DllImport
+
     [DllImport(nameof(HostFxr), CallingConvention = CallingConvention.Cdecl)]
-    public static unsafe extern hostfxr_status hostfxr_initialize_for_runtime_config(
+    public static extern unsafe hostfxr_status hostfxr_initialize_for_runtime_config(
         byte* runtimeConfigPath, // UTF-16 on Windows, UTF-8 elsewhere
         hostfxr_initialize_parameters* initializeParameters,
         out hostfxr_handle hostContextHandle);

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -97,6 +97,7 @@ internal static partial class HostFxr
         out nint functionPointer);
 
 #pragma warning disable SYSLIB1054 // Use LibraryImport instead of DllImport
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
 
     [DllImport(nameof(HostFxr), CallingConvention = CallingConvention.Cdecl)]
     public static extern unsafe hostfxr_status hostfxr_initialize_for_runtime_config(

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -96,20 +96,20 @@ internal static partial class HostFxr
         nint reserved,
         out nint functionPointer);
 
-    [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-    public static unsafe partial hostfxr_status hostfxr_initialize_for_runtime_config(
+    [DllImport(nameof(HostFxr), CallingConvention = CallingConvention.Cdecl)]
+    public static unsafe extern hostfxr_status hostfxr_initialize_for_runtime_config(
         byte* runtimeConfigPath, // UTF-16 on Windows, UTF-8 elsewhere
         hostfxr_initialize_parameters* initializeParameters,
         out hostfxr_handle hostContextHandle);
 
-    [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-    public static partial hostfxr_status hostfxr_get_runtime_delegate(
+    [DllImport(nameof(HostFxr), CallingConvention = CallingConvention.Cdecl)]
+    public static extern hostfxr_status hostfxr_get_runtime_delegate(
         hostfxr_handle hostContextHandle,
         hostfxr_delegate_type delegateType,
         [MarshalAs(UnmanagedType.FunctionPtr)] out load_assembly_and_get_function_pointer function);
 
-    [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-    public static partial hostfxr_status hostfxr_close(hostfxr_handle hostContextHandle);
+    [DllImport(nameof(HostFxr), CallingConvention = CallingConvention.Cdecl)]
+    public static extern hostfxr_status hostfxr_close(hostfxr_handle hostContextHandle);
 
     public enum hostfxr_status : uint
     {

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -55,7 +55,7 @@ internal static partial class HostFxr
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            return $"/usr/share/dotnet/host/fxr/{dotnetVersion}/libhostfxr.dylib";
+            return $"/usr/local/share/dotnet/host/fxr/{dotnetVersion}/libhostfxr.dylib";
         }
         else
         {

--- a/Runtime/Hosting/HostFxr.cs
+++ b/Runtime/Hosting/HostFxr.cs
@@ -76,6 +76,13 @@ internal static partial class HostFxr
         get_function_pointer,
     }
 
+    public unsafe struct hostfxr_initialize_parameters
+    {
+        public nuint size;
+        public byte* host_path;
+        public byte* dotnet_root;
+    }
+
     // Note this is CORECLR_DELEGATE_CALLTYPE, which is stdcall on Windows.
     // See https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h
     // The returned function pointer must be converted to a specific delegate via
@@ -92,7 +99,7 @@ internal static partial class HostFxr
     [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
     public static unsafe partial hostfxr_status hostfxr_initialize_for_runtime_config(
         byte* runtimeConfigPath, // UTF-16 on Windows, UTF-8 elsewhere
-        nint initializeParameters,
+        hostfxr_initialize_parameters* initializeParameters,
         out hostfxr_handle hostContextHandle);
 
     [LibraryImport(nameof(HostFxr)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/Runtime/Hosting/ManagedHost.cs
+++ b/Runtime/Hosting/ManagedHost.cs
@@ -1,0 +1,137 @@
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static NodeApi.JSNativeApi.Interop;
+
+namespace NodeApi.Hosting;
+
+[RequiresUnreferencedCode("Managed host is not used in trimmed assembly.")]
+public class ManagedHost
+{
+    private Dictionary<string, JSReference> _loadedModules = new();
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static napi_value InitializeModule(napi_env env, napi_value exports)
+    {
+        ////Console.WriteLine("> ManagedHost.InitializeModule()");
+
+        try
+        {
+            JSNativeApi.Interop.Initialize();
+
+            // Ensure references to this assembly can be resolved when loading other assemblies.
+            var nodeApiAssembly = typeof(JSValue).Assembly;
+            AppDomain.CurrentDomain.AssemblyResolve += (_, e) =>
+                e.Name.Split(',')[0] == nameof(NodeApi) ? nodeApiAssembly : null;
+
+            using var scope = new JSValueScope(env);
+            new JSModuleBuilder<ManagedHost>()
+                .AddMethod("require", (host) => host.LoadModule)
+                .AddMethod("loadAssembly", (host) => host.LoadAssembly)
+                .ExportModule(new JSValue(scope, exports), new ManagedHost());
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to load CLR managed host module: {ex}");
+        }
+
+        ////Console.WriteLine("< ManagedHost.InitializeModule()");
+
+        return exports;
+    }
+
+    public JSValue LoadModule(JSCallbackArgs args)
+    {
+        string assemblyFilePath = (string)args[0];
+
+        if (_loadedModules.TryGetValue(assemblyFilePath, out JSReference? exportsRef))
+        {
+            return exportsRef.GetValue()!.Value;
+        }
+
+        ////Console.WriteLine($"> ManagedHost.LoadModule({assemblyFilePath})");
+
+        var assembly = Assembly.LoadFile(assemblyFilePath);
+
+        MethodInfo? initializeMethod = null;
+
+        // First look for an auto-generated module initializer.
+        Type? moduleClass = assembly.GetType("NodeApi.Generated.Module", throwOnError: false);
+        if (moduleClass != null && moduleClass.IsClass && moduleClass.IsPublic &&
+            moduleClass.IsAbstract && moduleClass.IsSealed)
+        {
+            initializeMethod = GetInitializeMethod(moduleClass, "Initialize");
+        }
+
+        if (initializeMethod == null)
+        {
+            // A generated module initialize method was not found. Search for a
+            // ModuleInitialize method on any public static class in the assembly.
+            // (Static classes appear as abstract and sealed via reflection.)
+            foreach (var publicStaticClass in assembly.DefinedTypes
+                .Where((t) => t.IsClass && t.IsPublic && t.IsAbstract && t.IsSealed))
+            {
+                initializeMethod = GetInitializeMethod(publicStaticClass, "InitializeModule");
+                if (initializeMethod != null)
+                {
+                    break;
+                }
+            }
+
+            if (initializeMethod == null)
+            {
+                throw new Exception(
+                    "Failed to load module. A module initialize method was not found.");
+            }
+        }
+
+
+        JSValue exports = JSNativeApi.CreateObject();
+
+        using var childScope = new JSSimpleValueScope((napi_env)args.Scope);
+
+        // TODO: Return the module initialize result? Can it be different from the exports object?
+        object? result = initializeMethod.Invoke(
+            null, new object[] { (napi_env)childScope, (napi_value)exports });
+
+        exportsRef = JSNativeApi.CreateReference(exports);
+        _loadedModules.Add(assemblyFilePath, exportsRef);
+
+        ////Console.WriteLine("< ManagedHost.LoadModule()");
+
+        return exports;
+    }
+
+    private MethodInfo? GetInitializeMethod(Type moduleClass, string methodName)
+    {
+        MethodInfo? initializeMethod = moduleClass.GetMethod(
+            methodName, BindingFlags.Public | BindingFlags.Static);
+
+        if (initializeMethod != null)
+        {
+            var parameters = initializeMethod.GetParameters();
+            if (parameters.Length == 2 &&
+                parameters[0].ParameterType == typeof(napi_env) ||
+                parameters[1].ParameterType == typeof(napi_value) ||
+                initializeMethod.ReturnType == typeof(napi_value))
+            {
+                return initializeMethod;
+            }
+        }
+
+        return null;
+    }
+
+    public JSValue LoadAssembly(JSCallbackArgs args)
+    {
+        // TODO: This can be used to load an arbitrary .NET assembly that isn't designed specially
+        // as a JS module. Then additional methods on the returned JS object can be used by JS code
+        // to "reflect" on the loaded assembly and invoke members.
+        return default;
+    }
+}

--- a/Runtime/Hosting/ManagedHost.cs
+++ b/Runtime/Hosting/ManagedHost.cs
@@ -15,10 +15,22 @@ public class ManagedHost
 {
     private readonly Dictionary<string, JSReference> _loadedModules = new();
 
+    public static bool IsTracingEnabled { get; } =
+        Environment.GetEnvironmentVariable("NODE_API_DOTNET_TRACE") == "1";
+
+    public static void Trace(string msg)
+    {
+        if (IsTracingEnabled)
+        {
+            Console.WriteLine(msg);
+            Console.Out.Flush();
+        }
+    }
+
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     public static napi_value InitializeModule(napi_env env, napi_value exports)
     {
-        ////Console.WriteLine("> ManagedHost.InitializeModule()");
+        Trace($"> ManagedHost.InitializeModule({env.Handle:X8})");
 
         try
         {
@@ -40,7 +52,7 @@ public class ManagedHost
             Console.Error.WriteLine($"Failed to load CLR managed host module: {ex}");
         }
 
-        ////Console.WriteLine("< ManagedHost.InitializeModule()");
+        Trace("< ManagedHost.InitializeModule()");
 
         return exports;
     }
@@ -54,7 +66,7 @@ public class ManagedHost
             return exportsRef.GetValue()!.Value;
         }
 
-        ////Console.WriteLine($"> ManagedHost.LoadModule({assemblyFilePath})");
+        Trace($"> ManagedHost.LoadModule({assemblyFilePath})");
 
         var assembly = Assembly.LoadFile(assemblyFilePath);
 
@@ -102,7 +114,7 @@ public class ManagedHost
         exportsRef = JSNativeApi.CreateReference(exports);
         _loadedModules.Add(assemblyFilePath, exportsRef);
 
-        ////Console.WriteLine("< ManagedHost.LoadModule()");
+        Trace("< ManagedHost.LoadModule()");
 
         return exports;
     }

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -97,8 +97,8 @@ internal partial class NativeHost : IDisposable
         string managedHostPath = Path.Join(nodeApiHostDir, @"NodeApi.dll");
         Trace("    Managed host: " + managedHostPath);
 
-        var hostfxrPath = HostFxr.GetHostFxrPath();
-        var dotnetRoot = Path.GetDirectoryName(
+        string hostfxrPath = HostFxr.GetHostFxrPath();
+        string dotnetRoot = Path.GetDirectoryName(
             Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(hostfxrPath)))) !;
         Trace("    .NET root: " + dotnetRoot);
 
@@ -111,8 +111,8 @@ internal partial class NativeHost : IDisposable
 
         Trace("    Encoding runtime path parameters");
         int runtimeConfigPathCapacity = encoding.GetByteCount(runtimeConfigPath) + 2;
-        var hostfxrPathCapacity = encoding.GetByteCount(hostfxrPath) + 2;
-        var dotnetRootCapacity = encoding.GetByteCount(dotnetRoot) + 2;
+        int hostfxrPathCapacity = encoding.GetByteCount(hostfxrPath) + 2;
+        int dotnetRootCapacity = encoding.GetByteCount(dotnetRoot) + 2;
 
         hostfxr_status status;
         fixed (byte*

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -127,7 +127,7 @@ internal partial class NativeHost : IDisposable
                 managedHostTypeName,
                 new Span<byte>(managedHostTypeNameBytes, managedHostTypeNameCapacity));
 
-            int methodNameCapacity = nameof(InitializeModule).Length + 2;
+            int methodNameCapacity = encoding.GetByteCount(nameof(InitializeModule)) + 2;
             byte* methodNameBytes = stackalloc byte[methodNameCapacity];
             encoding.GetBytes(
                 nameof(InitializeModule), new Span<byte>(methodNameBytes, methodNameCapacity));

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -133,6 +133,7 @@ internal class NativeHost : IDisposable
     private static unsafe string GetCurrentModuleFilePath()
     {
         // TODO: Use dladdr() on non-Windows systems to get the current module file path.
+        // Unfortunately Assembly.Location/Codebase doesn't work for an AOT compiled library.
 
         delegate* unmanaged[Cdecl]<napi_env, napi_value, napi_value> functionInModule =
             &InitializeModule;

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -134,7 +134,7 @@ internal partial class NativeHost : IDisposable
             // Initialize the CLR with configuration from runtimeconfig.json.
             Trace("    Initializing runtime...");
             status = hostfxr_initialize_for_runtime_config(
-                runtimeConfigPathBytes, null/*&initializeParameters*/, out _hostContextHandle);
+                runtimeConfigPath, null/*&initializeParameters*/, out _hostContextHandle);
         }
 
         CheckStatus(status, "Failed to inialize CLR host.");

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -15,14 +15,14 @@ internal partial class NativeHost : IDisposable
     private const string ManagedHostTypeName =
         $"{nameof(NodeApi)}.{nameof(NodeApi.Hosting)}.ManagedHost";
 
-    private static readonly bool s_enableTracing =
-        Environment.GetEnvironmentVariable("NODE_API_DOTNET_TRACE") == "1";
-
     private hostfxr_handle _hostContextHandle;
 
-    private static void Trace(string msg)
+    public static bool IsTracingEnabled { get; } =
+        Environment.GetEnvironmentVariable("NODE_API_DOTNET_TRACE") == "1";
+
+    public static void Trace(string msg)
     {
-        if (s_enableTracing)
+        if (IsTracingEnabled)
         {
             Console.WriteLine(msg);
             Console.Out.Flush();

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -11,6 +11,8 @@ namespace NodeApi.Hosting;
 
 internal partial class NativeHost : IDisposable
 {
+    private static Version MinimumDotnetVersion { get; } = new(7, 0, 0);
+
     private const string ManagedHostAssemblyName = nameof(NodeApi);
     private const string ManagedHostTypeName =
         $"{nameof(NodeApi)}.{nameof(NodeApi.Hosting)}.ManagedHost";
@@ -102,13 +104,13 @@ internal partial class NativeHost : IDisposable
         string runtimeConfigPath = Path.Join(nodeApiHostDir, @"NodeApi.runtimeconfig.json");
         Trace("    Runtime config: " + runtimeConfigPath);
 
-        string hostfxrPath = HostFxr.GetHostFxrPath();
+        string hostfxrPath = HostFxr.GetHostFxrPath(MinimumDotnetVersion);
         string dotnetRoot = Path.GetDirectoryName(
             Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(hostfxrPath))))!;
         Trace("    .NET root: " + dotnetRoot);
 
         // Load the library that provides CLR hosting APIs.
-        HostFxr.Initialize();
+        HostFxr.Initialize(MinimumDotnetVersion);
 
         int runtimeConfigPathCapacity = HostFxr.Encoding.GetByteCount(runtimeConfigPath) + 2;
 

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -53,6 +53,7 @@ internal partial class NativeHost : IDisposable
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Failed to load CLR native host module: {ex}");
+            Console.Error.Flush();
         }
 
         Trace("< NativeHost.InitializeModule()");

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -1,0 +1,165 @@
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using static NodeApi.Hosting.HostFxr;
+using static NodeApi.JSNativeApi.Interop;
+
+namespace NodeApi.Hosting;
+
+internal class NativeHost : IDisposable
+{
+    private const string ManagedHostAssemblyName = nameof(NodeApi);
+    private const string ManagedHostTypeName =
+        $"{nameof(NodeApi)}.{nameof(NodeApi.Hosting)}.ManagedHost";
+
+    private hostfxr_handle _hostContextHandle;
+
+    [UnmanagedCallersOnly(
+        EntryPoint = nameof(napi_register_module_v1),
+        CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static napi_value InitializeModule(napi_env env, napi_value exports)
+    {
+        ////Console.WriteLine("> NativeHost.InitializeModule()");
+
+        try
+        {
+            using var scope = new JSValueScope(env);
+
+            // Constructing the native host also loads the CLR and initializes the managed host.
+            var host = new NativeHost(env, exports);
+
+            // The managed host defined several properties/methods already.
+            // Add on a dispose method implemented by the native host that closes the CLR context.
+            new JSValue(scope, exports).DefineProperties(new JSPropertyDescriptor(
+                nameof(NativeHost.Dispose),
+                (_) => { host.Dispose(); return default; }));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to load CLR native host module: {ex}");
+        }
+
+        ////Console.WriteLine("< NativeHost.InitializeModule()");
+
+        return exports;
+    }
+
+    public NativeHost(napi_env env, napi_value exports)
+    {
+        string currentModuleFilePath = GetCurrentModuleFilePath();
+        ////Console.WriteLine("Current module path: " + currentModuleFilePath);
+        string nodeApiHostDir = Path.GetDirectoryName(currentModuleFilePath)!;
+
+        string runtimeConfigJsonPath = Path.Join(nodeApiHostDir, @"NodeApi.runtimeconfig.json");
+        ////Console.WriteLine("CLR config: " + runtimeConfigJsonPath);
+
+        var managedHostAsssemblyPath = Path.Join(nodeApiHostDir, @"NodeApi.dll");
+        ////Console.WriteLine("Managed host: " + managedHostAsssemblyPath);
+
+        // Load the library that provides CLR hosting APIs.
+        HostFxr.Initialize();
+
+        // https://github.com/vmoroz/napi-cs/blob/dev/NodeApi.Sdk.CLR/Build/nativehost.cpp
+
+        // Initialize the CLR with configuration from runtimeconfig.json.
+        hostfxr_status status = hostfxr_initialize_for_runtime_config(
+            runtimeConfigJsonPath, initializeParameters: default, out _hostContextHandle);
+        CheckStatus(status, "Failed to inialize CLR host.");
+
+        try
+        {
+            // Get a CLR function that can load an assembly.
+            status = hostfxr_get_runtime_delegate(
+                _hostContextHandle,
+                hostfxr_delegate_type.load_assembly_and_get_function_pointer,
+                out load_assembly_and_get_function_pointer loadAssembly);
+            CheckStatus(status, "Failed to get CLR load-assembly function.");
+
+            // TODO Get the correct assembly version (and publickeytoken) somehow.
+            string managedHostTypeAssemblyQualifiedName =
+                $"{ManagedHostTypeName}, {ManagedHostAssemblyName}, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+            ////Console.WriteLine("Loading managed host type: " + managedHostTypeAssemblyQualifiedName);
+
+            // Load the managed host assembly and get a pointer to its module initialize method.
+            status = loadAssembly(
+                managedHostAsssemblyPath,
+                managedHostTypeAssemblyQualifiedName,
+                nameof(InitializeModule),
+                delegateType: -1 /* UNMANAGEDCALLERSONLY_METHOD */,
+                reserved: default,
+                out nint initializeModulePointer);
+            CheckStatus(status, "Failed to load managed host assembly.");
+
+            // Invoke the managed host initialize method.
+            // (It will define some properties on the exports object passed in.)
+            napi_register_module_v1 initializeModule =
+                Marshal.GetDelegateForFunctionPointer<napi_register_module_v1>(
+                    initializeModulePointer);
+            initializeModule(env, exports);
+        }
+        catch
+        {
+            hostfxr_close(_hostContextHandle);
+            _hostContextHandle = default;
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Close the CLR host context handle, if it's still open.
+        if (_hostContextHandle != default)
+        {
+            hostfxr_status status = hostfxr_close(_hostContextHandle);
+            _hostContextHandle = default;
+            CheckStatus(status, "Failed to dispose CLR host.");
+        }
+    }
+
+    private static void CheckStatus(hostfxr_status status, string message)
+    {
+        if (status != hostfxr_status.Success &&
+            status != hostfxr_status.Success_HostAlreadyInitialized)
+        {
+            throw new Exception(Enum.IsDefined(status) ?
+                $"{message} Status: {status}" : $"{message} HRESULT: 0x{(uint)status:x8}");
+        }
+    }
+
+    private static unsafe string GetCurrentModuleFilePath()
+    {
+        // TODO: Use dladdr() on non-Windows systems to get the current module file path.
+
+        delegate* unmanaged[Cdecl]<napi_env, napi_value, napi_value> functionInModule =
+            &InitializeModule;
+
+        const uint GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS = 0x00000004;
+        if (GetModuleHandleEx(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+            (nint)functionInModule,
+            out nint moduleHandle) == 0)
+        {
+            throw new Exception("Failed to get current module handle.");
+        }
+
+        StringBuilder filePathBuilder = new(255);
+        GetModuleFileName(moduleHandle, filePathBuilder, filePathBuilder.Capacity);
+        return filePathBuilder.ToString();
+    }
+
+    [DllImport("kernel32", SetLastError = true)]
+    private static extern uint GetModuleHandleEx(
+        [In] uint flags,
+        [In] nint moduleNameOrAddress,
+        out nint moduleHandle);
+
+    [DllImport("kernel32", SetLastError = true)]
+    private static extern uint GetModuleFileName(
+        [In] nint moduleHandle,
+        [Out] StringBuilder moduleFileName,
+        [In] [MarshalAs(UnmanagedType.U4)] int nSize);
+}

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -134,7 +134,7 @@ internal partial class NativeHost : IDisposable
             // Initialize the CLR with configuration from runtimeconfig.json.
             Trace("    Initializing runtime...");
             status = hostfxr_initialize_for_runtime_config(
-                null/*runtimeConfigPathBytes*/, &initializeParameters, out _hostContextHandle);
+                runtimeConfigPathBytes, null/*&initializeParameters*/, out _hostContextHandle);
         }
 
         CheckStatus(status, "Failed to inialize CLR host.");

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -99,7 +99,7 @@ internal partial class NativeHost : IDisposable
 
         string hostfxrPath = HostFxr.GetHostFxrPath();
         string dotnetRoot = Path.GetDirectoryName(
-            Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(hostfxrPath)))) !;
+            Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(hostfxrPath))))!;
         Trace("    .NET root: " + dotnetRoot);
 
         // Load the library that provides CLR hosting APIs.

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -134,7 +134,7 @@ internal partial class NativeHost : IDisposable
             // Initialize the CLR with configuration from runtimeconfig.json.
             Trace("    Initializing runtime...");
             status = hostfxr_initialize_for_runtime_config(
-                runtimeConfigPathBytes, null/*&initializeParameters*/, out _hostContextHandle);
+                null/*runtimeConfigPathBytes*/, &initializeParameters, out _hostContextHandle);
         }
 
         CheckStatus(status, "Failed to inialize CLR host.");

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -15,14 +15,14 @@ internal partial class NativeHost : IDisposable
     private const string ManagedHostTypeName =
         $"{nameof(NodeApi)}.{nameof(NodeApi.Hosting)}.ManagedHost";
 
-    private static readonly bool _enableTracing =
+    private static readonly bool s_enableTracing =
         Environment.GetEnvironmentVariable("NODE_API_DOTNET_TRACE") == "1";
 
     private hostfxr_handle _hostContextHandle;
 
     private static void Trace(string msg)
     {
-        if (_enableTracing)
+        if (s_enableTracing)
         {
             Console.WriteLine(msg);
             Console.Out.Flush();

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -134,7 +134,7 @@ internal partial class NativeHost : IDisposable
             // Initialize the CLR with configuration from runtimeconfig.json.
             Trace("    Initializing runtime...");
             status = hostfxr_initialize_for_runtime_config(
-                runtimeConfigPathBytes, &initializeParameters, out _hostContextHandle);
+                runtimeConfigPathBytes, null/*&initializeParameters*/, out _hostContextHandle);
         }
 
         CheckStatus(status, "Failed to inialize CLR host.");

--- a/Runtime/JSNativeApi.Interop.cs
+++ b/Runtime/JSNativeApi.Interop.cs
@@ -11,8 +11,13 @@ public static partial class JSNativeApi
     [SuppressUnmanagedCodeSecurity]
     public static unsafe partial class Interop
     {
-        static Interop()
+        private static bool s_initialized;
+
+        public static void Initialize()
         {
+            if (s_initialized) return;
+            s_initialized = true;
+
             // Node APIs are all imported from the main `node` executable. Overriding the import
             // resolution is more efficient and avoids issues with library search paths and
             // differences in the name of the executable.
@@ -23,6 +28,9 @@ public static partial class JSNativeApi
                   return libraryName == nameof(NodeApi) ? NativeLibrary.GetMainProgramHandle() : default;
               });
         }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate napi_value napi_register_module_v1(napi_env env, napi_value exports);
 
         //===========================================================================
         // Specialized pointer types

--- a/Runtime/NodeApi.Runtime.csproj
+++ b/Runtime/NodeApi.Runtime.csproj
@@ -1,10 +1,49 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<RootNamespace>NodeApi</RootNamespace>
-		<AssemblyName>NodeApi</AssemblyName>
-		<IsPackable>true</IsPackable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	</PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>NodeApi</RootNamespace>
+    <AssemblyName>NodeApi</AssemblyName>
+    <IsPackable>true</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishAot>true</PublishAot>
+    <NativeLib>Shared</NativeLib>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)'=='Release' ">
+    <!-- These trimming options are not required, but reduce the native binary size by around 600 KB. -->
+    <InvariantGlobalization>true</InvariantGlobalization><!-- Trim globalization-specific code and data. -->
+    <UseSystemResourceKeys>true</UseSystemResourceKeys><!-- Trim detailed system exception messages. -->
+  </PropertyGroup>
+
+  <Target Name="SetRuntimeConfigValues" BeforeTargets="GenerateBuildRuntimeConfigurationFiles">
+    <ItemGroup>
+      <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting" Value="true" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RenameToDotNode" AfterTargets="CopyNativeBinary">
+    <PropertyGroup>
+      <ManagedTargetPath>$(PublishDir)$(TargetFileName)</ManagedTargetPath>
+      <NativeTargetPath>$(PublishDir)$(TargetName).node</NativeTargetPath>
+    </PropertyGroup>
+
+    <!-- Rename the native DLL (and its PDB) to have a .node extension. -->
+    <Move SourceFiles="$(PublishDir)$(TargetFileName)"
+      DestinationFiles="$(NativeTargetPath)" />
+    <Move SourceFiles="$(PublishDir)$(TargetName).pdb"
+      DestinationFiles="$(PublishDir)$(TargetName).node.pdb" />
+
+    <!-- Publish the runtimeconfig.json file required for CLR hosting. -->
+    <Copy SourceFiles="$(PublishDir)..\$(ProjectRuntimeConfigFileName)"
+      DestinationFiles="$(PublishDir)$(ProjectRuntimeConfigFileName)" />
+
+    <!-- Also publish the managed assembly (and its PDB). -->
+    <Copy SourceFiles="$(PublishDir)..\$(TargetFileName)"
+      DestinationFiles="$(ManagedTargetPath)" />
+    <Copy SourceFiles="$(PublishDir)..\$(TargetName).pdb"
+      DestinationFiles="$(PublishDir)$(TargetName).pdb" />
+  </Target>
 
 </Project>

--- a/Runtime/NodeApi.Runtime.csproj
+++ b/Runtime/NodeApi.Runtime.csproj
@@ -29,10 +29,11 @@
       <NativeTargetPath>$(PublishDir)$(TargetName).node</NativeTargetPath>
     </PropertyGroup>
 
-    <!-- Rename the native DLL (and its PDB) to have a .node extension. -->
-    <Move SourceFiles="$(PublishDir)$(TargetFileName)"
+    <!-- Rename the native library (and its PDB) to have a .node extension. -->
+    <Move SourceFiles="$(PublishDir)$(TargetName)$(NativeBinaryExt)"
       DestinationFiles="$(NativeTargetPath)" />
-    <Move SourceFiles="$(PublishDir)$(TargetName).pdb"
+    <Move Condition="Exists('$(PublishDir)$(TargetName).pdb')"
+      SourceFiles="$(PublishDir)$(TargetName).pdb"
       DestinationFiles="$(PublishDir)$(TargetName).node.pdb" />
 
     <!-- Publish the runtimeconfig.json file required for CLR hosting. -->

--- a/Test/HostedClrTests.cs
+++ b/Test/HostedClrTests.cs
@@ -1,8 +1,139 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Xunit;
+
+using static NodeApi.Test.TestBuilder;
+
+// Avoid running MSBuild on the same project concurrently.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 namespace NodeApi.Test;
 
 public class HostedClrTests
 {
-    // TODO: Hosted CLR tests
+    private static readonly Dictionary<string, string?> s_builtTestModules = new();
+    private static Lazy<string> s_builtHostModule = new Lazy<string>(() => BuildHostModule());
+
+    public static IEnumerable<object[]> TestCases { get; } = ListTestCases();
+
+    [Theory()]
+    [MemberData(nameof(TestCases))]
+    public void Test(string id)
+    {
+        string[] idParts = id.Split('/');
+        string moduleName = idParts[0];
+        string testCaseName = idParts[1];
+
+        string hostFilePath = s_builtHostModule.Value;
+
+        string buildLogFilePath = GetBuildLogFilePath(moduleName);
+        if (!s_builtTestModules.TryGetValue(moduleName, out string? moduleFilePath))
+        {
+            moduleFilePath = BuildTestModuleCSharp(moduleName, buildLogFilePath);
+
+            if (moduleFilePath != null)
+            {
+                BuildTestModuleTypeScript(moduleName);
+            }
+
+            s_builtTestModules.Add(moduleName, moduleFilePath);
+        }
+
+        if (moduleFilePath == null)
+        {
+            Assert.Fail("Build failed. Check the log for details: " + buildLogFilePath);
+        }
+
+        // TODO: Support compiling TS files to JS.
+        string jsFilePath = Path.Join(TestCasesDirectory, moduleName, testCaseName + ".js");
+
+        string runLogFilePath = GetRunLogFilePath("aot", moduleName, testCaseName);
+        RunNodeTestCase(jsFilePath, runLogFilePath, new Dictionary<string, string>
+        {
+            [ModulePathEnvironmentVariableName] = moduleFilePath,
+            [HostPathEnvironmentVariableName] = hostFilePath,
+        });
+    }
+
+    private static string BuildHostModule()
+    {
+        string projectFilePath = Path.Join(RepoRootDirectory, "Runtime", "NodeApi.Runtime.csproj");
+
+        string logDir = Path.Join(
+            RepoRootDirectory, "out", "obj", Configuration);
+        Directory.CreateDirectory(logDir);
+        string logFilePath = Path.Join(logDir, "publish-host.log");
+
+        string runtimeIdentifier = GetCurrentPlatformRuntimeIdentifier();
+        var properties = new Dictionary<string, string>
+        {
+            ["RuntimeIdentifier"] = runtimeIdentifier,
+            ["Configuration"] = Configuration,
+        };
+
+        string? buildResult = BuildProject(
+          projectFilePath,
+          targets: new[] { "Restore", "Publish" },
+          properties,
+          returnProperty: "PublishDir",
+          logFilePath: logFilePath,
+          verboseLog: true);
+
+        if (string.IsNullOrEmpty(buildResult))
+        {
+            Assert.Fail("Host publish failed. Check the log for details: " + logFilePath);
+        }
+
+        string publishDir = buildResult.Replace(
+            Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        string moduleFilePath = Path.Combine(publishDir, "NodeApi.node");
+        Assert.True(
+            File.Exists(moduleFilePath), "Host module file was not built: " + moduleFilePath);
+        return moduleFilePath;
+    }
+
+    private static string? BuildTestModuleCSharp(
+      string testCaseName,
+      string logFilePath)
+    {
+        string projectFilePath = Path.Join(
+            TestCasesDirectory, testCaseName, testCaseName + ".csproj");
+
+        // Auto-generate an empty project file. All project info is inherited from
+        // TestCases/Directory.Build.{props,targets}
+        File.WriteAllText(projectFilePath, "<Project Sdk=\"Microsoft.NET.Sdk\">\n</Project>\n");
+
+        string runtimeIdentifier = GetCurrentPlatformRuntimeIdentifier();
+        var properties = new Dictionary<string, string>
+        {
+            ["RuntimeIdentifier"] = runtimeIdentifier,
+            ["Configuration"] = Configuration,
+        };
+
+        string? buildResult = BuildProject(
+          projectFilePath,
+          targets: new[] { "Restore", "Build" },
+          properties,
+          returnProperty: "TargetPath",
+          logFilePath: logFilePath,
+          verboseLog: false);
+
+        if (string.IsNullOrEmpty(buildResult))
+        {
+            return null;
+        }
+
+        string moduleFilePath = buildResult.Replace(
+            Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        Assert.True(File.Exists(moduleFilePath), "Module file was not built: " + moduleFilePath);
+        return moduleFilePath;
+    }
+
+    private static void BuildTestModuleTypeScript(string _ /*testCaseName*/)
+    {
+        // TODO: Compile TypeScript code, if the test uses TS.
+        // Reference the generated type definitions from the C#?
+    }
 }

--- a/Test/HostedClrTests.cs
+++ b/Test/HostedClrTests.cs
@@ -54,6 +54,10 @@ public class HostedClrTests
         {
             [ModulePathEnvironmentVariableName] = moduleFilePath,
             [HostPathEnvironmentVariableName] = hostFilePath,
+
+            // CLR host tracing (very verbose).
+            // This will cause the test to always fail because tracing writes to stderr.
+            ["COREHOST_TRACE"] = "1",
         });
     }
 

--- a/Test/HostedClrTests.cs
+++ b/Test/HostedClrTests.cs
@@ -49,7 +49,7 @@ public class HostedClrTests
         // TODO: Support compiling TS files to JS.
         string jsFilePath = Path.Join(TestCasesDirectory, moduleName, testCaseName + ".js");
 
-        string runLogFilePath = GetRunLogFilePath("aot", moduleName, testCaseName);
+        string runLogFilePath = GetRunLogFilePath("hosted", moduleName, testCaseName);
         RunNodeTestCase(jsFilePath, runLogFilePath, new Dictionary<string, string>
         {
             [ModulePathEnvironmentVariableName] = moduleFilePath,

--- a/Test/HostedClrTests.cs
+++ b/Test/HostedClrTests.cs
@@ -57,7 +57,7 @@ public class HostedClrTests
 
             // CLR host tracing (very verbose).
             // This will cause the test to always fail because tracing writes to stderr.
-            ["COREHOST_TRACE"] = "1",
+            ////["COREHOST_TRACE"] = "1",
         });
     }
 

--- a/Test/HostedClrTests.cs
+++ b/Test/HostedClrTests.cs
@@ -14,7 +14,7 @@ namespace NodeApi.Test;
 public class HostedClrTests
 {
     private static readonly Dictionary<string, string?> s_builtTestModules = new();
-    private static Lazy<string> s_builtHostModule = new Lazy<string>(() => BuildHostModule());
+    private static readonly Lazy<string> s_builtHostModule = new(() => BuildHostModule());
 
     public static IEnumerable<object[]> TestCases { get; } = ListTestCases();
 

--- a/Test/NativeAotTests.cs
+++ b/Test/NativeAotTests.cs
@@ -43,7 +43,7 @@ public class NativeAotTests
         // TODO: Support compiling TS files to JS.
         string jsFilePath = Path.Join(TestCasesDirectory, moduleName, testCaseName + ".js");
 
-        string runLogFilePath = GetRunLogFilePath("hosted", moduleName, testCaseName);
+        string runLogFilePath = GetRunLogFilePath("aot", moduleName, testCaseName);
         RunNodeTestCase(jsFilePath, runLogFilePath, new Dictionary<string, string>
         {
             [ModulePathEnvironmentVariableName] = moduleFilePath,

--- a/Test/NativeAotTests.cs
+++ b/Test/NativeAotTests.cs
@@ -2,37 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using Xunit;
 
 using static NodeApi.Test.TestBuilder;
 
 namespace NodeApi.Test;
+
 public class NativeAotTests
 {
-    // JS code loads test modules via this environment variable:
-    //    require(process.env['TEST_NODE_API_MODULE_PATH'])
-    private const string ModulePathEnvironmentVariableName = "TEST_NODE_API_MODULE_PATH";
-
     private static readonly Dictionary<string, string?> s_builtTestModules = new();
 
-    public static IEnumerable<object[]> ListTestCases()
-    {
-        foreach (string dir in Directory.GetDirectories(TestCasesDirectory))
-        {
-            string moduleName = Path.GetFileName(dir);
-
-            foreach (string? jsFile in Directory.GetFiles(dir, "*.js")
-              .Concat(Directory.GetFiles(dir, "*.ts")))
-            {
-                string testCaseName = Path.GetFileNameWithoutExtension(jsFile);
-                yield return new[] { moduleName + "/" + testCaseName };
-            }
-        }
-    }
+    public static IEnumerable<object[]> TestCases { get; } = ListTestCases();
 
     [Theory()]
-    [MemberData(nameof(ListTestCases))]
+    [MemberData(nameof(TestCases))]
     public void Test(string id)
     {
         string[] idParts = id.Split('/');
@@ -60,15 +43,19 @@ public class NativeAotTests
         // TODO: Support compiling TS files to JS.
         string jsFilePath = Path.Join(TestCasesDirectory, moduleName, testCaseName + ".js");
 
-        string runLogFilePath = GetRunLogFilePath(moduleName, testCaseName);
-        RunTestCase(jsFilePath, moduleFilePath, runLogFilePath);
+        string runLogFilePath = GetRunLogFilePath("hosted", moduleName, testCaseName);
+        RunNodeTestCase(jsFilePath, runLogFilePath, new Dictionary<string, string>
+        {
+            [ModulePathEnvironmentVariableName] = moduleFilePath,
+        });
     }
 
     private static string? BuildTestModuleCSharp(
       string testCaseName,
       string logFilePath)
     {
-        string projectFilePath = Path.Join(TestCasesDirectory, testCaseName, testCaseName + ".csproj");
+        string projectFilePath = Path.Join(
+            TestCasesDirectory, testCaseName, testCaseName + ".csproj");
 
         // Auto-generate an empty project file. All project info is inherited from
         // TestCases/Directory.Build.{props,targets}
@@ -95,7 +82,7 @@ public class NativeAotTests
         }
 
         string moduleFilePath = buildResult.Replace(
-          Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
         moduleFilePath = Path.ChangeExtension(moduleFilePath, ".node");
         Assert.True(File.Exists(moduleFilePath), "Module file was not built: " + moduleFilePath);
         return moduleFilePath;
@@ -105,64 +92,5 @@ public class NativeAotTests
     {
         // TODO: Compile TypeScript code, if the test uses TS.
         // Reference the generated type definitions from the C#?
-    }
-
-    private static void RunTestCase(
-      string jsFilePath,
-      string moduleFilePath,
-      string logFilePath)
-    {
-        Assert.True(File.Exists(jsFilePath), "JS file not found: " + jsFilePath);
-
-        Environment.SetEnvironmentVariable(ModulePathEnvironmentVariableName, moduleFilePath);
-
-        // This assumes the `node` executable is on the current PATH.
-        string nodeExe = "node";
-
-        StreamWriter outputWriter = File.CreateText(logFilePath);
-        outputWriter.WriteLine($"{ModulePathEnvironmentVariableName}={moduleFilePath}");
-        outputWriter.WriteLine($"{nodeExe} --expose-gc {jsFilePath}");
-        outputWriter.WriteLine();
-        outputWriter.Flush();
-        bool hasErrorOutput = false;
-
-        var startInfo = new ProcessStartInfo(nodeExe, $"--expose-gc {jsFilePath}")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-
-        Process nodeProcess = Process.Start(startInfo)!;
-        nodeProcess.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data != null)
-            {
-                outputWriter.WriteLine(e.Data);
-            }
-        };
-        nodeProcess.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data != null)
-            {
-                outputWriter.WriteLine(e.Data);
-                outputWriter.Flush();
-                hasErrorOutput = e.Data.Trim().Length > 0;
-            }
-        };
-        nodeProcess.BeginOutputReadLine();
-        nodeProcess.BeginErrorReadLine();
-
-        nodeProcess.WaitForExit();
-
-        if (nodeProcess.ExitCode != 0)
-        {
-            Assert.Fail("Node process exited with code: " + nodeProcess.ExitCode + ". " +
-            "Check the log for details: " + logFilePath);
-        }
-        else if (hasErrorOutput)
-        {
-            Assert.Fail("Node process produced error output. Check the log for details: " + logFilePath);
-        }
     }
 }

--- a/Test/TestBuilder.cs
+++ b/Test/TestBuilder.cs
@@ -209,17 +209,23 @@ internal static class TestBuilder
         {
             if (e.Data != null)
             {
-                outputWriter.WriteLine(e.Data);
-                outputWriter.Flush();
+                lock (outputWriter)
+                {
+                    outputWriter.WriteLine(e.Data);
+                    outputWriter.Flush();
+                }
             }
         };
         nodeProcess.ErrorDataReceived += (_, e) =>
         {
             if (e.Data != null)
             {
-                outputWriter.WriteLine(e.Data);
-                outputWriter.Flush();
-                hasErrorOutput = e.Data.Trim().Length > 0;
+                lock (outputWriter)
+                {
+                    outputWriter.WriteLine(e.Data);
+                    outputWriter.Flush();
+                    hasErrorOutput = e.Data.Trim().Length > 0;
+                }
             }
         };
         nodeProcess.BeginOutputReadLine();

--- a/Test/TestBuilder.cs
+++ b/Test/TestBuilder.cs
@@ -163,7 +163,7 @@ internal static class TestBuilder
 
         using var projectCollection = new ProjectCollection();
 
-        var project = projectCollection.LoadProject(projectFilePath, properties, toolsVersion: null);
+        Project project = projectCollection.LoadProject(projectFilePath, properties, toolsVersion: null);
         bool buildResult = project.Build(targets, new[] { logger });
         if (!buildResult)
         {
@@ -194,7 +194,7 @@ internal static class TestBuilder
             UseShellExecute = false,
         };
 
-        foreach (var (name, value) in testEnvironmentVariables)
+        foreach ((string name, string value) in testEnvironmentVariables)
         {
             startInfo.Environment[name] = value;
             outputWriter.WriteLine($"{name}={value}");

--- a/Test/TestCases/A/example.js
+++ b/Test/TestCases/A/example.js
@@ -1,5 +1,7 @@
-// Load the addon module.
-const example = require(process.env['TEST_NODE_API_MODULE_PATH']);
+// Load the addon module, using either hosted or native AOT mode.
+const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
+const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
+const example = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
 
 // Call a method exported by the addon module.
 example.helloNoParam();

--- a/Test/TestCases/A/hello.js
+++ b/Test/TestCases/A/hello.js
@@ -1,7 +1,9 @@
 const assert = require('assert');
 
-// Load the addon module.
-const test = require(process.env['TEST_NODE_API_MODULE_PATH']);
+// Load the addon module, using either hosted or native AOT mode.
+const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
+const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
+const test = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
 
 // Call a method exported by the addon module.
 const result = test.hello('world');

--- a/Test/TestCases/node-addon-api/common/index.js
+++ b/Test/TestCases/node-addon-api/common/index.js
@@ -110,7 +110,9 @@ async function whichBuildType() {
 exports.whichBuildType = whichBuildType;
 
 exports.runTest = async function (test) {
-  const binding = require(process.env['TEST_NODE_API_MODULE_PATH']);
+  const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
+  const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
+  const binding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
   await Promise.resolve(test(binding))
     .finally(exports.mustCall());
 };


### PR DESCRIPTION
 - Code generation:
   - Generate two module-initialize methods. The one that supports unmanaged callers just forwards to the one that supports managed callers. This enables using the same generated initialization code in either AOT or hosted models.
 - Runtime:
   - Add `Hosting` subfolder/namespace to the `NodeApi` assembly. (I considered making it a separate project/assembly, and we still could, but for now it's simpler to keep it together.)
   - Add `HostFxr` class, which is a port of the minimum required CLR hosting APIs from `hostfxr.h` to C#.
   - Add `NativeHost` class, which (when AOT compiled) is responsible for hosting the CLR and initializing the `ManagedHost`.
   - Add `ManagedHost` class, which (when not AOT compiled) is responsible for loading/initializing additional .NET node modules.
 - Build:
   - Publish the `NodeApi` assembly as an AOT-compiled `.node` module that exports a native entrypoint for the `NativeHost`.
   - Generate and publish the `.runtimeconfig.json` file (that defines required CLR hosting parameters).
   - Also publish the _managed_ `NodeApi.dll` that contains the `ManagedHost` and managed `NodeApi` runtime for CLR-hosted node modules.
 - Test:
   - Enable running all the test cases in both AOT and hosted modes. The only difference is in how the module is imported.

This is working end-to-end now, though there are a couple important TODOs in the code:
  - Logic to locate hostfxr: It needs select the architecture matching the current process.
  - Loading the `ManagedHost` requires a full assembly name including version. This will break when we implement versioning and it's no longer `1.0.0.0`.