### PR TITLE
Port node-addon-api object tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,13 @@ jobs:
     - name: Test
       run: dotnet test --no-build --configuration Release --logger trx --results-directory "test-${{ matrix.dotnet-version }}-node${{ matrix.node-version }}"
 
+    - name: Upload test logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-logs-${{ runner.os }}-dotnet${{ matrix.dotnet-version }}-node${{ matrix.node-version }}
+        path: out/obj/Release/**/*.log
+      if: ${{ always() }}
+
     - name: Publish test results
       uses: dorny/test-reporter@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        os: [ windows-latest, ubuntu-latest ]
         dotnet-version: [ 7.0.x ]
         node-version: [ 18.x ]
 

--- a/Runtime/JSCallbackArgs.cs
+++ b/Runtime/JSCallbackArgs.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using static NodeApi.JSNativeApi.Interop;
 
 namespace NodeApi;
@@ -12,7 +13,7 @@ public class JSCallbackArgs
 
     public JSValue ThisArg { get; }
 
-    public nint Data { get; }
+    public object? Data { get; set; } = null;
 
     public JSValue GetNewTarget()
     {
@@ -44,7 +45,7 @@ public class JSCallbackArgs
             }
 
             ThisArg = thisArg;
-            Data = data;
+            Data = data != nint.Zero ? GCHandle.FromIntPtr(data).Target : null;
         }
     }
 }

--- a/Runtime/JSNativeApi.cs
+++ b/Runtime/JSNativeApi.cs
@@ -1000,13 +1000,12 @@ public static partial class JSNativeApi
         {
             // TODO: [vmoroz] In future we will be not allowed to run JS in finalizers.
             // We must remove creation of the scope.
-            using JSSimpleValueScope scope = new(env);
+            using var scope = new JSValueScope(env);
             ((Action)gcHandle.Target!)();
         }
         finally
         {
             gcHandle.Free();
-
         }
     }
 

--- a/Runtime/JSPropertyDescriptor.cs
+++ b/Runtime/JSPropertyDescriptor.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace NodeApi;
 
-public class JSPropertyDescriptor
+public readonly struct JSPropertyDescriptor
 {
     public JSValue Name { get; }
     public JSCallback? Method { get; } = null;
@@ -10,45 +10,56 @@ public class JSPropertyDescriptor
     public JSCallback? Setter { get; } = null;
     public JSValue? Value { get; } = null;
     public JSPropertyAttributes Attributes { get; } = JSPropertyAttributes.Default;
+    public object? Data { get; } = null;
 
-    public JSPropertyDescriptor(JSValue name, JSValue value, JSPropertyAttributes attributes = JSPropertyAttributes.DefaultProperty)
-    {
-        Name = name;
-        Value = value;
-        Attributes = attributes;
-    }
-
-    public JSPropertyDescriptor(string name, JSValue value, JSPropertyAttributes attributes = JSPropertyAttributes.DefaultProperty)
-      : this(JSNativeApi.CreateStringUtf16(name), value, attributes)
-    {
-    }
-
-    public JSPropertyDescriptor(JSValue name, JSCallback method, JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod)
+    public JSPropertyDescriptor(
+        JSValue name,
+        JSCallback? method = null,
+        JSCallback? getter = null,
+        JSCallback? setter = null,
+        JSValue? value = null,
+        JSPropertyAttributes attributes = JSPropertyAttributes.Default,
+        object? data = null)
     {
         Name = name;
         Method = method;
+        Getter = getter;
+        Setter = setter;
+        Value = value;
         Attributes = attributes;
+        Data = data;
     }
 
-    public JSPropertyDescriptor(string name, JSCallback method, JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod)
-      : this(JSNativeApi.CreateStringUtf16(name), method, attributes)
-    {
-    }
-
-    public JSPropertyDescriptor(JSValue name, JSCallback? getter, JSCallback? setter, JSPropertyAttributes attributes = JSPropertyAttributes.Configurable)
+    public static JSPropertyDescriptor Accessor(
+        JSValue name,
+        JSCallback? getter = null,
+        JSCallback? setter = null,
+        JSPropertyAttributes attributes = JSPropertyAttributes.Default,
+        object? data = null)
     {
         if (getter == null && setter == null)
         {
             throw new ArgumentException($"Either `{nameof(getter)}` or `{nameof(setter)}` or both must be not null");
         }
-        Name = name;
-        Getter = getter;
-        Setter = setter;
-        Attributes = attributes;
+
+        return new JSPropertyDescriptor(name, null, getter, setter, null, attributes, data);
     }
 
-    public JSPropertyDescriptor(string name, JSCallback? getter, JSCallback? setter, JSPropertyAttributes attributes = JSPropertyAttributes.Configurable)
-      : this(JSNativeApi.CreateStringUtf16(name), getter, setter, attributes)
+    public static JSPropertyDescriptor ForValue(
+        JSValue name,
+        JSValue value,
+        JSPropertyAttributes attributes = JSPropertyAttributes.Default,
+        object? data = null)
     {
+        return new JSPropertyDescriptor(name, null, null, null, value, attributes, data);
+    }
+
+    public static JSPropertyDescriptor Function(
+        JSValue name,
+        JSCallback method,
+        JSPropertyAttributes attributes = JSPropertyAttributes.Default,
+        object? data = null)
+    {
+        return new JSPropertyDescriptor(name, method, null, null, null, attributes, data);
     }
 }

--- a/Runtime/JSPropertyDescriptorListOfT.cs
+++ b/Runtime/JSPropertyDescriptorListOfT.cs
@@ -18,7 +18,7 @@ public class JSPropertyDescriptorList<TDerived, TObject>
       JSValue value,
       JSPropertyAttributes attributes = JSPropertyAttributes.DefaultProperty)
     {
-        Properties.Add(new JSPropertyDescriptor(name, value, attributes));
+        Properties.Add(JSPropertyDescriptor.ForValue(name, value, attributes));
         return (TDerived)(object)this;
     }
 
@@ -28,7 +28,7 @@ public class JSPropertyDescriptorList<TDerived, TObject>
       JSCallback? setter,
       JSPropertyAttributes attributes = JSPropertyAttributes.DefaultProperty)
     {
-        Properties.Add(new JSPropertyDescriptor(name, getter, setter, attributes));
+        Properties.Add(JSPropertyDescriptor.Accessor(name, getter, setter, attributes));
         return (TDerived)(object)this;
     }
 
