### PR TITLE
Generate adapters for arbitrary parameters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -152,9 +152,6 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-# License header
-file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
-
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,9 @@ jobs:
       if: ${{ always() }} # Run this step even when there are test failures
 
     - name: Check formatting
-      run: dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
+      run: |
+        dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
+        dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
       if: ${{ always() }} # Run this step even when there are build failures
 
     # TODO: Publish packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,7 @@ jobs:
       if: ${{ always() }} # Run this step even when there are test failures
 
     - name: Check formatting
-      run: dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
-        dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
+      run: dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
       if: ${{ always() }} # Run this step even when there are build failures
 
     # TODO: Publish packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,7 @@ jobs:
       if: ${{ always() }} # Run this step even when there are test failures
 
     - name: Check formatting
-      run: |
-        dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
+      run: dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
         dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
       if: ${{ always() }} # Run this step even when there are build failures
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,6 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release
 
-    - name: Check formatting
-      run: dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
-      if: ${{ always() }} # Run this step even when there are build failures
-
     - name: pack
       run: dotnet pack --no-build --configuration Release
 
@@ -74,6 +70,10 @@ jobs:
         path: test-${{ matrix.dotnet-version }}-node${{ matrix.node-version }}/*.trx
         reporter: dotnet-trx
       if: ${{ always() }} # Run this step even when there are test failures
+
+    - name: Check formatting
+      run: dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
+      if: ${{ always() }} # Run this step even when there are build failures
 
     # TODO: Publish packages
     # - name: Publish packages

--- a/Generator/AdapterGenerator.cs
+++ b/Generator/AdapterGenerator.cs
@@ -1,0 +1,298 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace NodeApi.Generator;
+
+/// <summary>
+/// Generates C# <-> JavaScript adapter code for C# members exported to JavaScript.
+/// </summary>
+internal class AdapterGenerator : SourceGenerator
+{
+    private const string adapterPrefix = "__";
+    private const string adapterGetPrefix = adapterPrefix + "get_";
+    private const string adapterSetPrefix = adapterPrefix + "set_";
+    private const string adapterConstructorPrefix = adapterPrefix + "new_";
+
+    private readonly List<KeyValuePair<string, ISymbol>> _adaptedSymbols = new();
+
+    internal AdapterGenerator(GeneratorExecutionContext context)
+    {
+        Context = context;
+    }
+
+    internal static bool HasNoArgsConstructor(ITypeSymbol type)
+    {
+        return type.GetMembers().OfType<IMethodSymbol>()
+            .Any((m) => m.MethodKind == MethodKind.Constructor && m.Parameters.Length == 0);
+    }
+
+    internal string? GetConstructorAdapterName(ITypeSymbol type)
+    {
+        var constructors = type.GetMembers().OfType<IMethodSymbol>()
+            .Where((m) => m.MethodKind == MethodKind.Constructor)
+            .ToArray();
+        if (!constructors.Any() || constructors.Any((c) => c.Parameters.Length == 0 ||
+            (c.Parameters.Length == 1 && c.Parameters[0].Type.Name == "JSCallbackArgs")))
+        {
+            return null;
+        }
+
+        // TODO: Look for [JSExport] attribute among multiple constructors?
+        if (constructors.Count() > 1)
+        {
+            ReportError(
+                DiagnosticId.UnsupportedOverloads,
+                constructors.Skip(1).First(),
+                "Exported class must cannot have an overloaded constructor.");
+        }
+
+        var constructor = constructors.Single();
+        string ns = GetNamespace(constructor);
+        string className = type.Name;
+        string adapterName = $"{adapterConstructorPrefix}{ns.Replace('.', '_')}_{className}";
+        _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(adapterName, constructor));
+        return adapterName;
+    }
+
+    internal string? GetMethodAdapterName(IMethodSymbol method)
+    {
+        // TODO: Check full type names.
+        if ((method.Parameters.Length == 0 ||
+            (method.Parameters.Length == 1 &&
+            method.Parameters[0].Type.Name == "JSCallbackArgs")) &&
+            (method.ReturnsVoid ||
+            method.ReturnType.Name == "JSValue"))
+        {
+            return null;
+        }
+
+        foreach (IParameterSymbol parameter in method.Parameters)
+        {
+            if (parameter.RefKind != RefKind.None)
+            {
+                ReportError(
+                    DiagnosticId.UnsupportedMethodParameterType,
+                    parameter,
+                    "Parameters with 'ref' or 'out' modifiers are not supported in exported methods.");
+            }
+        }
+
+        string ns = GetNamespace(method);
+        string className = method.ContainingType.Name;
+        string adapterName = $"{adapterPrefix}{ns.Replace('.', '_')}_{className}_{method.Name}";
+        _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(adapterName, method));
+        return adapterName;
+    }
+
+    internal (string?, string?) GetPropertyAdapterNames(IPropertySymbol property)
+    {
+        // TODO: Check full type name.
+        if (property.Type.Name == "JSValue")
+        {
+            return (null, null);
+        }
+
+        string ns = GetNamespace(property);
+        string className = property.ContainingType.Name;
+
+        string? getAdapterName = null;
+        if (property?.GetMethod?.DeclaredAccessibility == Accessibility.Public)
+        {
+            getAdapterName = $"{adapterGetPrefix}{ns.Replace('.', '_')}_{className}_{property.Name}";
+            _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(getAdapterName, property));
+        }
+
+        string? setAdapterName = null;
+        if (property?.SetMethod?.DeclaredAccessibility == Accessibility.Public)
+        {
+            setAdapterName = $"{adapterSetPrefix}{ns.Replace('.', '_')}_{className}_{property.Name}";
+            _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(setAdapterName, property));
+        }
+
+        return (getAdapterName, setAdapterName);
+    }
+
+    internal void GenerateAdapters(SourceBuilder s)
+    {
+        foreach (KeyValuePair<string, ISymbol> nameAndSymbol in _adaptedSymbols)
+        {
+            s++;
+
+            string adapterName = nameAndSymbol.Key;
+            ISymbol symbol = nameAndSymbol.Value;
+            if (symbol is IMethodSymbol method)
+            {
+                if (method.MethodKind == MethodKind.Constructor)
+                {
+                    GenerateConstructorAdapter(s, adapterName, method);
+                }
+                else
+                {
+                    GenerateMethodAdapter(s, adapterName, method);
+                }
+            }
+            else
+            {
+                GeneratePropertyAdapter(s, adapterName, (IPropertySymbol)symbol);
+            }
+        }
+    }
+
+    private void GenerateConstructorAdapter(
+        SourceBuilder s,
+        string adapterName,
+        IMethodSymbol constructor)
+    {
+        string ns = GetNamespace(constructor);
+        string className = constructor.ContainingType.Name;
+
+        s += $"private static {ns}.{className} {adapterName}(JSCallbackArgs __args)";
+        s += "{";
+
+        var parameters = constructor.Parameters;
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            AdaptArgument(s, parameters[i].Type, parameters[i].Name, i);
+        }
+
+        string argumentList = string.Join(", ", parameters.Select((p) => p.Name));
+
+        s += $"return new {ns}.{className}({argumentList});";
+        s += "}";
+    }
+
+    private void GenerateMethodAdapter(
+        SourceBuilder s,
+        string adapterName,
+        IMethodSymbol method)
+    {
+        s += $"private static JSValue {adapterName}(JSCallbackArgs __args)";
+        s += "{";
+
+        if (!method.IsStatic)
+        {
+            AdaptThisArg(s, method);
+        }
+
+        var parameters = method.Parameters;
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            AdaptArgument(s, parameters[i].Type, parameters[i].Name, i);
+        }
+
+        string argumentList = string.Join(", ", parameters.Select((p) => p.Name));
+        string returnAssignment = method.ReturnsVoid ? string.Empty : "var __result = ";
+
+        string ns = GetNamespace(method);
+        string className = method.ContainingType.Name;
+        
+        if (method.IsStatic)
+        {
+            s += $"{returnAssignment}{ns}.{className}.{method.Name}({argumentList});";
+        }
+        else
+        {
+            s += $"{returnAssignment}__obj.{method.Name}({argumentList});";
+        }
+
+        if (method.ReturnsVoid)
+        {
+            s += "return JSValue.Undefined;";
+        }
+        else
+        {
+            AdaptReturnValue(s, method.ReturnType);
+        }
+
+        s += "}";
+    }
+
+    private void GeneratePropertyAdapter(
+        SourceBuilder s,
+        string adapterName,
+        IPropertySymbol property)
+    {
+        string ns = GetNamespace(property);
+        string className = property.ContainingType.Name;
+
+        if (adapterName.StartsWith(adapterGetPrefix))
+        {
+            s += $"private static JSValue {adapterName}(JSCallbackArgs __args)";
+            s += "{";
+
+            if (property.IsStatic)
+            {
+                s += $"var __result = {ns}.{className}.{property.Name};";
+            }
+            else
+            {
+                AdaptThisArg(s, property);
+                s += $"var __result = __obj.{property.Name};";
+            }
+
+            AdaptReturnValue(s, property.Type);
+            s += "}";
+        }
+        else
+        {
+            s += $"private static JSValue {adapterName}(JSCallbackArgs __args)";
+            s += "{";
+
+            if (property.IsStatic)
+            {
+                AdaptArgument(s, property.Type, "__value", 0);
+                s += $"{ns}.{className}.{property.Name} = __value;";
+            }
+            else
+            {
+                AdaptThisArg(s, property);
+                AdaptArgument(s, property.Type, "__value", 0);
+                s += $"__obj.{property.Name} = __value;";
+            }
+
+            s += "return JSValue.Undefined;";
+            s += "}";
+        }
+    }
+
+    private void AdaptThisArg(SourceBuilder s, ISymbol symbol)
+    {
+
+        string ns = GetNamespace(symbol);
+        string className = symbol.ContainingType.Name;
+
+        // For a method on a module class, the .NET object handle is stored in
+        // module instance data instead of the JS object.
+        if (symbol.ContainingType.GetAttributes().Any(
+            (a) => a.AttributeClass?.Name == "JSModuleAttribute"))
+        {
+            s += $"if (!(JSNativeApi.GetInstanceData() is {ns}.{className} __obj))";
+            s += "{";
+            s += "return JSValue.Undefined;";
+            s += "}";
+        }
+        else
+        {
+            s += $"if (!(__args.ThisArg.Unwrap() is {ns}.{className} __obj))";
+            s += "{";
+            s += "return JSValue.Undefined;";
+            s += "}";
+        }
+    }
+
+    private void AdaptArgument(
+        SourceBuilder s,
+        ITypeSymbol parameterType,
+        string parameterName,
+        int index)
+    {
+        s += $"var {parameterName} = ({parameterType})__args[{index}];";
+    }
+
+    private void AdaptReturnValue(SourceBuilder s, ITypeSymbol returnType)
+    {
+        s += $"return (JSValue)__result;";
+    }
+}

--- a/Generator/AdapterGenerator.cs
+++ b/Generator/AdapterGenerator.cs
@@ -6,14 +6,13 @@ using Microsoft.CodeAnalysis;
 namespace NodeApi.Generator;
 
 /// <summary>
-/// Generates C# <-> JavaScript adapter code for C# members exported to JavaScript.
+/// Generates adapter methods for C# members exported to JavaScript.
 /// </summary>
 internal class AdapterGenerator : SourceGenerator
 {
-    private const string AdapterPrefix = "__";
-    private const string AdapterGetPrefix = AdapterPrefix + "get_";
-    private const string AdapterSetPrefix = AdapterPrefix + "set_";
-    private const string AdapterConstructorPrefix = AdapterPrefix + "new_";
+    private const string AdapterGetPrefix = "get_";
+    private const string AdapterSetPrefix = "set_";
+    private const string AdapterConstructorPrefix = "new_";
 
     private readonly List<KeyValuePair<string, ISymbol>> _adaptedSymbols = new();
 
@@ -81,7 +80,7 @@ internal class AdapterGenerator : SourceGenerator
 
         string ns = GetNamespace(method);
         string className = method.ContainingType.Name;
-        string adapterName = $"{AdapterPrefix}{ns.Replace('.', '_')}_{className}_{method.Name}";
+        string adapterName = $"{ns.Replace('.', '_')}_{className}_{method.Name}";
         _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(adapterName, method));
         return adapterName;
     }

--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -154,6 +154,29 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         {
             if (type.GetAttributes().Any((a) => a.AttributeClass?.Name == "JSExportAttribute"))
             {
+                if (type.TypeKind == TypeKind.Delegate)
+                {
+                    ReportError(
+                        DiagnosticId.UnsupportedTypeKind,
+                        type,
+                        "Exporting delegates is not currently supported.");
+                }
+                else if (type.TypeKind == TypeKind.Interface)
+                {
+                    ReportError(
+                        DiagnosticId.UnsupportedTypeKind,
+                        type,
+                        "Exporting interfaces is not currently supported.");
+                }
+                else if (type.TypeKind != TypeKind.Class)
+                {
+                    ReportError(
+                        DiagnosticId.UnsupportedTypeKind,
+                        type,
+                        "Exporting value types is not currently supported.");
+                }
+
+
                 if (type.DeclaredAccessibility != Accessibility.Public)
                 {
                     ReportError(
@@ -196,27 +219,6 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                         yield return member;
                     }
                 }
-            }
-            else if (type.TypeKind == TypeKind.Delegate)
-            {
-                ReportError(
-                    DiagnosticId.UnsupportedTypeKind,
-                    type,
-                    "Exporting delegates is not currently supported.");
-            }
-            else if (type.TypeKind == TypeKind.Interface)
-            {
-                ReportError(
-                    DiagnosticId.UnsupportedTypeKind,
-                    type,
-                    "Exporting interfaces is not currently supported.");
-            }
-            else
-            {
-                ReportError(
-                    DiagnosticId.UnsupportedTypeKind,
-                    type,
-                    "Exporting value types is not currently supported.");
             }
         }
     }

--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -277,7 +277,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         }
         else
         {
-            ExportModule(s, moduleInitializer as ITypeSymbol, exportItems, adapterGenerator);
+            ExportModule(ref s, moduleInitializer as ITypeSymbol, exportItems, adapterGenerator);
             s++;
             s += "return exportsValue.GetCheckedHandle();";
         }
@@ -297,8 +297,8 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         return s;
     }
 
-    private void ExportModule(
-      SourceBuilder s,
+    private static void ExportModule(
+      ref SourceBuilder s,
       ITypeSymbol? moduleType,
       IEnumerable<ISymbol> exportItems,
       AdapterGenerator adapterGenerator)
@@ -317,11 +317,11 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
             {
                 if (member is IMethodSymbol method && method.MethodKind == MethodKind.Ordinary)
                 {
-                    ExportMethod(s, method, adapterGenerator);
+                    ExportMethod(ref s, method, adapterGenerator);
                 }
                 else if (member is IPropertySymbol property)
                 {
-                    ExportProperty(s, property, adapterGenerator);
+                    ExportProperty(ref s, property, adapterGenerator);
                 }
             }
         }
@@ -349,7 +349,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                 {
                     s += $"new JSClassBuilder<{ns}.{exportType.Name}>(\"{exportName}\",";
 
-                    var constructorAdapterName =
+                    string? constructorAdapterName =
                         adapterGenerator.GetConstructorAdapterName(exportType);
                     if (constructorAdapterName != null)
                     {
@@ -365,17 +365,17 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                     }
                 }
 
-                ExportMembers(s, exportType, adapterGenerator);
+                ExportMembers(ref s, exportType, adapterGenerator);
                 s += ".DefineClass())";
                 s.DecreaseIndent();
             }
             else if (exportItem is IPropertySymbol exportProperty)
             {
-                ExportProperty(s, exportProperty, adapterGenerator, exportName);
+                ExportProperty(ref s, exportProperty, adapterGenerator, exportName);
             }
             else if (exportItem is IMethodSymbol exportMethod)
             {
-                ExportMethod(s, exportMethod, adapterGenerator, exportName);
+                ExportMethod(ref s, exportMethod, adapterGenerator, exportName);
             }
         }
 
@@ -392,8 +392,8 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         s.DecreaseIndent();
     }
 
-    private void ExportMembers(
-      SourceBuilder s,
+    private static void ExportMembers(
+      ref SourceBuilder s,
       ITypeSymbol classType,
       AdapterGenerator adapterGenerator)
     {
@@ -404,17 +404,17 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         {
             if (member is IMethodSymbol method && method.MethodKind == MethodKind.Ordinary)
             {
-                ExportMethod(s, method, adapterGenerator);
+                ExportMethod(ref s, method, adapterGenerator);
             }
             else if (member is IPropertySymbol property)
             {
-                ExportProperty(s, property, adapterGenerator);
+                ExportProperty(ref s, property, adapterGenerator);
             }
         }
     }
 
-    private void ExportMethod(
-      SourceBuilder s,
+    private static void ExportMethod(
+      ref SourceBuilder s,
       IMethodSymbol method,
       AdapterGenerator adapterGenerator,
       string? exportName = null)
@@ -438,8 +438,8 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         }
     }
 
-    private void ExportProperty(
-      SourceBuilder s,
+    private static void ExportProperty(
+      ref SourceBuilder s,
       IPropertySymbol property,
       AdapterGenerator adapterGenerator,
       string? exportName = null)

--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -17,17 +17,22 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
     private const string ModuleInitializeMethodName = "Initialize";
     private const string ModuleRegisterFunctionName = "napi_register_module_v1";
 
-    void ISourceGenerator.Initialize(GeneratorInitializationContext context) { }
-
-    public void Execute(GeneratorExecutionContext context)
+#pragma warning disable CA1822 // Mark members as static
+    public void Initialize(GeneratorInitializationContext context)
     {
-        Context = context;
 #if DEBUG
         // Note source generators are not covered by normal debugging,
         // because the generator runs at build time, not at application run-time.
         // Un-comment the line below to enable debugging at build time.
+
         ////System.Diagnostics.Debugger.Launch();
 #endif
+    }
+#pragma warning restore CA1822 // Mark members as static
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        Context = context;
 
         try
         {

--- a/Generator/SourceGenerator.cs
+++ b/Generator/SourceGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;

--- a/Generator/SourceGenerator.cs
+++ b/Generator/SourceGenerator.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace NodeApi.Generator;
+
+/// <summary>
+/// Base class for source generators for C# APIs exported to JS.
+/// Contains shared definitions and utility methods.
+/// </summary>
+public abstract class SourceGenerator
+{
+    private const string DiagnosticPrefix = "NAPI";
+    private const string DiagnosticCategory = "NodeApi";
+
+    public enum DiagnosticId
+    {
+        GeneratorError = 1000,
+        MultipleModuleAttributes,
+        InvalidModuleInitializer,
+        ModuleInitializerIsNotPublic,
+        ModuleInitializerIsNotStatic,
+        ExportIsNotPublic,
+        ExportIsNotStatic,
+        UnsupportedTypeKind,
+        UnsupportedPropertyType,
+        UnsupportedMethodParameterType,
+        UnsupportedMethodReturnType,
+        UnsupportedOverloads,
+    }
+
+    public GeneratorExecutionContext Context { get; protected set; }
+
+    public static string GetNamespace(ISymbol symbol)
+    {
+        string ns = string.Empty;
+        for (INamespaceSymbol s = symbol.ContainingNamespace;
+            !s.IsGlobalNamespace;
+            s = s.ContainingNamespace)
+        {
+            ns = s.Name + (ns.Length > 0 ? "." + ns : string.Empty);
+        }
+        return ns;
+    }
+
+    public static string ToCamelCase(string name)
+    {
+        StringBuilder sb = new(name);
+        sb[0] = char.ToLowerInvariant(sb[0]);
+        return sb.ToString();
+    }
+
+    public void ReportError(
+      DiagnosticId id,
+      ISymbol? symbol,
+      string title,
+      string? description = null) =>
+      ReportDiagnostic(
+          DiagnosticSeverity.Error,
+          id,
+          symbol?.Locations.Single(),
+          title,
+          description);
+
+    public void ReportDiagnostic(
+      DiagnosticSeverity severity,
+      DiagnosticId id,
+      Location? location,
+      string title,
+      string? description = null)
+    {
+        var descriptor = new DiagnosticDescriptor(
+            id: DiagnosticPrefix + id,
+            title,
+            messageFormat: title +
+            (!string.IsNullOrEmpty(description) ? " " + description : string.Empty),
+            DiagnosticCategory,
+            severity,
+            isEnabledByDefault: true);
+        Context.ReportDiagnostic(
+            Diagnostic.Create(descriptor, location));
+    }
+}

--- a/Generator/SourceGenerator.cs
+++ b/Generator/SourceGenerator.cs
@@ -51,6 +51,8 @@ public abstract class SourceGenerator
         return sb.ToString();
     }
 
+// An analyzer bug results in incorrect reports of CA1822 against this method. (It can't be static.)
+#pragma warning disable CA1822 // Mark members as static
     public void ReportError(
       DiagnosticId id,
       ISymbol? symbol,
@@ -64,6 +66,7 @@ public abstract class SourceGenerator
             title,
             description);
     }
+#pragma warning restore CA1822 // Mark members as static
 
     public void ReportDiagnostic(
       DiagnosticSeverity severity,

--- a/Generator/SourceGenerator.cs
+++ b/Generator/SourceGenerator.cs
@@ -51,13 +51,13 @@ public abstract class SourceGenerator
         return sb.ToString();
     }
 
-// An analyzer bug results in incorrect reports of CA1822 against this method. (It can't be static.)
+    // An analyzer bug results in incorrect reports of CA1822 against this method. (It can't be static.)
 #pragma warning disable CA1822 // Mark members as static
     public void ReportError(
-      DiagnosticId id,
-      ISymbol? symbol,
-      string title,
-      string? description = null)
+        DiagnosticId id,
+        ISymbol? symbol,
+        string title,
+        string? description = null)
     {
         ReportDiagnostic(
             DiagnosticSeverity.Error,
@@ -69,11 +69,11 @@ public abstract class SourceGenerator
 #pragma warning restore CA1822 // Mark members as static
 
     public void ReportDiagnostic(
-      DiagnosticSeverity severity,
-      DiagnosticId id,
-      Location? location,
-      string title,
-      string? description = null)
+        DiagnosticSeverity severity,
+        DiagnosticId id,
+        Location? location,
+        string title,
+        string? description = null)
     {
         var descriptor = new DiagnosticDescriptor(
             id: DiagnosticPrefix + id,

--- a/Generator/SourceGenerator.cs
+++ b/Generator/SourceGenerator.cs
@@ -55,13 +55,15 @@ public abstract class SourceGenerator
       DiagnosticId id,
       ISymbol? symbol,
       string title,
-      string? description = null) =>
-      ReportDiagnostic(
-          DiagnosticSeverity.Error,
-          id,
-          symbol?.Locations.Single(),
-          title,
-          description);
+      string? description = null)
+    {
+        ReportDiagnostic(
+            DiagnosticSeverity.Error,
+            id,
+            symbol?.Locations.Single(),
+            title,
+            description);
+    }
 
     public void ReportDiagnostic(
       DiagnosticSeverity severity,

--- a/Runtime/JSClassBuilderOfT.cs
+++ b/Runtime/JSClassBuilderOfT.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 namespace NodeApi;
@@ -7,16 +8,21 @@ public class JSClassBuilder<T>
   , IJSObjectUnwrap<T>
   where T : class
 {
-    public delegate T ConstructorDelegate(JSCallbackArgs args);
-
     public string ClassName { get; }
 
-    public ConstructorDelegate? Constructor { get; }
+    private Func<T>? _constructor;
+    private Func<JSCallbackArgs, T>? _constructorWithArgs;
 
-    public JSClassBuilder(string className, ConstructorDelegate? constructor = null)
+    public JSClassBuilder(string className, Func<T>? constructor = null)
     {
         ClassName = className;
-        Constructor = constructor;
+        _constructor = constructor;
+    }
+
+    public JSClassBuilder(string className, Func<JSCallbackArgs, T> constructor)
+    {
+        ClassName = className;
+        _constructorWithArgs = constructor;
     }
 
     static T? IJSObjectUnwrap<T>.Unwrap(JSCallbackArgs args)
@@ -26,11 +32,18 @@ public class JSClassBuilder<T>
 
     public JSValue DefineClass()
     {
-        if (Constructor != null)
+        if (_constructor != null)
         {
             return JSNativeApi.DefineClass(
                 ClassName,
-                (args) => args.ThisArg.Wrap(Constructor(args)),
+                (args) => args.ThisArg.Wrap(_constructor()),
+                Properties.ToArray());
+        }
+        else if (_constructorWithArgs != null)
+        {
+            return JSNativeApi.DefineClass(
+                ClassName,
+                (args) => args.ThisArg.Wrap(_constructorWithArgs(args)),
                 Properties.ToArray());
         }
         else

--- a/Runtime/JSClassBuilderOfT.cs
+++ b/Runtime/JSClassBuilderOfT.cs
@@ -10,8 +10,8 @@ public class JSClassBuilder<T>
 {
     public string ClassName { get; }
 
-    private Func<T>? _constructor;
-    private Func<JSCallbackArgs, T>? _constructorWithArgs;
+    private readonly Func<T>? _constructor;
+    private readonly Func<JSCallbackArgs, T>? _constructorWithArgs;
 
     public JSClassBuilder(string className, Func<T>? constructor = null)
     {

--- a/Test/TestCases/napi-dotnet/Another.cs
+++ b/Test/TestCases/napi-dotnet/Another.cs
@@ -7,12 +7,12 @@ namespace NodeApi.TestCases;
 [JSExport]
 public class Another
 {
-    public Another(JSCallbackArgs _)
+    public Another()
     {
-        Console.WriteLine("Another()");
+        Console.WriteLine("Another({init})");
     }
 
-    public static JSValue StaticValue
+    public static string StaticValue
     {
         get
         {
@@ -21,7 +21,7 @@ public class Another
         }
     }
 
-    public JSValue InstanceValue
+    public string InstanceValue
     {
         get
         {
@@ -30,15 +30,15 @@ public class Another
         }
     }
 
-    public static JSValue StaticMethod(JSCallbackArgs _)
+    public static bool StaticMethod(bool arg1, int arg2)
     {
-        Console.WriteLine("Another.StaticMethod()");
+        Console.WriteLine($"Another.StaticMethod({arg1}, {arg2})");
         return true;
     }
 
-    public JSValue InstanceMethod(JSCallbackArgs _)
+    public bool InstanceMethod(string arg)
     {
-        Console.WriteLine("Another.InstanceMethod()");
+        Console.WriteLine($"Another.InstanceMethod({arg})");
         return false;
     }
 }

--- a/Test/TestCases/napi-dotnet/Counter.cs
+++ b/Test/TestCases/napi-dotnet/Counter.cs
@@ -4,17 +4,11 @@ using System.Threading;
 namespace NodeApi.TestCases;
 
 [JSExport]
-public class Counter
+public static class Counter
 {
-    // TODO: Support exporting static classes without a constructor.
-    public Counter(JSCallbackArgs _)
-    {
-        Console.WriteLine("Counter()");
-    }
-
     private static uint s_count;
 
-    public static JSValue Count(JSCallbackArgs _)
+    public static uint Count()
     {
         uint result = Interlocked.Increment(ref s_count);
 

--- a/Test/TestCases/napi-dotnet/Hello.cs
+++ b/Test/TestCases/napi-dotnet/Hello.cs
@@ -5,9 +5,9 @@ namespace NodeApi.TestCases;
 public static class Hello
 {
     [JSExport("hello")]
-    public static JSValue Test(JSCallbackArgs args)
+    public static string Test(string greeter)
     {
-        Console.WriteLine($"Hello(\"{(string)args[0]}\")");
-        return $"Hello {(string)args[0]}!";
+        Console.WriteLine($"Hello(\"{greeter}\")");
+        return $"Hello {greeter}!";
     }
 }

--- a/Test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/Test/TestCases/napi-dotnet/ModuleClass.cs
@@ -26,15 +26,15 @@ public class ModuleClass : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public JSValue ModuleProperty
+    public string ModuleProperty
     {
         get => _value;
-        set => _value = (string)value;
+        set => _value = value;
     }
 
-    public JSValue ModuleMethod(JSCallbackArgs args)
+    public string ModuleMethod(string greeter)
     {
-        string stringValue = (string)args[0];
+        string stringValue = greeter;
         return $"Hello {stringValue}!";
     }
 }

--- a/Test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/Test/TestCases/napi-dotnet/ModuleClass.cs
@@ -12,8 +12,6 @@ namespace NodeApi.TestCases;
 [JSModule]
 public class ModuleClass : IDisposable
 {
-    private string _value = "test";
-
     /// <summary>
     /// The module class must have a public constructor that takes no parameters.
     /// </summary>
@@ -26,11 +24,7 @@ public class ModuleClass : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public string ModuleProperty
-    {
-        get => _value;
-        set => _value = value;
-    }
+    public string ModuleProperty { get; set; } = "test";
 
     public string ModuleMethod(string greeter)
     {


### PR DESCRIPTION
This enables a cleaner more natural syntax for exporting methods, constructors, and properties that use only primitive types. See changes to the test C# code in which `JSCallbackArgs` and `JSValue` parameter and return types are replaced with C# types.

This is just a start, as it only handles basic conversions that can be done with a simple cast to/from `JSValue`. I'll extend it later to handle classes, structs, interfaces, delegates, etc.