@@ -74,7 +74,7 @@ public class JSPropertyDescriptorList<TDerived, TObject>
       JSCallback callback,
       JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod)
     {
-        Properties.Add(new JSPropertyDescriptor(name, callback, attributes));
+        Properties.Add(JSPropertyDescriptor.Function(name, callback, attributes));
         return (TDerived)(object)this;
     }
 

--- a/Runtime/JSReference.cs
+++ b/Runtime/JSReference.cs
@@ -17,6 +17,13 @@ public class JSReference : IDisposable
         IsWeak = isWeak;
     }
 
+    public JSReference(napi_ref handle, bool isWeak = false)
+    {
+        _env = (napi_env)JSSimpleValueScope.Current;
+        _handle = handle;
+        IsWeak = isWeak;
+    }
+
     public void MakeWeak()
     {
         if (!IsWeak)
@@ -36,7 +43,7 @@ public class JSReference : IDisposable
 
     public JSValue? GetValue()
     {
-        napi_get_reference_value(_env, _handle, out napi_value result);
+        napi_get_reference_value(_env, _handle, out napi_value result).ThrowIfFailed();
         return result;
     }
 

--- a/Test/NativeAotTests.cs
+++ b/Test/NativeAotTests.cs
@@ -121,12 +121,12 @@ public class NativeAotTests
 
         StreamWriter outputWriter = File.CreateText(logFilePath);
         outputWriter.WriteLine($"{ModulePathEnvironmentVariableName}={moduleFilePath}");
-        outputWriter.WriteLine($"{nodeExe} {jsFilePath}");
+        outputWriter.WriteLine($"{nodeExe} --expose-gc {jsFilePath}");
         outputWriter.WriteLine();
         outputWriter.Flush();
         bool hasErrorOutput = false;
 
-        var startInfo = new ProcessStartInfo(nodeExe, jsFilePath)
+        var startInfo = new ProcessStartInfo(nodeExe, $"--expose-gc {jsFilePath}")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/Test/TestCases/node-addon-api/binding.cs
+++ b/Test/TestCases/node-addon-api/binding.cs
@@ -1,0 +1,14 @@
+using System;
+using NodeApi;
+
+namespace NodeApiTest;
+
+[JSModule]
+public class Binding
+{
+    private readonly Lazy<JSReference> _testObject = new(() => new JSReference(TestObject.Init()));
+    private readonly Lazy<JSReference> _testObjectFreezeSeal = new(() => new JSReference(TestObjectFreezeSeal.Init()));
+
+    public JSValue Object => _testObject.Value.GetValue() ?? JSValue.Undefined;
+    public JSValue ObjectFreezeSeal => _testObjectFreezeSeal.Value.GetValue() ?? JSValue.Undefined;
+}

--- a/Test/TestCases/node-addon-api/common/index.js
+++ b/Test/TestCases/node-addon-api/common/index.js
@@ -1,0 +1,138 @@
+/* Test helpers ported from test/common/index.js in Node.js project. */
+'use strict';
+const assert = require('assert');
+const path = require('path');
+const { access } = require('node:fs/promises');
+
+const noop = () => { };
+
+const mustCallChecks = [];
+
+function runCallChecks(exitCode) {
+  if (exitCode !== 0) return;
+
+  const failed = mustCallChecks.filter(function (context) {
+    if ('minimum' in context) {
+      context.messageSegment = `at least ${context.minimum}`;
+      return context.actual < context.minimum;
+    } else {
+      context.messageSegment = `exactly ${context.exact}`;
+      return context.actual !== context.exact;
+    }
+  });
+
+  failed.forEach(function (context) {
+    console.log('Mismatched %s function calls. Expected %s, actual %d.',
+      context.name,
+      context.messageSegment,
+      context.actual);
+    console.log(context.stack.split('\n').slice(2).join('\n'));
+  });
+
+  if (failed.length) process.exit(1);
+}
+
+exports.mustCall = function (fn, exact) {
+  return _mustCallInner(fn, exact, 'exact');
+};
+exports.mustCallAtLeast = function (fn, minimum) {
+  return _mustCallInner(fn, minimum, 'minimum');
+};
+
+function _mustCallInner(fn, criteria, field) {
+  if (typeof fn === 'number') {
+    criteria = fn;
+    fn = noop;
+  } else if (fn === undefined) {
+    fn = noop;
+  }
+  if (criteria === undefined) {
+    criteria = 1;
+  }
+
+  if (typeof criteria !== 'number') { throw new TypeError(`Invalid ${field} value: ${criteria}`); }
+
+  const context = {
+    [field]: criteria,
+    actual: 0,
+    stack: (new Error()).stack,
+    name: fn.name || '<anonymous>'
+  };
+
+  // add the exit listener only once to avoid listener leak warnings
+  if (mustCallChecks.length === 0) process.on('exit', runCallChecks);
+
+  mustCallChecks.push(context);
+
+  return function () {
+    context.actual++;
+    return fn.apply(this, arguments);
+  };
+}
+
+exports.mustNotCall = function (msg) {
+  return function mustNotCall() {
+    assert.fail(msg || 'function should not have been called');
+  };
+};
+
+const buildTypes = {
+  Release: 'Release',
+  Debug: 'Debug'
+};
+
+async function checkBuildType(buildType) {
+  try {
+    await access(path.join(path.resolve('./test/build'), buildType));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function whichBuildType() {
+  let buildType = 'Release';
+  const envBuildType = process.env.NODE_API_BUILD_CONFIG;
+  if (envBuildType) {
+    if (Object.values(buildTypes).includes(envBuildType)) {
+      if (await checkBuildType(envBuildType)) {
+        buildType = envBuildType;
+      } else {
+        throw new Error(`The ${envBuildType} build doesn't exists.`);
+      }
+    } else {
+      throw new Error('Invalid value for NODE_API_BUILD_CONFIG environment variable. It should be set to Release or Debug.');
+    }
+  }
+  return buildType;
+}
+
+exports.whichBuildType = whichBuildType;
+
+exports.runTest = async function (test) {
+  const binding = require(process.env['TEST_NODE_API_MODULE_PATH']);
+  await Promise.resolve(test(binding))
+    .finally(exports.mustCall());
+};
+
+exports.runTestWithBindingPath = async function (test, buildType, buildPathRoot = process.env.BUILD_PATH || '') {
+  buildType = buildType || await whichBuildType();
+
+  const bindings = [
+    path.join(buildPathRoot, `../build/${buildType}/binding.node`),
+    path.join(buildPathRoot, `../build/${buildType}/binding_noexcept.node`),
+    path.join(buildPathRoot, `../build/${buildType}/binding_noexcept_maybe.node`),
+    path.join(buildPathRoot, `../build/${buildType}/binding_custom_namespace.node`)
+  ].map(it => require.resolve(it));
+
+  for (const item of bindings) {
+    await test(item);
+  }
+};
+
+exports.runTestWithBuildType = async function (test, buildType) {
+  buildType = buildType || await whichBuildType();
+
+  await Promise.resolve(test(buildType))
+    .finally(exports.mustCall());
+};

--- a/Test/TestCases/node-addon-api/delete_property.cs
+++ b/Test/TestCases/node-addon-api/delete_property.cs
@@ -1,0 +1,49 @@
+using System;
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static JSValue DeletePropertyWithNapiValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.DeleteProperty((JSNativeApi.Interop.napi_value)key);
+    }
+
+    private static JSValue DeletePropertyWithNapiWrapperValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.DeleteProperty(key);
+    }
+
+    private static JSValue DeletePropertyWithLatin1StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.DeleteProperty(JSNativeApi.CreateStringLatin1(key.GetValueStringLatin1()));
+    }
+
+    private static JSValue DeletePropertyWithUtf8StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.DeleteProperty(key.GetValueStringUtf8());
+    }
+
+    private static JSValue DeletePropertyWithCSharpStyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.DeleteProperty((string)key);
+    }
+
+    private static JSValue DeletePropertyWithUInt32(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.DeleteProperty((uint)key);
+    }
+}

--- a/Test/TestCases/node-addon-api/delete_property.js
+++ b/Test/TestCases/node-addon-api/delete_property.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test (binding) {
+  function testDeleteProperty (nativeDeleteProperty) {
+    const obj = { one: 1, two: 2 };
+    Object.defineProperty(obj, 'three', { configurable: false, value: 3 });
+    assert.strictEqual(nativeDeleteProperty(obj, 'one'), true);
+    assert.strictEqual(nativeDeleteProperty(obj, 'missing'), true);
+
+    /* Returns true for all cases except when the property is an own non-
+       configurable property, in which case, false is returned in non-strict mode. */
+    assert.strictEqual(nativeDeleteProperty(obj, 'three'), false);
+    assert.deepStrictEqual(obj, { two: 2 });
+  }
+
+  function testShouldThrowErrorIfKeyIsInvalid (nativeDeleteProperty) {
+    assert.throws(() => {
+      nativeDeleteProperty(undefined, 'test');
+    }, /Cannot convert undefined or null to object/);
+  }
+
+  const testObj = { 15: 42, three: 3 };
+  binding.object.deletePropertyWithUInt32(testObj, 15);
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(testObj, 15), false);
+
+  testDeleteProperty(binding.object.deletePropertyWithNapiValue);
+  testDeleteProperty(binding.object.deletePropertyWithNapiWrapperValue);
+  testDeleteProperty(binding.object.deletePropertyWithLatin1StyleString);
+  testDeleteProperty(binding.object.deletePropertyWithUtf8StyleString);
+  testDeleteProperty(binding.object.deletePropertyWithCSharpStyleString);
+
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.deletePropertyWithNapiValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.deletePropertyWithNapiWrapperValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.deletePropertyWithLatin1StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.deletePropertyWithUtf8StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.deletePropertyWithCSharpStyleString);
+}

--- a/Test/TestCases/node-addon-api/finalizer.cs
+++ b/Test/TestCases/node-addon-api/finalizer.cs
@@ -1,0 +1,21 @@
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static JSValue AddFinalizer(JSCallbackArgs args)
+    {
+        JSValue result = JSNativeApi.CreateObject();
+        JSReference objRef = new(result);
+        args[0].AddFinalizer(() =>
+        {
+            if (objRef.GetValue() is JSValue value)
+            {
+                value.SetProperty("finalizerCalled", true);
+            }
+            objRef.Dispose();
+        });
+        return result;
+    }
+}

--- a/Test/TestCases/node-addon-api/finalizer.js
+++ b/Test/TestCases/node-addon-api/finalizer.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+const testUtil = require('./testUtil');
+
+module.exports = require('./common').runTest(test);
+
+function createWeakRef (binding, bindingToTest) {
+  return binding.object[bindingToTest]({});
+}
+
+function test (binding) {
+  let obj1;
+  return testUtil.runGCTests([
+    'addFinalizer',
+    () => {
+      obj1 = createWeakRef(binding, 'addFinalizer');
+    },
+    () => assert.deepStrictEqual(obj1, { finalizerCalled: true })
+  ]);
+}

--- a/Test/TestCases/node-addon-api/get_property.cs
+++ b/Test/TestCases/node-addon-api/get_property.cs
@@ -1,0 +1,48 @@
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static JSValue GetPropertyWithNapiValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.GetProperty((JSNativeApi.Interop.napi_value)key);
+    }
+
+    private static JSValue GetPropertyWithNapiWrapperValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.GetProperty(key);
+    }
+
+    private static JSValue GetPropertyWithLatin1StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.GetProperty(JSNativeApi.CreateStringLatin1(key.GetValueStringLatin1()));
+    }
+
+    private static JSValue GetPropertyWithUtf8StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.GetProperty(key.GetValueStringUtf8());
+    }
+
+    private static JSValue GetPropertyWithCSharpStyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.GetProperty((string)key);
+    }
+
+    private static JSValue GetPropertyWithUInt32(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.GetProperty((uint)key);
+    }
+}

--- a/Test/TestCases/node-addon-api/get_property.js
+++ b/Test/TestCases/node-addon-api/get_property.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test(binding) {
+  function testGetProperty(nativeGetProperty) {
+    const obj = { test: 1 };
+    assert.strictEqual(nativeGetProperty(obj, 'test'), 1);
+  }
+
+  function testShouldReturnUndefinedIfKeyIsNotPresent(nativeGetProperty) {
+    const obj = {};
+    assert.strictEqual(nativeGetProperty(obj, 'test'), undefined);
+  }
+
+  function testShouldThrowErrorIfKeyIsInvalid(nativeGetProperty) {
+    assert.throws(() => {
+      nativeGetProperty(undefined, 'test');
+    }, /Cannot convert undefined or null to object/);
+  }
+
+  const testObject = { 42: 100 };
+  const property = binding.object.getPropertyWithUInt32(testObject, 42);
+  assert.strictEqual(property, 100);
+
+  const nativeFunctions = [
+    binding.object.getPropertyWithNapiValue,
+    binding.object.getPropertyWithNapiWrapperValue,
+    binding.object.getPropertyWithLatin1StyleString,
+    binding.object.getPropertyWithUtf8StyleString,
+    binding.object.getPropertyWithCSharpStyleString
+  ];
+
+  nativeFunctions.forEach((nativeFunction) => {
+    testGetProperty(nativeFunction);
+    testShouldReturnUndefinedIfKeyIsNotPresent(nativeFunction);
+    testShouldThrowErrorIfKeyIsInvalid(nativeFunction);
+  });
+}

--- a/Test/TestCases/node-addon-api/has_own_property.cs
+++ b/Test/TestCases/node-addon-api/has_own_property.cs
@@ -1,0 +1,41 @@
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static JSValue HasOwnPropertyWithNapiValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasOwnProperty((JSNativeApi.Interop.napi_value)key);
+    }
+
+    private static JSValue HasOwnPropertyWithNapiWrapperValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasOwnProperty(key);
+    }
+
+    private static JSValue HasOwnPropertyWithLatin1StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasOwnProperty(JSNativeApi.CreateStringLatin1(key.GetValueStringLatin1()));
+    }
+
+    private static JSValue HasOwnPropertyWithUtf8StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasOwnProperty(key.GetValueStringUtf8());
+    }
+
+    private static JSValue HasOwnPropertyWithCSharpStyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasOwnProperty((string)key);
+    }
+}

--- a/Test/TestCases/node-addon-api/has_own_property.js
+++ b/Test/TestCases/node-addon-api/has_own_property.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test (binding) {
+  function testHasOwnProperty (nativeHasOwnProperty) {
+    const obj = { one: 1 };
+
+    Object.defineProperty(obj, 'two', { value: 2 });
+
+    assert.strictEqual(nativeHasOwnProperty(obj, 'one'), true);
+    assert.strictEqual(nativeHasOwnProperty(obj, 'two'), true);
+    assert.strictEqual('toString' in obj, true);
+    assert.strictEqual(nativeHasOwnProperty(obj, 'toString'), false);
+  }
+
+  function testShouldThrowErrorIfKeyIsInvalid (nativeHasOwnProperty) {
+    assert.throws(() => {
+      nativeHasOwnProperty(undefined, 'test');
+    }, /Cannot convert undefined or null to object/);
+  }
+
+  testHasOwnProperty(binding.object.hasOwnPropertyWithNapiValue);
+  testHasOwnProperty(binding.object.hasOwnPropertyWithNapiWrapperValue);
+  testHasOwnProperty(binding.object.hasOwnPropertyWithLatin1StyleString);
+  testHasOwnProperty(binding.object.hasOwnPropertyWithUtf8StyleString);
+  testHasOwnProperty(binding.object.hasOwnPropertyWithCSharpStyleString);
+
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasOwnPropertyWithNapiValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasOwnPropertyWithNapiWrapperValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasOwnPropertyWithLatin1StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasOwnPropertyWithUtf8StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasOwnPropertyWithCSharpStyleString);
+}

--- a/Test/TestCases/node-addon-api/has_property.cs
+++ b/Test/TestCases/node-addon-api/has_property.cs
@@ -1,0 +1,48 @@
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static JSValue HasPropertyWithNapiValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasProperty((JSNativeApi.Interop.napi_value)key);
+    }
+
+    private static JSValue HasPropertyWithNapiWrapperValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasProperty(key);
+    }
+
+    private static JSValue HasPropertyWithLatin1StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasProperty(JSNativeApi.CreateStringLatin1(key.GetValueStringLatin1()));
+    }
+
+    private static JSValue HasPropertyWithUtf8StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasProperty(key.GetValueStringUtf8());
+    }
+
+    private static JSValue HasPropertyWithCSharpStyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasProperty((string)key);
+    }
+
+    private static JSValue HasPropertyWithUInt32(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        return obj.HasProperty((uint)key);
+    }
+}

--- a/Test/TestCases/node-addon-api/has_property.js
+++ b/Test/TestCases/node-addon-api/has_property.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test (binding) {
+  function testHasProperty (nativeHasProperty) {
+    const obj = { one: 1 };
+
+    Object.defineProperty(obj, 'two', { value: 2 });
+
+    assert.strictEqual(nativeHasProperty(obj, 'one'), true);
+    assert.strictEqual(nativeHasProperty(obj, 'two'), true);
+    assert.strictEqual('toString' in obj, true);
+    assert.strictEqual(nativeHasProperty(obj, 'toString'), true);
+  }
+
+  function testShouldThrowErrorIfKeyIsInvalid (nativeHasProperty) {
+    assert.throws(() => {
+      nativeHasProperty(undefined, 'test');
+    }, /Cannot convert undefined or null to object/);
+  }
+
+  const objectWithInt32Key = { 12: 101 };
+  assert.strictEqual(binding.object.hasPropertyWithUInt32(objectWithInt32Key, 12), true);
+
+  testHasProperty(binding.object.hasPropertyWithNapiValue);
+  testHasProperty(binding.object.hasPropertyWithNapiWrapperValue);
+  testHasProperty(binding.object.hasPropertyWithLatin1StyleString);
+  testHasProperty(binding.object.hasPropertyWithUtf8StyleString);
+  testHasProperty(binding.object.hasPropertyWithCSharpStyleString);
+
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithNapiValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithNapiWrapperValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithLatin1StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithUtf8StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithCSharpStyleString);
+}

--- a/Test/TestCases/node-addon-api/object.cs
+++ b/Test/TestCases/node-addon-api/object.cs
@@ -1,0 +1,217 @@
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static bool s_testValue = true;
+
+    // Used to test void* Data() integrity
+    private class UserDataHolder
+    {
+        public int Value { get; set; }
+    }
+
+    private static JSValue TestGetter(JSCallbackArgs args)
+    {
+        return JSNativeApi.GetBoolean(s_testValue);
+    }
+
+    private static JSValue TestSetter(JSCallbackArgs args)
+    {
+        s_testValue = (bool)args[0];
+        return JSValue.Undefined;
+    }
+
+    private static JSValue TestGetterWithUserData(JSCallbackArgs args)
+    {
+        if (args.Data is UserDataHolder holder)
+        {
+            return (JSValue)holder.Value;
+        }
+        return JSValue.Undefined;
+    }
+
+    private static JSValue TestSetterWithUserData(JSCallbackArgs args)
+    {
+        if (args.Data is UserDataHolder holder)
+        {
+            holder.Value = (int)args[0];
+        }
+        return JSValue.Undefined;
+    }
+
+    private static JSValue TestFunction(JSCallbackArgs args)
+    {
+        return true;
+    }
+
+    private static JSValue TestFunctionWithUserData(JSCallbackArgs args)
+    {
+        if (args.Data is UserDataHolder holder)
+        {
+            return holder.Value;
+        }
+        return JSValue.Undefined;
+    }
+
+    private static JSValue GetPropertyNames(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        return obj.GetPropertyNames();
+    }
+
+    private static JSValue DefineProperties(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+
+        JSValue trueValue = JSValue.True;
+        UserDataHolder holder = new()
+        {
+            Value = 1234
+        };
+
+        obj.DefineProperties(
+            JSPropertyDescriptor.Accessor("readonlyAccessor", TestGetter),
+            JSPropertyDescriptor.Accessor("readWriteAccessor", TestGetter, TestSetter),
+            JSPropertyDescriptor.Accessor("readonlyAccessorWithUserData",
+                                          TestGetterWithUserData,
+                                          data: holder),
+            JSPropertyDescriptor.Accessor("readWriteAccessorWithUserData",
+                                          TestGetterWithUserData,
+                                          TestSetterWithUserData,
+                                          data: holder),
+            JSPropertyDescriptor.ForValue("readonlyValue", trueValue),
+            JSPropertyDescriptor.ForValue("readWriteValue", trueValue, JSPropertyAttributes.Writable),
+            JSPropertyDescriptor.ForValue("enumerableValue", trueValue, JSPropertyAttributes.Enumerable),
+            JSPropertyDescriptor.ForValue("configurableValue", trueValue, JSPropertyAttributes.Configurable),
+            JSPropertyDescriptor.Function("function", TestFunction),
+            JSPropertyDescriptor.Function("functionWithUserData",
+                                          TestFunctionWithUserData,
+                                          data: holder)
+        );
+        return JSValue.Undefined;
+    }
+
+    private static JSValue DefineValueProperty(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue name = args[1];
+        JSValue value = args[2];
+        obj.DefineProperties(JSPropertyDescriptor.ForValue(name, value));
+        return JSValue.Undefined;
+    }
+
+    private static JSValue CreateObjectUsingMagic(JSCallbackArgs args)
+    {
+        JSValue obj = JSNativeApi.CreateObject();
+        obj["cp_false"] = false;
+        obj["cp_true"] = true;
+        obj["s_true"] = true;
+        obj["s_false"] = false;
+        obj["0"] = 0;
+        obj[(uint)42] = 120;
+        obj["0.0f"] = 0.0f;
+        obj["0.0"] = 0.0;
+        obj["-1"] = -1;
+        obj["foo2"] = "foo"u8;
+        obj["foo4"] = "foo";
+        obj["circular"] = obj;
+        obj["circular2"] = obj;
+        return obj;
+    }
+
+    private static JSValue Sum(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        long sum = 0;
+
+        foreach ((JSValue _, JSValue value) in obj)
+        {
+            sum += (long)value;
+        }
+
+        return sum;
+    }
+
+    private static JSValue Increment(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+
+        foreach ((JSValue name, JSValue value) in obj)
+        {
+            obj[name] = (long)value + 1;
+        }
+
+        return JSValue.Undefined;
+    }
+
+    private static JSValue InstanceOf(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue constructor = args[1];
+        return obj.InstanceOf(constructor);
+    }
+
+    public static JSValue Init()
+    {
+        JSValue exports = JSNativeApi.CreateObject();
+
+        exports["GetPropertyNames"] = (JSCallback)GetPropertyNames;
+        exports["defineProperties"] = (JSCallback)DefineProperties;
+        exports["defineValueProperty"] = (JSCallback)DefineValueProperty;
+
+        exports["getPropertyWithNapiValue"] = (JSCallback)GetPropertyWithNapiValue;
+        exports["getPropertyWithNapiWrapperValue"] = (JSCallback)GetPropertyWithNapiWrapperValue;
+        exports["getPropertyWithLatin1StyleString"] = (JSCallback)GetPropertyWithLatin1StyleString;
+        exports["getPropertyWithUtf8StyleString"] = (JSCallback)GetPropertyWithUtf8StyleString;
+        exports["getPropertyWithCSharpStyleString"] = (JSCallback)GetPropertyWithCSharpStyleString;
+        exports["getPropertyWithUInt32"] = (JSCallback)GetPropertyWithUInt32;
+
+        exports["setPropertyWithNapiValue"] = (JSCallback)SetPropertyWithNapiValue;
+        exports["setPropertyWithNapiWrapperValue"] = (JSCallback)SetPropertyWithNapiWrapperValue;
+        exports["setPropertyWithLatin1StyleString"] = (JSCallback)SetPropertyWithLatin1StyleString;
+        exports["setPropertyWithUtf8StyleString"] = (JSCallback)SetPropertyWithUtf8StyleString;
+        exports["setPropertyWithCSharpStyleString"] = (JSCallback)SetPropertyWithCSharpStyleString;
+        exports["setPropertyWithUInt32"] = (JSCallback)SetPropertyWithUInt32;
+
+        exports["deletePropertyWithNapiValue"] = (JSCallback)DeletePropertyWithNapiValue;
+        exports["deletePropertyWithNapiWrapperValue"] = (JSCallback)DeletePropertyWithNapiWrapperValue;
+        exports["deletePropertyWithLatin1StyleString"] = (JSCallback)DeletePropertyWithLatin1StyleString;
+        exports["deletePropertyWithUtf8StyleString"] = (JSCallback)DeletePropertyWithUtf8StyleString;
+        exports["deletePropertyWithCSharpStyleString"] = (JSCallback)DeletePropertyWithCSharpStyleString;
+        exports["deletePropertyWithUInt32"] = (JSCallback)DeletePropertyWithUInt32;
+
+        exports["hasOwnPropertyWithNapiValue"] = (JSCallback)HasOwnPropertyWithNapiValue;
+        exports["hasOwnPropertyWithNapiWrapperValue"] = (JSCallback)HasOwnPropertyWithNapiWrapperValue;
+        exports["hasOwnPropertyWithLatin1StyleString"] = (JSCallback)HasOwnPropertyWithLatin1StyleString;
+        exports["hasOwnPropertyWithUtf8StyleString"] = (JSCallback)HasOwnPropertyWithUtf8StyleString;
+        exports["hasOwnPropertyWithCSharpStyleString"] = (JSCallback)HasOwnPropertyWithCSharpStyleString;
+
+        exports["hasPropertyWithNapiValue"] = (JSCallback)HasPropertyWithNapiValue;
+        exports["hasPropertyWithNapiWrapperValue"] = (JSCallback)HasPropertyWithNapiWrapperValue;
+        exports["hasPropertyWithLatin1StyleString"] = (JSCallback)HasPropertyWithLatin1StyleString;
+        exports["hasPropertyWithUtf8StyleString"] = (JSCallback)HasPropertyWithUtf8StyleString;
+        exports["hasPropertyWithCSharpStyleString"] = (JSCallback)HasPropertyWithCSharpStyleString;
+        exports["hasPropertyWithUInt32"] = (JSCallback)HasPropertyWithUInt32;
+
+        exports["createObjectUsingMagic"] = (JSCallback)CreateObjectUsingMagic;
+        exports["sum"] = (JSCallback)Sum;
+        exports["increment"] = (JSCallback)Increment;
+
+        exports["addFinalizer"] = (JSCallback)AddFinalizer;
+
+        exports["instanceOf"] = (JSCallback)InstanceOf;
+
+        exports["subscriptGetWithLatin1StyleString"] = (JSCallback)SubscriptGetWithLatin1StyleString;
+        exports["subscriptGetWithUtf8StyleString"] = (JSCallback)SubscriptGetWithUtf8StyleString;
+        exports["subscriptGetWithCSharpStyleString"] = (JSCallback)SubscriptGetWithCSharpStyleString;
+        exports["subscriptGetAtIndex"] = (JSCallback)SubscriptGetAtIndex;
+        exports["subscriptSetWithLatin1StyleString"] = (JSCallback)SubscriptSetWithLatin1StyleString;
+        exports["subscriptSetWithUtf8StyleString"] = (JSCallback)SubscriptSetWithUtf8StyleString;
+        exports["subscriptSetWithCSharpStyleString"] = (JSCallback)SubscriptSetWithCSharpStyleString;
+        exports["subscriptSetAtIndex"] = (JSCallback)SubscriptSetAtIndex;
+
+        return exports;
+    }
+}

--- a/Test/TestCases/node-addon-api/object.js
+++ b/Test/TestCases/node-addon-api/object.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test(binding) {
+
+  function assertPropertyIs(obj, key, attribute) {
+    const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+    assert.ok(propDesc);
+    assert.ok(propDesc[attribute]);
+  }
+
+  function assertPropertyIsNot(obj, key, attribute) {
+    const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+    assert.ok(propDesc);
+    assert.ok(!propDesc[attribute]);
+  }
+
+  function testDefineProperties() {
+    const obj = {};
+    binding.object.defineProperties(obj);
+
+    // accessors
+    assertPropertyIsNot(obj, 'readonlyAccessor', 'enumerable');
+    assertPropertyIsNot(obj, 'readonlyAccessor', 'configurable');
+    assert.strictEqual(obj.readonlyAccessor, true);
+
+    assertPropertyIsNot(obj, 'readonlyAccessorWithUserData', 'enumerable');
+    assertPropertyIsNot(obj, 'readonlyAccessorWithUserData', 'configurable');
+    assert.strictEqual(obj.readonlyAccessorWithUserData, 1234);
+
+    assertPropertyIsNot(obj, 'readWriteAccessor', 'enumerable');
+    assertPropertyIsNot(obj, 'readWriteAccessor', 'configurable');
+    obj.readWriteAccessor = false;
+    assert.strictEqual(obj.readWriteAccessor, false);
+    obj.readWriteAccessor = true;
+    assert.strictEqual(obj.readWriteAccessor, true);
+
+    assertPropertyIsNot(obj, 'readWriteAccessorWithUserData', 'enumerable');
+    assertPropertyIsNot(obj, 'readWriteAccessorWithUserData', 'configurable');
+    obj.readWriteAccessorWithUserData = 2;
+    assert.strictEqual(obj.readWriteAccessorWithUserData, 2);
+    obj.readWriteAccessorWithUserData = -14;
+    assert.strictEqual(obj.readWriteAccessorWithUserData, -14);
+
+    // values
+    assertPropertyIsNot(obj, 'readonlyValue', 'writable');
+    assertPropertyIsNot(obj, 'readonlyValue', 'enumerable');
+    assertPropertyIsNot(obj, 'readonlyValue', 'configurable');
+    assert.strictEqual(obj.readonlyValue, true);
+
+    assertPropertyIs(obj, 'readWriteValue', 'writable');
+    assertPropertyIsNot(obj, 'readWriteValue', 'enumerable');
+    assertPropertyIsNot(obj, 'readWriteValue', 'configurable');
+    obj.readWriteValue = false;
+    assert.strictEqual(obj.readWriteValue, false);
+    obj.readWriteValue = true;
+    assert.strictEqual(obj.readWriteValue, true);
+
+    assertPropertyIsNot(obj, 'enumerableValue', 'writable');
+    assertPropertyIs(obj, 'enumerableValue', 'enumerable');
+    assertPropertyIsNot(obj, 'enumerableValue', 'configurable');
+
+    assertPropertyIsNot(obj, 'configurableValue', 'writable');
+    assertPropertyIsNot(obj, 'configurableValue', 'enumerable');
+    assertPropertyIs(obj, 'configurableValue', 'configurable');
+
+    // functions
+    assertPropertyIsNot(obj, 'function', 'writable');
+    assertPropertyIsNot(obj, 'function', 'enumerable');
+    assertPropertyIsNot(obj, 'function', 'configurable');
+    assert.strictEqual(obj.function(), true);
+    assert.strictEqual(obj.functionWithUserData(), obj.readonlyAccessorWithUserData);
+  }
+
+  testDefineProperties();
+
+  {
+    const obj = {};
+    const testSym = Symbol('testSym');
+    binding.object.defineValueProperty(obj, testSym, 1);
+    assert.strictEqual(obj[testSym], 1);
+  }
+
+  {
+    const testSym = Symbol('testSym');
+    const obj = { one: 1, two: 2, three: 3, [testSym]: 4 };
+    const arr = binding.object.GetPropertyNames(obj);
+    assert.deepStrictEqual(arr, ['one', 'two', 'three']);
+  }
+
+  {
+    const magicObject = binding.object.createObjectUsingMagic();
+    assert.deepStrictEqual(magicObject, {
+      0: 0,
+      42: 120,
+      cp_false: false,
+      cp_true: true,
+      s_true: true,
+      s_false: false,
+      '0.0f': 0,
+      '0.0': 0,
+      '-1': -1,
+      foo2: 'foo',
+      foo4: 'foo',
+      circular: magicObject,
+      circular2: magicObject
+    });
+  }
+
+  {
+    function Ctor() { }
+
+    assert.strictEqual(binding.object.instanceOf(new Ctor(), Ctor), true);
+    assert.strictEqual(binding.object.instanceOf(new Ctor(), Object), true);
+    assert.strictEqual(binding.object.instanceOf({}, Ctor), false);
+    assert.strictEqual(binding.object.instanceOf(null, Ctor), false);
+  }
+
+  if ('sum' in binding.object) {
+    {
+      const obj = {
+        '-forbid': -0x4B1D,
+        '-feedcode': -0xFEEDC0DE,
+        '+office': +0x0FF1CE,
+        '+forbid': +0x4B1D,
+        '+deadbeef': +0xDEADBEEF,
+        '+feedcode': +0xFEEDC0DE
+      };
+
+      let sum = 0;
+      for (const key in obj) {
+        sum += obj[key];
+      }
+
+      assert.strictEqual(binding.object.sum(obj), sum);
+    }
+
+    {
+      const obj = new Proxy({
+        '-forbid': -0x4B1D,
+        '-feedcode': -0xFEEDC0DE,
+        '+office': +0x0FF1CE,
+        '+forbid': +0x4B1D,
+        '+deadbeef': +0xDEADBEEF,
+        '+feedcode': +0xFEEDC0DE
+      }, {
+        getOwnPropertyDescriptor(target, p) {
+          throw new Error('getOwnPropertyDescriptor error');
+        },
+        ownKeys(target) {
+          throw new Error('ownKeys error');
+        }
+      });
+
+      assert.throws(() => {
+        binding.object.sum(obj);
+      }, /ownKeys error/);
+    }
+  }
+
+  if ('increment' in binding.object) {
+    const obj = {
+      a: 0,
+      b: 1,
+      c: 2
+    };
+
+    binding.object.increment(obj);
+
+    assert.deepStrictEqual(obj, {
+      a: 1,
+      b: 2,
+      c: 3
+    });
+  }
+}

--- a/Test/TestCases/node-addon-api/object_freeze_seal.cs
+++ b/Test/TestCases/node-addon-api/object_freeze_seal.cs
@@ -1,0 +1,28 @@
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObjectFreezeSeal
+{
+    private static JSValue Freeze(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        obj.Freeze();
+        return true;
+    }
+
+    private static JSValue Seal(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        obj.Seal();
+        return true;
+    }
+
+    public static JSValue Init()
+    {
+        JSValue exports = JSNativeApi.CreateObject();
+        exports["freeze"] = (JSCallback)Freeze;
+        exports["seal"] = (JSCallback)Seal;
+        return exports;
+    }
+}

--- a/Test/TestCases/node-addon-api/object_freeze_seal.js
+++ b/Test/TestCases/node-addon-api/object_freeze_seal.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test(binding) {
+  {
+    const obj = { x: 'a', y: 'b', z: 'c' };
+    assert.strictEqual(binding.objectFreezeSeal.freeze(obj), true);
+    assert.strictEqual(Object.isFrozen(obj), true);
+    assert.throws(() => {
+      obj.x = 10;
+    }, /Cannot assign to read only property 'x' of object '#<Object>/);
+    assert.throws(() => {
+      obj.w = 15;
+    }, /Cannot add property w, object is not extensible/);
+    assert.throws(() => {
+      delete obj.x;
+    }, /Cannot delete property 'x' of #<Object>/);
+  }
+
+  {
+    const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
+      preventExtensions() {
+        throw new Error('foo');
+      }
+    });
+
+    assert.throws(() => {
+      binding.objectFreezeSeal.freeze(obj);
+    }, /foo/);
+  }
+
+  {
+    const obj = { x: 'a', y: 'b', z: 'c' };
+    assert.strictEqual(binding.objectFreezeSeal.seal(obj), true);
+    assert.strictEqual(Object.isSealed(obj), true);
+    assert.throws(() => {
+      obj.w = 'd';
+    }, /Cannot add property w, object is not extensible/);
+    assert.throws(() => {
+      delete obj.x;
+    }, /Cannot delete property 'x' of #<Object>/);
+    // Sealed objects allow updating existing properties,
+    // so this should not throw.
+    obj.x = 'd';
+  }
+
+  {
+    const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
+      preventExtensions() {
+        throw new Error('foo');
+      }
+    });
+
+    assert.throws(() => {
+      binding.objectFreezeSeal.seal(obj);
+    }, /foo/);
+  }
+}

--- a/Test/TestCases/node-addon-api/set_property.cs
+++ b/Test/TestCases/node-addon-api/set_property.cs
@@ -1,0 +1,61 @@
+using System;
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static JSValue SetPropertyWithNapiValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        JSValue value = args[2];
+        obj.SetProperty((JSNativeApi.Interop.napi_value)key, value);
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SetPropertyWithNapiWrapperValue(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        JSValue value = args[2];
+        obj.SetProperty(key, value);
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SetPropertyWithLatin1StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        JSValue value = args[2];
+        obj.SetProperty(JSNativeApi.CreateStringLatin1(key.GetValueStringLatin1()), value);
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SetPropertyWithUtf8StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        JSValue value = args[2];
+        obj.SetProperty(key.GetValueStringUtf8(), value);
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SetPropertyWithCSharpStyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        JSValue value = args[2];
+        obj.SetProperty((string)key, value);
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SetPropertyWithUInt32(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        JSValue key = args[1];
+        JSValue value = args[2];
+        obj.SetProperty((uint)key, value);
+        return JSValue.Undefined;
+    }
+}

--- a/Test/TestCases/node-addon-api/set_property.js
+++ b/Test/TestCases/node-addon-api/set_property.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test(binding) {
+  function testSetProperty(nativeSetProperty, key = 'test') {
+    const obj = {};
+    nativeSetProperty(obj, key, 1);
+    assert.strictEqual(obj[key], 1);
+  }
+
+  function testShouldThrowErrorIfKeyIsInvalid(nativeSetProperty) {
+    assert.throws(() => {
+      nativeSetProperty(undefined, 'test', 1);
+    }, /Cannot convert undefined or null to object/);
+  }
+
+  testSetProperty(binding.object.setPropertyWithNapiValue);
+  testSetProperty(binding.object.setPropertyWithNapiWrapperValue);
+  testSetProperty(binding.object.setPropertyWithLatin1StyleString);
+  testSetProperty(binding.object.setPropertyWithUtf8StyleString);
+  testSetProperty(binding.object.setPropertyWithCSharpStyleString);
+  testSetProperty(binding.object.setPropertyWithUInt32, 12);
+
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.setPropertyWithNapiValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.setPropertyWithNapiWrapperValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.setPropertyWithLatin1StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.setPropertyWithUtf8StyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.setPropertyWithCSharpStyleString);
+}

--- a/Test/TestCases/node-addon-api/subscript_operator.cs
+++ b/Test/TestCases/node-addon-api/subscript_operator.cs
@@ -1,0 +1,70 @@
+using NodeApi;
+
+namespace NodeApiTest;
+
+public partial class TestObject
+{
+    private static JSValue SubscriptGetWithLatin1StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        byte[] key = args[1].GetValueStringLatin1();
+        return obj[JSNativeApi.CreateStringLatin1(key)];
+    }
+
+    private static JSValue SubscriptGetWithUtf8StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        byte[] key = args[1].GetValueStringUtf8();
+        return obj[key];
+    }
+
+    private static JSValue SubscriptGetWithCSharpStyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        string key = (string)args[1];
+        return obj[key];
+    }
+
+    private static JSValue SubscriptGetAtIndex(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        uint index = (uint)args[1];
+        return obj[index];
+    }
+
+    private static JSValue SubscriptSetWithLatin1StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        byte[] key = args[1].GetValueStringLatin1();
+        JSValue value = args[2];
+        obj[JSNativeApi.CreateStringLatin1(key)] = value;
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SubscriptSetWithUtf8StyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        byte[] key = args[1].GetValueStringUtf8();
+        JSValue value = args[2];
+        obj[key] = value;
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SubscriptSetWithCSharpStyleString(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        string key = (string)args[1];
+        JSValue value = args[2];
+        obj[key] = value;
+        return JSValue.Undefined;
+    }
+
+    private static JSValue SubscriptSetAtIndex(JSCallbackArgs args)
+    {
+        JSValue obj = args[0];
+        uint index = (uint)args[1];
+        JSValue value = args[2];
+        obj[index] = value;
+        return JSValue.Undefined;
+    }
+}

--- a/Test/TestCases/node-addon-api/subscript_operator.js
+++ b/Test/TestCases/node-addon-api/subscript_operator.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTest(test);
+
+function test(binding) {
+  function testProperty(obj, key, value, nativeGetProperty, nativeSetProperty) {
+    nativeSetProperty(obj, key, value);
+    assert.strictEqual(nativeGetProperty(obj, key), value);
+  }
+
+  testProperty({}, 'key', 'value', binding.object.subscriptGetWithLatin1StyleString, binding.object.subscriptSetWithLatin1StyleString);
+  testProperty({}, 'key', 'value', binding.object.subscriptGetWithUtf8StyleString, binding.object.subscriptSetWithUtf8StyleString);
+  testProperty({ key: 'override me' }, 'key', 'value', binding.object.subscriptGetWithCSharpStyleString, binding.object.subscriptSetWithCSharpStyleString);
+  testProperty({}, 0, 'value', binding.object.subscriptGetAtIndex, binding.object.subscriptSetAtIndex);
+  testProperty({ key: 'override me' }, 0, 'value', binding.object.subscriptGetAtIndex, binding.object.subscriptSetAtIndex);
+}

--- a/Test/TestCases/node-addon-api/testUtil.js
+++ b/Test/TestCases/node-addon-api/testUtil.js
@@ -1,0 +1,54 @@
+// Run each test function in sequence,
+// with an async delay and GC call between each.
+
+function tick(x) {
+  return new Promise((resolve) => {
+    setImmediate(function ontick() {
+      if (--x === 0) {
+        resolve();
+      } else {
+        setImmediate(ontick);
+      }
+    });
+  });
+}
+
+async function runGCTests(tests) {
+  // Break up test list into a list of lists of the form
+  // [ [ 'test name', function() {}, ... ], ..., ].
+  const testList = [];
+  let currentTest;
+  for (const item of tests) {
+    if (typeof item === 'string') {
+      currentTest = [];
+      testList.push(currentTest);
+    }
+    currentTest.push(item);
+  }
+
+  for (const test of testList) {
+    await (async function (test) {
+      let title;
+      for (let i = 0; i < test.length; i++) {
+        if (i === 0) {
+          title = test[i];
+        } else {
+          try {
+            test[i]();
+          } catch (e) {
+            console.error('Test failed: ' + title);
+            throw e;
+          }
+          if (i < tests.length - 1) {
+            global.gc();
+            await tick(10);
+          }
+        }
+      }
+    })(test);
+  }
+}
+
+module.exports = {
+  runGCTests
+};


### PR DESCRIPTION
In this PR we are starting to implement unit tests by adopting them from the [C++ Node-API repo](https://github.com/nodejs/node-addon-api).
This PR implements tests that can be found in the [test/object](https://github.com/vmoroz/node-addon-api/tree/main/test/object) folder.

Some code was needed to be fixed for tests to work:
- Test runner must use the `--expose-gc` Node.js flag to enable explicit GC runs in tests.
- Methods that accept C `const char*` strings for property names were removed - there is no good use for them in C#.
- `JSPropertyDescriptor` is changed to become a `struct`.
- Fixed proper passing of `Data` object in property descriptors.
- Added `AddFinalizer` method.
- Other minor renamings and adjustments.