### PR TITLE
Generate marshalling code for classes and structs

### DIFF
--- a/Generator/AdapterGenerator.cs
+++ b/Generator/AdapterGenerator.cs
@@ -5,6 +5,9 @@ using Microsoft.CodeAnalysis;
 
 namespace NodeApi.Generator;
 
+// An analyzer bug results in incorrect reports of CA1822 against methods in this class.
+#pragma warning disable CA1822 // Mark members as static
+
 /// <summary>
 /// Generates adapter methods for C# members exported to JavaScript.
 /// </summary>

--- a/Generator/AdapterGenerator.cs
+++ b/Generator/AdapterGenerator.cs
@@ -13,8 +13,11 @@ internal class AdapterGenerator : SourceGenerator
     private const string AdapterGetPrefix = "get_";
     private const string AdapterSetPrefix = "set_";
     private const string AdapterConstructorPrefix = "new_";
+    private const string AdapterFromPrefix = "from_";
+    private const string AdapterToPrefix = "to_";
 
-    private readonly List<KeyValuePair<string, ISymbol>> _adaptedSymbols = new();
+    private readonly Dictionary<string, ISymbol> _adaptedMembers = new();
+    private readonly Dictionary<string, ITypeSymbol> _adaptedStructs = new();
 
     internal AdapterGenerator(GeneratorExecutionContext context)
     {
@@ -51,7 +54,7 @@ internal class AdapterGenerator : SourceGenerator
         string ns = GetNamespace(constructor);
         string className = type.Name;
         string adapterName = $"{AdapterConstructorPrefix}{ns.Replace('.', '_')}_{className}";
-        _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(adapterName, constructor));
+        _adaptedMembers.Add(adapterName, constructor);
         return adapterName;
     }
 
@@ -81,7 +84,20 @@ internal class AdapterGenerator : SourceGenerator
         string ns = GetNamespace(method);
         string className = method.ContainingType.Name;
         string adapterName = $"{ns.Replace('.', '_')}_{className}_{method.Name}";
-        _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(adapterName, method));
+        _adaptedMembers.Add(adapterName, method);
+        return adapterName;
+    }
+
+    private string GetStructAdapterName(ITypeSymbol structType, bool toJS)
+    {
+        string ns = GetNamespace(structType);
+        string structName = structType.Name;
+        string prefix = toJS ? AdapterFromPrefix : AdapterToPrefix;
+        string adapterName = $"{prefix}{ns.Replace('.', '_')}_{structName}";
+        if (!_adaptedStructs.ContainsKey(adapterName))
+        {
+            _adaptedStructs.Add(adapterName, structType);
+        }
         return adapterName;
     }
 
@@ -100,14 +116,14 @@ internal class AdapterGenerator : SourceGenerator
         if (property?.GetMethod?.DeclaredAccessibility == Accessibility.Public)
         {
             getAdapterName = $"{AdapterGetPrefix}{ns.Replace('.', '_')}_{className}_{property.Name}";
-            _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(getAdapterName, property));
+            _adaptedMembers.Add(getAdapterName, property);
         }
 
         string? setAdapterName = null;
         if (property?.SetMethod?.DeclaredAccessibility == Accessibility.Public)
         {
             setAdapterName = $"{AdapterSetPrefix}{ns.Replace('.', '_')}_{className}_{property.Name}";
-            _adaptedSymbols.Add(new KeyValuePair<string, ISymbol>(setAdapterName, property));
+            _adaptedMembers.Add(setAdapterName, property);
         }
 
         return (getAdapterName, setAdapterName);
@@ -115,7 +131,7 @@ internal class AdapterGenerator : SourceGenerator
 
     internal void GenerateAdapters(SourceBuilder s)
     {
-        foreach (KeyValuePair<string, ISymbol> nameAndSymbol in _adaptedSymbols)
+        foreach (KeyValuePair<string, ISymbol> nameAndSymbol in _adaptedMembers)
         {
             s++;
 
@@ -137,9 +153,17 @@ internal class AdapterGenerator : SourceGenerator
                 GeneratePropertyAdapter(ref s, adapterName, (IPropertySymbol)symbol);
             }
         }
+
+        foreach (KeyValuePair<string, ITypeSymbol> nameAndSymbol in _adaptedStructs)
+        {
+            s++;
+            string adapterName = nameAndSymbol.Key;
+            ITypeSymbol structSymbol = nameAndSymbol.Value;
+            GenerateStructAdapter(ref s, adapterName, structSymbol);
+        }
     }
 
-    private static void GenerateConstructorAdapter(
+    private void GenerateConstructorAdapter(
         ref SourceBuilder s,
         string adapterName,
         IMethodSymbol constructor)
@@ -162,7 +186,7 @@ internal class AdapterGenerator : SourceGenerator
         s += "}";
     }
 
-    private static void GenerateMethodAdapter(
+    private void GenerateMethodAdapter(
         ref SourceBuilder s,
         string adapterName,
         IMethodSymbol method)
@@ -208,7 +232,7 @@ internal class AdapterGenerator : SourceGenerator
         s += "}";
     }
 
-    private static void GeneratePropertyAdapter(
+    private void GeneratePropertyAdapter(
         ref SourceBuilder s,
         string adapterName,
         IPropertySymbol property)
@@ -256,42 +280,278 @@ internal class AdapterGenerator : SourceGenerator
         }
     }
 
-    private static void AdaptThisArg(ref SourceBuilder s, ISymbol symbol)
+    private void GenerateStructAdapter(
+        ref SourceBuilder s,
+        string adapterName,
+        ITypeSymbol structType)
+    {
+        List<ISymbol> copyableProperties = new();
+        foreach (ISymbol member in structType.GetMembers()
+            .Where((m) => !m.IsStatic && m.DeclaredAccessibility == Accessibility.Public))
+        {
+            if (member.Kind == SymbolKind.Property &&
+                ((IPropertySymbol)member).GetMethod?.DeclaredAccessibility == Accessibility.Public &&
+                ((IPropertySymbol)member).SetMethod?.DeclaredAccessibility == Accessibility.Public)
+            {
+                copyableProperties.Add(member);
+            }
+            else if (member.Kind == SymbolKind.Field &&
+                !((IFieldSymbol)member).IsConst &&
+                !((IFieldSymbol)member).IsReadOnly)
+            {
+                copyableProperties.Add(member);
+            }
+        }
+
+        string ns = GetNamespace(structType);
+        string structName = structType.Name;
+
+        if (adapterName.StartsWith(AdapterFromPrefix))
+        {
+            s += $"private static JSValue {adapterName}({ns}.{structName} value)";
+            s += "{";
+            s += $"JSValue jsValue = JSNativeApi.CreateStruct<{ns}.{structName}>();";
+
+            foreach (ISymbol property in copyableProperties)
+            {
+                ITypeSymbol propertyType = (property as IPropertySymbol)?.Type ??
+                    ((IFieldSymbol)property).Type;
+                s += $"jsValue[\"{ToCamelCase(property.Name)}\"] = " +
+                    $"{Convert($"value.{property.Name}", propertyType, null)};";
+            }
+
+            s += "return jsValue;";
+            s += "}";
+        }
+        else
+        {
+            s += $"private static {ns}.{structName} {adapterName}(JSValue jsValue)";
+            s += "{";
+            s += $"{ns}.{structName} value = new();";
+
+            foreach (ISymbol property in copyableProperties)
+            {
+                ITypeSymbol propertyType = (property as IPropertySymbol)?.Type ??
+                    ((IFieldSymbol)property).Type;
+                s += $"value.{property.Name} = " +
+                    $"{Convert($"jsValue[\"{ToCamelCase(property.Name)}\"]", null, propertyType)};";
+            }
+
+            s += "return value;";
+            s += "}";
+        }
+    }
+
+    private void AdaptThisArg(ref SourceBuilder s, ISymbol symbol)
     {
 
         string ns = GetNamespace(symbol);
-        string className = symbol.ContainingType.Name;
+        string typeName = symbol.ContainingType.Name;
 
         // For a method on a module class, the .NET object handle is stored in
         // module instance data instead of the JS object.
         if (symbol.ContainingType.GetAttributes().Any(
             (a) => a.AttributeClass?.Name == "JSModuleAttribute"))
         {
-            s += $"if (!(JSNativeApi.GetInstanceData() is {ns}.{className} __obj))";
+            s += $"if (!(JSNativeApi.GetInstanceData() is {ns}.{typeName} __obj))";
             s += "{";
             s += "return JSValue.Undefined;";
             s += "}";
         }
-        else
+        else if (symbol.ContainingType.TypeKind == TypeKind.Class)
         {
-            s += $"if (!(__args.ThisArg.Unwrap() is {ns}.{className} __obj))";
+            s += $"if (!(__args.ThisArg.Unwrap() is {ns}.{typeName} __obj))";
             s += "{";
             s += "return JSValue.Undefined;";
             s += "}";
+        }
+        else if (symbol.ContainingType.TypeKind == TypeKind.Struct)
+        {
+            // Structs are not wrapped; they are passed by value via an adapter method.
+            string adapterName = GetStructAdapterName(symbol.ContainingType, toJS: false);
+            s += $"{ns}.{typeName} __obj = {adapterName}(__args.ThisArg);";
         }
     }
 
-    private static void AdaptArgument(
+    private void AdaptArgument(
         ref SourceBuilder s,
         ITypeSymbol parameterType,
         string parameterName,
         int index)
     {
-        s += $"var {parameterName} = ({parameterType})__args[{index}];";
+        s += $"var {parameterName} = {Convert($"__args[{index}]", null, parameterType)};";
     }
 
-    private static void AdaptReturnValue(ref SourceBuilder s, ITypeSymbol _/*returnType*/)
+    private void AdaptReturnValue(ref SourceBuilder s, ITypeSymbol returnType)
     {
-        s += $"return (JSValue)__result;";
+        s += $"return {Convert("__result", returnType, null)};";
+    }
+
+    private string Convert(string fromExpression, ITypeSymbol? fromType, ITypeSymbol? toType)
+    {
+        if (fromType == null)
+        {
+            // Convert from JSValue to a C# type.
+            (toType, bool isNullable) = SplitNullable(toType!);
+            if (CanCast(toType!))
+            {
+                if (isNullable)
+                {
+                    return $"({fromExpression}).IsNullOrUndefined() ? null : " +
+                        $"({toType}?)({fromExpression})";
+                }
+                else
+                {
+                    return $"({toType})({fromExpression})";
+                }
+            }
+            else if (toType.TypeKind == TypeKind.Class)
+            {
+                VerifyReferencedTypeIsExported(toType);
+
+                if (isNullable)
+                {
+                    return $"({fromExpression}).IsNullOrUndefined() ? null : " +
+                        $"({toType})JSNativeApi.Unwrap({fromExpression})!";
+                }
+                else
+                {
+                    return $"({toType})JSNativeApi.Unwrap({fromExpression})!";
+                }
+
+            }
+            else if (toType.TypeKind == TypeKind.Struct)
+            {
+                VerifyReferencedTypeIsExported(toType);
+
+                string adapterName = GetStructAdapterName(toType, toJS: false);
+                if (isNullable)
+                {
+                    return $"({fromExpression}).IsNullOrUndefined() ? ({toType}?)null : " +
+                        $"{adapterName}({fromExpression})";
+                }
+                else
+                {
+                    return $"{adapterName}({fromExpression})";
+                }
+            }
+
+            // TODO: Handle other kinds of conversions from JSValue.
+            // TODO: Handle unwrapping external values.
+            return $"default({toType})" + (isNullable ? string.Empty : "!");
+        }
+        else if (toType == null)
+        {
+            // Convert from a C# type to JSValue.
+            (fromType, bool isNullable) = SplitNullable(fromType!);
+            if (CanCast(fromType!))
+            {
+                if (isNullable)
+                {
+                    if (fromType.IsValueType)
+                    {
+                        return $"{fromExpression}.HasValue ? " +
+                            $"(JSValue)({fromExpression}.Value) : JSValue.Null";
+                    }
+                    else
+                    {
+                        return $"{fromExpression} == null ? " +
+                            $"JSValue.Null : (JSValue)({fromExpression}!)";
+                    }
+                }
+                else
+                {
+                    return $"(JSValue)({fromExpression})";
+                }
+            }
+            else if (fromType.TypeKind == TypeKind.Class)
+            {
+                VerifyReferencedTypeIsExported(fromType);
+
+                if (isNullable)
+                {
+                    return $"{fromExpression} == null ? JSValue.Null : " +
+                        $"JSNativeApi.Wrap({fromExpression})";
+                }
+                else
+                {
+                    return $"JSNativeApi.Wrap({fromExpression})";
+                }
+            }
+            else if (fromType.TypeKind == TypeKind.Struct)
+            {
+                VerifyReferencedTypeIsExported(fromType);
+
+                string adapterName = GetStructAdapterName(fromType, toJS: true);
+                if (isNullable)
+                {
+                    return $"{fromExpression} == null ? JSValue.Null : " +
+                        $"{adapterName}({fromExpression}.Value)";
+                }
+                else
+                {
+                    return $"{adapterName}({fromExpression})";
+                }
+            }
+
+            // TODO: Handle other kinds of conversions to JSValue.
+            // TODO: Consider wrapping unsupported types in a value of type "external".
+            return "JSValue.Undefined";
+        }
+        else
+        {
+            (toType, bool isNullable) = SplitNullable(toType!);
+
+            // TODO: Handle multi-step conversions.
+            return $"default({toType})" + (isNullable ? string.Empty : "!");
+        }
+    }
+
+    private void VerifyReferencedTypeIsExported(ITypeSymbol type)
+    {
+        if (ModuleGenerator.GetJSExportAttribute(type) == null)
+        {
+            // TODO: Consider an option to automatically export referenced classes?
+            ReportError(
+                DiagnosticId.ReferenedTypeNotExported,
+                type,
+                $"Referenced type {type} is not exported.");
+        }
+    }
+
+    private static bool CanCast(ITypeSymbol type)
+    {
+        (type, bool isNullable) = SplitNullable(type);
+        return type.SpecialType switch
+        {
+            SpecialType.System_Boolean => true,
+            SpecialType.System_SByte => true,
+            SpecialType.System_Byte => true,
+            SpecialType.System_Int16 => true,
+            SpecialType.System_UInt16 => true,
+            SpecialType.System_Int32 => true,
+            SpecialType.System_UInt32 => true,
+            SpecialType.System_Int64 => true,
+            SpecialType.System_UInt64 => true,
+            SpecialType.System_Single => true,
+            SpecialType.System_Double => true,
+            SpecialType.System_String => !isNullable,
+            _ => false,
+        };
+    }
+
+    private static (ITypeSymbol, bool) SplitNullable(ITypeSymbol type)
+    {
+        bool isNullable = false;
+        if (type.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            isNullable = true;
+
+            // Handle either a Nullable<T> (value type) or a nullable reference type.
+            type = type.IsValueType
+                ? ((INamedTypeSymbol)type).TypeArguments[0]
+                : type.OriginalDefinition;
+        }
+        return (type, isNullable);
     }
 }

--- a/Generator/AdapterGenerator.cs
+++ b/Generator/AdapterGenerator.cs
@@ -313,7 +313,7 @@ internal class AdapterGenerator : SourceGenerator
         {
             s += $"private static JSValue {adapterName}({ns}.{structName} value)";
             s += "{";
-            s += $"JSValue jsValue = JSNativeApi.CreateStruct<{ns}.{structName}>();";
+            s += $"JSValue jsValue = Context.CreateStruct<{ns}.{structName}>();";
 
             foreach (ISymbol property in copyableProperties)
             {
@@ -474,11 +474,11 @@ internal class AdapterGenerator : SourceGenerator
                 if (isNullable)
                 {
                     return $"{fromExpression} == null ? JSValue.Null : " +
-                        $"JSNativeApi.Wrap({fromExpression})";
+                        $"Context.GetOrCreateObjectWrapper({fromExpression})";
                 }
                 else
                 {
-                    return $"JSNativeApi.Wrap({fromExpression})";
+                    return $"Context.GetOrCreateObjectWrapper({fromExpression})";
                 }
             }
             else if (fromType.TypeKind == TypeKind.Struct)

--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -104,6 +104,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                         "Module class must have public visibility.");
                 }
 
+                // TODO: Check for a public constructor that takes a single JSContext argument.
 
                 moduleInitializers.Add(type);
             }
@@ -261,17 +262,18 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         s += $"[GeneratedCode(\"{generatorName}\", \"{generatorVersion}\")]";
         s += $"public static class {ModuleInitializerClassName}";
         s += "{";
+        s += "private static JSContext Context { get; set; } = null!;";
 
         s += $"[UnmanagedCallersOnly(EntryPoint = \"{ModuleRegisterFunctionName}\")]";
         s += $"public static napi_value _{ModuleInitializeMethodName}(napi_env env, napi_value exports)";
-        s += $"{s.Indent}=> Initialize(env, exports);";
-        s += "";
+        s += $"{s.Indent}=> {ModuleInitializeMethodName}(env, exports);";
+        s++;
         s += $"public static napi_value {ModuleInitializeMethodName}(napi_env env, napi_value exports)";
         s += "{";
         s += "try";
         s += "{";
-        s += "JSNativeApi.Interop.Initialize();";
-        s += "";
+        s += "Context = new JSContext();";
+        s++;
         s += "using JSValueScope scope = new(env);";
         s += "JSValue exportsValue = new(scope, exports);";
         s++;
@@ -290,7 +292,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
             string ns = GetNamespace(moduleInitializerMethod);
             string className = moduleInitializerMethod.ContainingType.Name;
             string methodName = moduleInitializerMethod.Name;
-            s += $"return {ns}.{className}.{methodName}((JSObject)exportsValue)";
+            s += $"return {ns}.{className}.{methodName}(Context, (JSObject)exportsValue)";
             s += "\t.GetCheckedHandle();";
         }
         else
@@ -345,7 +347,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         }
         else
         {
-            s += $"exportsValue = new JSModuleBuilder<System.Object>()";
+            s += $"exportsValue = new JSModuleBuilder<JSContext>()";
             s.IncreaseIndent();
         }
 
@@ -362,11 +364,11 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                 string ns = GetNamespace(exportClass);
                 if (exportClass.IsStatic)
                 {
-                    s += $"new JSClassBuilder<object>(\"{exportName}\")";
+                    s += $"new JSClassBuilder<object>(Context, \"{exportName}\")";
                 }
                 else
                 {
-                    s += $"new JSClassBuilder<{ns}.{exportClass.Name}>(\"{exportName}\",";
+                    s += $"new JSClassBuilder<{ns}.{exportClass.Name}>(Context, \"{exportName}\",";
 
                     string? constructorAdapterName =
                         adapterGenerator.GetConstructorAdapterName(exportClass);
@@ -395,7 +397,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                 s.IncreaseIndent();
 
                 string ns = GetNamespace(exportStruct);
-                s += $"new JSStructBuilder<{ns}.{exportStruct.Name}>(\"{exportName}\")";
+                s += $"new JSStructBuilder<{ns}.{exportStruct.Name}>(Context, \"{exportName}\")";
 
                 ExportMembers(ref s, exportStruct, adapterGenerator);
                 s += ".DefineStruct())";
@@ -413,12 +415,21 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
 
         if (moduleType != null)
         {
+            // The module class constructor may optionally take a JSContext parameter. If an
+            // appropriate constructor is not present then the generated code will not compile.
+            IEnumerable<IMethodSymbol> constructors = moduleType.GetMembers()
+                .OfType<IMethodSymbol>().Where((m) => m.MethodKind == MethodKind.Constructor);
+            IMethodSymbol? constructor = constructors.SingleOrDefault((c) =>
+                c.Parameters.Length == 1 && c.Parameters[0].Type.Name == "JSContext") ??
+                constructors.SingleOrDefault((c) => c.Parameters.Length == 0);
+            string contextParameter = constructor?.Parameters.Length == 1 ?
+                "Context" : string.Empty;
             string ns = GetNamespace(moduleType);
-            s += $".ExportModule((JSObject)exportsValue, new {ns}.{moduleType.Name}());";
+            s += $".ExportModule(new {ns}.{moduleType.Name}({contextParameter}), (JSObject)exportsValue);";
         }
         else
         {
-            s += $".ExportModule((JSObject)exportsValue, null);";
+            s += $".ExportModule(Context, (JSObject)exportsValue);";
         }
 
         s.DecreaseIndent();

--- a/Generator/SourceGenerator.cs
+++ b/Generator/SourceGenerator.cs
@@ -32,6 +32,7 @@ public abstract class SourceGenerator
         UnsupportedMethodParameterType,
         UnsupportedMethodReturnType,
         UnsupportedOverloads,
+        ReferenedTypeNotExported,
     }
 
     public GeneratorExecutionContext Context { get; protected set; }

--- a/Generator/SourceGenerator.cs
+++ b/Generator/SourceGenerator.cs
@@ -7,6 +7,9 @@ using Microsoft.CodeAnalysis;
 
 namespace NodeApi.Generator;
 
+// An analyzer bug results in incorrect reports of CA1822 against methods in this class.
+#pragma warning disable CA1822 // Mark members as static
+
 /// <summary>
 /// Base class for source generators for C# APIs exported to JS.
 /// Contains shared definitions and utility methods.
@@ -56,8 +59,6 @@ public abstract class SourceGenerator
         return sb.ToString();
     }
 
-    // An analyzer bug results in incorrect reports of CA1822 against this method. (It can't be static.)
-#pragma warning disable CA1822 // Mark members as static
     public void ReportError(
         DiagnosticId id,
         ISymbol? symbol,

--- a/Generator/TypeDefinitionsGenerator.cs
+++ b/Generator/TypeDefinitionsGenerator.cs
@@ -22,7 +22,8 @@ internal class TypeDefinitionsGenerator : SourceGenerator
 
         foreach (ISymbol exportItem in exportItems)
         {
-            if (exportItem is ITypeSymbol exportType && exportType.TypeKind == TypeKind.Class)
+            if (exportItem is ITypeSymbol exportType &&
+                (exportType.TypeKind == TypeKind.Class || exportType.TypeKind == TypeKind.Struct))
             {
                 GenerateClassTypeDefinitions(ref s, exportType);
             }
@@ -88,7 +89,8 @@ internal class TypeDefinitionsGenerator : SourceGenerator
                 }
                 else
                 {
-                    s += $"{memberName}({parameters}): {returnType};";
+                    s += $"{(member.IsStatic ? "static " : "")}{memberName}({parameters}): " +
+                        $"{returnType};";
                 }
             }
             else if (member is IPropertySymbol exportProperty)
@@ -106,7 +108,8 @@ internal class TypeDefinitionsGenerator : SourceGenerator
                 {
                     string readonlyModifier =
                         exportProperty.SetMethod == null ? "readonly " : "";
-                    s += $"{readonlyModifier}{memberName}: {propertyType};";
+                    s += $"{(member.IsStatic ? "static " : "")}{readonlyModifier}{memberName}: " +
+                        $"{propertyType};";
                 }
             }
         }

--- a/Runtime/JSClassBuilderOfT.cs
+++ b/Runtime/JSClassBuilderOfT.cs
@@ -8,19 +8,23 @@ public class JSClassBuilder<T>
   , IJSObjectUnwrap<T>
   where T : class
 {
+    public JSContext Context { get; }
+
     public string ClassName { get; }
 
     private readonly Func<T>? _constructor;
     private readonly Func<JSCallbackArgs, T>? _constructorWithArgs;
 
-    public JSClassBuilder(string className, Func<T>? constructor = null)
+    public JSClassBuilder(JSContext context, string className, Func<T>? constructor = null)
     {
+        Context = context;
         ClassName = className;
         _constructor = constructor;
     }
 
-    public JSClassBuilder(string className, Func<JSCallbackArgs, T> constructor)
+    public JSClassBuilder(JSContext context, string className, Func<JSCallbackArgs, T> constructor)
     {
+        Context = context;
         ClassName = className;
         _constructorWithArgs = constructor;
     }
@@ -34,7 +38,7 @@ public class JSClassBuilder<T>
     {
         if (_constructor != null)
         {
-            return ObjectMap.RegisterClass<T>(JSNativeApi.DefineClass(
+            return Context.RegisterClass<T>(JSNativeApi.DefineClass(
                 ClassName,
                 (args) =>
                 {
@@ -49,13 +53,13 @@ public class JSClassBuilder<T>
                         instance = _constructor();
                     }
 
-                    return ObjectMap.InitializeObjectWrapper(args.ThisArg, instance);
+                    return Context.InitializeObjectWrapper(args.ThisArg, instance);
                 },
                 Properties.ToArray()));
         }
         else if (_constructorWithArgs != null)
         {
-            return ObjectMap.RegisterClass<T>(JSNativeApi.DefineClass(
+            return Context.RegisterClass<T>(JSNativeApi.DefineClass(
                 ClassName,
                 (args) =>
                 {
@@ -70,7 +74,7 @@ public class JSClassBuilder<T>
                         instance = _constructorWithArgs(args);
                     }
 
-                    return ObjectMap.InitializeObjectWrapper(args.ThisArg, instance);
+                    return Context.InitializeObjectWrapper(args.ThisArg, instance);
                 },
                 Properties.ToArray()));
         }

--- a/Runtime/JSClassBuilderOfT.cs
+++ b/Runtime/JSClassBuilderOfT.cs
@@ -34,17 +34,45 @@ public class JSClassBuilder<T>
     {
         if (_constructor != null)
         {
-            return JSNativeApi.DefineClass(
+            return ObjectMap.RegisterClass<T>(JSNativeApi.DefineClass(
                 ClassName,
-                (args) => args.ThisArg.Wrap(_constructor()),
-                Properties.ToArray());
+                (args) =>
+                {
+                    T instance;
+                    if (args.Length == 1 && args[0].IsExternal())
+                    {
+                        // Constructing a JS instance to wrap a pre-existing C# instance.
+                        instance = (T)args[0].GetValueExternal();
+                    }
+                    else
+                    {
+                        instance = _constructor();
+                    }
+
+                    return ObjectMap.InitializeObjectWrapper(args.ThisArg, instance);
+                },
+                Properties.ToArray()));
         }
         else if (_constructorWithArgs != null)
         {
-            return JSNativeApi.DefineClass(
+            return ObjectMap.RegisterClass<T>(JSNativeApi.DefineClass(
                 ClassName,
-                (args) => args.ThisArg.Wrap(_constructorWithArgs(args)),
-                Properties.ToArray());
+                (args) =>
+                {
+                    T instance;
+                    if (args.Length == 1 && args[0].IsExternal())
+                    {
+                        // Constructing a JS instance to wrap a pre-existing C# instance.
+                        instance = (T)args[0].GetValueExternal();
+                    }
+                    else
+                    {
+                        instance = _constructorWithArgs(args);
+                    }
+
+                    return ObjectMap.InitializeObjectWrapper(args.ThisArg, instance);
+                },
+                Properties.ToArray()));
         }
         else
         {

--- a/Runtime/JSModuleBuilderOfT.cs
+++ b/Runtime/JSModuleBuilderOfT.cs
@@ -1,7 +1,13 @@
+using System;
 using System.Linq;
 
 namespace NodeApi;
 
+/// <summary>
+/// Builds JS module exports.
+/// </summary>
+/// <typeparam name="T">Either <see cref="JSContext" /> or a custom module class that
+/// wraps a <see cref="JSContext"/> instance.</typeparam>
 public class JSModuleBuilder<T>
   : JSPropertyDescriptorList<JSModuleBuilder<T>, T>
   , IJSObjectUnwrap<T>
@@ -12,9 +18,18 @@ public class JSModuleBuilder<T>
         return (T?)JSNativeApi.GetInstanceData();
     }
 
-    public JSValue ExportModule(JSObject exports, T obj)
+    /// <summary>
+    /// Exports the built properties to the module exports object.
+    /// </summary>
+    /// <param name="context">An object that represents the module instance and is
+    /// used as the 'this' argument for any non-static methods on the module. If the object
+    /// implements <see cref="IDisposable"/> then it is also registered for disposal when
+    /// the module is unloaded.</param>
+    /// <param name="exports">Object to be returned from the module initializer.</param>
+    /// <returns>The module exports.</returns>
+    public JSValue ExportModule(T context, JSObject exports)
     {
-        JSNativeApi.SetInstanceData(obj);
+        JSNativeApi.SetInstanceData(context);
         exports.DefineProperties(Properties.ToArray());
         return exports;
     }

--- a/Runtime/JSPropertyDescriptorListOfT.cs
+++ b/Runtime/JSPropertyDescriptorListOfT.cs
@@ -5,13 +5,13 @@ namespace NodeApi;
 
 // TODO: Add interceptors for C# exceptions
 
-public class JSPropertyDescriptorList<TDerived, TObject>
+public abstract class JSPropertyDescriptorList<TDerived, TObject>
   where TDerived : class, IJSObjectUnwrap<TObject>
   where TObject : class
 {
     public IList<JSPropertyDescriptor> Properties { get; } = new List<JSPropertyDescriptor>();
 
-    public JSPropertyDescriptorList() { }
+    protected JSPropertyDescriptorList() { }
 
     public TDerived AddProperty(
       string name,

--- a/Runtime/JSStructBuilderOfT.cs
+++ b/Runtime/JSStructBuilderOfT.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NodeApi;
+
+public class JSStructBuilder<T> where T : struct
+{
+    public IList<JSPropertyDescriptor> Properties { get; } = new List<JSPropertyDescriptor>();
+
+    public string StructName { get; }
+
+    public JSStructBuilder(string structName)
+    {
+        StructName = structName;
+    }
+
+    public JSStructBuilder<T> AddProperty(string name, bool isStatic = false)
+    {
+        Properties.Add(JSPropertyDescriptor.ForValue(
+            name,
+            JSValue.Undefined,
+            JSPropertyAttributes.DefaultProperty | (isStatic ? JSPropertyAttributes.Static : 0)));
+        return this;
+    }
+
+    public JSStructBuilder<T> AddMethod(
+        string name,
+        JSCallback callback,
+        bool isStatic = false)
+    {
+        Properties.Add(JSPropertyDescriptor.Function(
+            name,
+            callback,
+            JSPropertyAttributes.DefaultProperty | (isStatic ? JSPropertyAttributes.Static : 0)));
+        return this;
+    }
+
+    public JSValue DefineStruct()
+    {
+        // TODO: Generate a constructor callback that initializes properties on the JS object
+        // to converted default values? Otherwise they will be initially undefined.
+
+        // Note this does not use Wrap() because structs are passed by value.
+        return ObjectMap.RegisterStruct<T>(JSNativeApi.DefineClass(
+            StructName,
+            (args) => args.ThisArg,
+            Properties.ToArray()));
+    }
+}

--- a/Runtime/JSStructBuilderOfT.cs
+++ b/Runtime/JSStructBuilderOfT.cs
@@ -7,10 +7,13 @@ public class JSStructBuilder<T> where T : struct
 {
     public IList<JSPropertyDescriptor> Properties { get; } = new List<JSPropertyDescriptor>();
 
+    public JSContext Context { get; }
+
     public string StructName { get; }
 
-    public JSStructBuilder(string structName)
+    public JSStructBuilder(JSContext context, string structName)
     {
+        Context = context;
         StructName = structName;
     }
 
@@ -41,7 +44,7 @@ public class JSStructBuilder<T> where T : struct
         // to converted default values? Otherwise they will be initially undefined.
 
         // Note this does not use Wrap() because structs are passed by value.
-        return ObjectMap.RegisterStruct<T>(JSNativeApi.DefineClass(
+        return Context.RegisterStruct<T>(JSNativeApi.DefineClass(
             StructName,
             (args) => args.ThisArg,
             Properties.ToArray()));

--- a/Runtime/JSValue.cs
+++ b/Runtime/JSValue.cs
@@ -249,17 +249,17 @@ public struct JSValue
     public static implicit operator JSValue(ulong value) => CreateNumber(value);
     public static implicit operator JSValue(float value) => CreateNumber(value);
     public static implicit operator JSValue(double value) => CreateNumber(value);
-    public static implicit operator JSValue(bool? value) => value.HasValue ? GetBoolean(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(sbyte? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(byte? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(short? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(ushort? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(int? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(uint? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(long? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(ulong? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(float? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
-    public static implicit operator JSValue(double? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(bool? value) => ValueOrNull(value, value => GetBoolean(value));
+    public static implicit operator JSValue(sbyte? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(byte? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(short? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(ushort? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(int? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(uint? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(long? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(ulong? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(float? value) => ValueOrNull(value, value => CreateNumber(value));
+    public static implicit operator JSValue(double? value) => ValueOrNull(value, value => CreateNumber(value));
     public static implicit operator JSValue(string value) => CreateStringUtf16(value);
     public static implicit operator JSValue(char[] value) => CreateStringUtf16(value);
     public static implicit operator JSValue(Span<char> value) => CreateStringUtf16(value);
@@ -268,11 +268,6 @@ public struct JSValue
     public static implicit operator JSValue(Span<byte> value) => CreateStringUtf8(value);
     public static implicit operator JSValue(ReadOnlySpan<byte> value) => CreateStringUtf8(value);
     public static implicit operator JSValue(JSCallback callback) => CreateFunction("Unknown", callback);
-
-    // The C# compiler doesn't support distinct conversions for nullable reference types.
-    ////public static implicit operator JSValue(string? value) => value is not null ? CreateStringUtf16(value) : JSValue.Null;
-    ////public static implicit operator JSValue(char[]? value) => value is not null ? CreateStringUtf16(value) : JSValue.Null;
-    ////public static implicit operator JSValue(byte[]? value) => value is not null ? CreateStringUtf8(value) : JSValue.Null;
 
     public static explicit operator bool(JSValue value) => value.GetValueBool();
     public static explicit operator sbyte(JSValue value) => (sbyte)value.GetValueInt32();
@@ -288,26 +283,27 @@ public struct JSValue
     public static explicit operator string(JSValue value) => value.GetValueStringUtf16();
     public static explicit operator char[](JSValue value) => value.GetValueStringUtf16AsCharArray();
     public static explicit operator byte[](JSValue value) => value.GetValueStringUtf8();
-    public static explicit operator bool?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueBool();
-    public static explicit operator sbyte?(JSValue value) => value.IsNullOrUndefined() ? null : (sbyte)value.GetValueInt32();
-    public static explicit operator byte?(JSValue value) => value.IsNullOrUndefined() ? null : (byte)value.GetValueUInt32();
-    public static explicit operator short?(JSValue value) => value.IsNullOrUndefined() ? null : (short)value.GetValueInt32();
-    public static explicit operator ushort?(JSValue value) => value.IsNullOrUndefined() ? null : (ushort)value.GetValueUInt32();
-    public static explicit operator int?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueInt32();
-    public static explicit operator uint?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueUInt32();
-    public static explicit operator long?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueInt64();
-    public static explicit operator ulong?(JSValue value) => value.IsNullOrUndefined() ? null : (ulong)value.GetValueInt64();
-    public static explicit operator float?(JSValue value) => value.IsNullOrUndefined() ? null : (float)value.GetValueDouble();
-    public static explicit operator double?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueDouble();
-
-    // The C# compiler doesn't support distinct conversions for nullable reference types.
-    ////public static explicit operator string?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueStringUtf16();
-    ////public static explicit operator char[]?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueStringUtf16AsCharArray();
-    ////public static explicit operator byte[]?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueStringUtf8();
+    public static explicit operator bool?(JSValue value) => ValueOrNull(value, value => value.GetValueBool());
+    public static explicit operator sbyte?(JSValue value) => ValueOrNull(value, value => (sbyte)value.GetValueInt32());
+    public static explicit operator byte?(JSValue value) => ValueOrNull(value, value => (byte)value.GetValueUInt32());
+    public static explicit operator short?(JSValue value) => ValueOrNull(value, value => (short)value.GetValueInt32());
+    public static explicit operator ushort?(JSValue value) => ValueOrNull(value, value => (ushort)value.GetValueUInt32());
+    public static explicit operator int?(JSValue value) => ValueOrNull(value, value => value.GetValueInt32());
+    public static explicit operator uint?(JSValue value) => ValueOrNull(value, value => value.GetValueUInt32());
+    public static explicit operator long?(JSValue value) => ValueOrNull(value, value => value.GetValueInt64());
+    public static explicit operator ulong?(JSValue value) => ValueOrNull(value, value => (ulong)value.GetValueInt64());
+    public static explicit operator float?(JSValue value) => ValueOrNull(value, value => (float)value.GetValueDouble());
+    public static explicit operator double?(JSValue value) => ValueOrNull(value, value => value.GetValueDouble());
 
     public static explicit operator napi_value(JSValue value) => value.GetCheckedHandle();
     public static implicit operator JSValue(napi_value handle) => new(handle);
 
     public static explicit operator napi_value(JSValue? value) => value?.Handle ?? new napi_value(nint.Zero);
     public static implicit operator JSValue?(napi_value handle) => handle.Handle != nint.Zero ? new JSValue?(new JSValue(handle)) : null;
+
+    private static JSValue ValueOrNull<T>(T? value, Func<T, JSValue> convert) where T : struct
+        => value.HasValue ? convert(value.Value) : JSValue.Null;
+
+    private static T? ValueOrNull<T>(JSValue value, Func<JSValue, T> convert) where T : struct
+        => value.IsNullOrUndefined() ? null : convert(value);
 }

--- a/Runtime/JSValue.cs
+++ b/Runtime/JSValue.cs
@@ -249,6 +249,17 @@ public struct JSValue
     public static implicit operator JSValue(ulong value) => CreateNumber(value);
     public static implicit operator JSValue(float value) => CreateNumber(value);
     public static implicit operator JSValue(double value) => CreateNumber(value);
+    public static implicit operator JSValue(bool? value) => value.HasValue ? GetBoolean(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(sbyte? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(byte? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(short? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(ushort? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(int? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(uint? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(long? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(ulong? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(float? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
+    public static implicit operator JSValue(double? value) => value.HasValue ? CreateNumber(value.Value) : JSValue.Null;
     public static implicit operator JSValue(string value) => CreateStringUtf16(value);
     public static implicit operator JSValue(char[] value) => CreateStringUtf16(value);
     public static implicit operator JSValue(Span<char> value) => CreateStringUtf16(value);
@@ -257,6 +268,11 @@ public struct JSValue
     public static implicit operator JSValue(Span<byte> value) => CreateStringUtf8(value);
     public static implicit operator JSValue(ReadOnlySpan<byte> value) => CreateStringUtf8(value);
     public static implicit operator JSValue(JSCallback callback) => CreateFunction("Unknown", callback);
+
+    // The C# compiler doesn't support distinct conversions for nullable reference types.
+    ////public static implicit operator JSValue(string? value) => value is not null ? CreateStringUtf16(value) : JSValue.Null;
+    ////public static implicit operator JSValue(char[]? value) => value is not null ? CreateStringUtf16(value) : JSValue.Null;
+    ////public static implicit operator JSValue(byte[]? value) => value is not null ? CreateStringUtf8(value) : JSValue.Null;
 
     public static explicit operator bool(JSValue value) => value.GetValueBool();
     public static explicit operator sbyte(JSValue value) => (sbyte)value.GetValueInt32();
@@ -272,6 +288,22 @@ public struct JSValue
     public static explicit operator string(JSValue value) => value.GetValueStringUtf16();
     public static explicit operator char[](JSValue value) => value.GetValueStringUtf16AsCharArray();
     public static explicit operator byte[](JSValue value) => value.GetValueStringUtf8();
+    public static explicit operator bool?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueBool();
+    public static explicit operator sbyte?(JSValue value) => value.IsNullOrUndefined() ? null : (sbyte)value.GetValueInt32();
+    public static explicit operator byte?(JSValue value) => value.IsNullOrUndefined() ? null : (byte)value.GetValueUInt32();
+    public static explicit operator short?(JSValue value) => value.IsNullOrUndefined() ? null : (short)value.GetValueInt32();
+    public static explicit operator ushort?(JSValue value) => value.IsNullOrUndefined() ? null : (ushort)value.GetValueUInt32();
+    public static explicit operator int?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueInt32();
+    public static explicit operator uint?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueUInt32();
+    public static explicit operator long?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueInt64();
+    public static explicit operator ulong?(JSValue value) => value.IsNullOrUndefined() ? null : (ulong)value.GetValueInt64();
+    public static explicit operator float?(JSValue value) => value.IsNullOrUndefined() ? null : (float)value.GetValueDouble();
+    public static explicit operator double?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueDouble();
+
+    // The C# compiler doesn't support distinct conversions for nullable reference types.
+    ////public static explicit operator string?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueStringUtf16();
+    ////public static explicit operator char[]?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueStringUtf16AsCharArray();
+    ////public static explicit operator byte[]?(JSValue value) => value.IsNullOrUndefined() ? null : value.GetValueStringUtf8();
 
     public static explicit operator napi_value(JSValue value) => value.GetCheckedHandle();
     public static implicit operator JSValue(napi_value handle) => new(handle);

--- a/Runtime/ObjectMap.cs
+++ b/Runtime/ObjectMap.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using static NodeApi.JSNativeApi;
+using static NodeApi.JSNativeApi.Interop;
+
+namespace NodeApi;
+
+/// <summary>
+/// Tracks JS constructors and instance JS wrappers for exported classes, enabling
+/// .NET objects to be automatically wrapped when returned to JS, and re-wrapped as needed
+/// if the (weakly-referenced) JS wrapper has been released.
+/// </summary>
+internal static class ObjectMap
+{
+    // TODO: Consider an optimization that avoids dictionary lookups:
+    // If an exported class is declared as partial, then the generator can add a
+    // static `JSConstructor` property and an instance `JSWrapper` property to the class.
+    // (The dictionary mappings could still be used to export external/non-partial classes.)
+
+    private static ConcurrentDictionary<Type, JSReference> s_classMap = new();
+    private static ConcurrentDictionary<object, JSReference> s_objectMap = new();
+    private static ConcurrentDictionary<Type, JSReference> s_structMap = new();
+
+    /// <summary>
+    /// Registers a class JS constructor, enabling automatic JS wrapping of instances of the class.
+    /// </summary>
+    /// <param name="constructorFunction">JS class constructor function returned from
+    /// <see cref="JSNativeApi.DefineClass"/></param>
+    /// <returns>The JS constructor.</returns>
+    internal static JSValue RegisterClass<T>(JSValue constructorFunction) where T : class
+    {
+        s_classMap.AddOrUpdate(
+            typeof(T),
+            (_) => new JSReference(constructorFunction, isWeak: false),
+            (_, _) => throw new InvalidOperationException(
+                "Class already registered for JS export: " + typeof(T)));
+        return constructorFunction;
+    }
+
+    /// <summary>
+    /// Gets a class JS constructor that was previously registered.
+    /// </summary>
+    private static JSValue GetClassConstructor<T>() where T : class
+    {
+        if (!s_classMap.TryGetValue(typeof(T), out JSReference? constructorReference))
+        {
+            throw new InvalidOperationException(
+                "Class not registered for JS export: " + typeof(T));
+        }
+
+        JSValue? constructorFunction = constructorReference!.GetValue();
+        if (!constructorFunction.HasValue)
+        {
+            // This should never happen because the reference is "strong".
+            throw new InvalidOperationException("Failed to resolve class constructor reference.");
+        }
+
+        return constructorFunction.Value;
+    }
+
+    /// <summary>
+    /// Attaches an object to a JS wrapper, and saves a weak reference to the wrapper.
+    /// </summary>
+    /// <param name="wrapper">JS object passed as the 'this' argument to the constructor callback
+    /// for <see cref="JSNativeApi.DefineClass"/>.</param>
+    /// <param name="obj">New or existing instance of the class to be wrapped.</param>
+    /// <returns>The JS wrapper.</returns>
+    internal static unsafe JSValue InitializeObjectWrapper<T>(JSValue wrapper, T obj) where T : class
+    {
+        GCHandle valueHandle = GCHandle.Alloc(obj);
+        napi_ref result;
+        napi_wrap(
+            (napi_env)JSValueScope.Current,
+            (napi_value)wrapper,
+            (nint)valueHandle,
+            new napi_finalize(&FinalizeGCHandle),
+            nint.Zero,
+            &result).ThrowIfFailed();
+
+        // The reference returned by napi_wrap() is weak (refcount=0), which is good:
+        // if the JS object is released then the reference will fail to resolve, and
+        // GetOrCreateObjectWrapper() will create a new JS wrapper if requested.
+        JSReference wrapperReference = new(result, isWeak: true);
+
+        s_objectMap.AddOrUpdate(
+            obj,
+            (_) => wrapperReference,
+            (_, oldReference) =>
+            {
+                oldReference.Dispose();
+                return wrapperReference;
+            });
+
+        return wrapper;
+    }
+
+    /// <summary>
+    /// Gets or creates a JS wrapper for an instance of a class.
+    /// </summary>
+    /// <returns>The JS wrapper.</returns>
+    /// <remarks>
+    /// If the class was constructed via JS, then the wrapper created at that time will be
+    /// found in the map and returned, if the weak reference to it is still valid. Otherwise
+    /// a new JS object is constructed to wrap the existing instance, and a weak reference to
+    /// the new wrapper is saved in the map.
+    /// </remarks>
+    internal static JSValue GetOrCreateObjectWrapper<T>(T obj) where T : class
+    {
+        JSValue? wrapper = null;
+        JSReference CreateWrapper(T obj)
+        {
+            // Pass the existing instance as an external value to the JS constructor.
+            // The constructor callback will then use that instead of creating a new
+            // instance of the class.
+            JSValue externalValue = JSValue.CreateExternal(obj);
+            JSValue constructorFunction = GetClassConstructor<T>();
+            wrapper = constructorFunction.CallAsConstructor(externalValue);
+            return new(wrapper.Value, isWeak: true);
+        }
+
+        s_objectMap.AddOrUpdate(
+            obj,
+            (_) =>
+            {
+                // No wrapper was found in the map for the object. Create a new one.
+                return CreateWrapper(obj);
+            },
+            (_, wrapperReference) =>
+            {
+                wrapper = wrapperReference.GetValue();
+                if (wrapper.HasValue)
+                {
+                    // A valid reference was found in the map. Return it to keep the same mapping.
+                    return wrapperReference;
+                }
+
+                // A reference was found in the map, but the JS object was released.
+                // Create a new wrapper JS object and update the reference in the map.l
+                wrapperReference.Dispose();
+                return CreateWrapper(obj);
+            });
+
+        return wrapper!.Value;
+    }
+
+    /// <summary>
+    /// Registers a struct JS constructor, enabling instantiation of JS wrappers for the struct.
+    /// </summary>
+    /// <param name="constructorFunction">JS struct constructor function returned from
+    /// <see cref="JSNativeApi.DefineClass"/></param>
+    /// <returns>The JS constructor.</returns>
+    internal static JSValue RegisterStruct<T>(JSValue constructorFunction) where T : struct
+    {
+        s_structMap.AddOrUpdate(
+            typeof(T),
+            (_) => new JSReference(constructorFunction, isWeak: false),
+            (_, _) => throw new InvalidOperationException(
+                "Struct already registered for JS export: " + typeof(T)));
+        return constructorFunction;
+    }
+
+    /// <summary>
+    /// Creates a new (empty) JS wrapper instance for a struct.
+    /// </summary>
+    /// <returns>The JS wrapper.</returns>
+    internal static JSValue CreateStructWrapper<T>() where T : struct
+    {
+        if (!s_structMap.TryGetValue(typeof(T), out JSReference? constructorReference))
+        {
+            throw new InvalidOperationException(
+                "Struct not registered for JS export: " + typeof(T));
+        }
+
+        JSValue? constructorFunction = constructorReference!.GetValue();
+        if (!constructorFunction.HasValue)
+        {
+            // This should never happen because the reference is "strong".
+            throw new InvalidOperationException("Failed to resolve struct constructor reference.");
+        }
+
+        return JSNativeApi.CallAsConstructor(constructorFunction.Value);
+    }
+}

--- a/Runtime/ObjectMap.cs
+++ b/Runtime/ObjectMap.cs
@@ -18,9 +18,9 @@ internal static class ObjectMap
     // static `JSConstructor` property and an instance `JSWrapper` property to the class.
     // (The dictionary mappings could still be used to export external/non-partial classes.)
 
-    private static ConcurrentDictionary<Type, JSReference> s_classMap = new();
-    private static ConcurrentDictionary<object, JSReference> s_objectMap = new();
-    private static ConcurrentDictionary<Type, JSReference> s_structMap = new();
+    private static readonly ConcurrentDictionary<Type, JSReference> s_classMap = new();
+    private static readonly ConcurrentDictionary<object, JSReference> s_objectMap = new();
+    private static readonly ConcurrentDictionary<Type, JSReference> s_structMap = new();
 
     /// <summary>
     /// Registers a class JS constructor, enabling automatic JS wrapping of instances of the class.

--- a/Test/TestCases/napi-dotnet-init/ModuleInitializer.cs
+++ b/Test/TestCases/napi-dotnet-init/ModuleInitializer.cs
@@ -5,7 +5,7 @@ namespace NodeApi.TestCases;
 public class ModuleInitializer
 {
     [JSModule]
-    public static JSValue Initialize(JSObject exports)
+    public static JSValue Initialize(JSContext context, JSObject exports)
     {
         Console.WriteLine("Module.Initialize()");
 
@@ -17,8 +17,8 @@ public class ModuleInitializer
         }
 
         // Export a module with a JS property that doesn't map to any C# property.
-        JSModuleBuilder<ModuleInitializer> moduleBuilder = new();
+        JSModuleBuilder<JSContext> moduleBuilder = new();
         moduleBuilder.AddProperty("test", JSValue.GetBoolean(true));
-        return moduleBuilder.ExportModule(exports, new ModuleInitializer());
+        return moduleBuilder.ExportModule(context, exports);
     }
 }

--- a/Test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/Test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace NodeApi.TestCases;
+
+/// <summary>
+/// Tests marshalling of various non-primitive types.
+/// </summary>
+[JSExport]
+public static class ComplexTypes
+{
+    public static int? NullableInt { get; set; }
+
+    public static string? NullableString { get; set; }
+
+    public static StructObject StructObject { get; set; } = new() { Value = "test" };
+
+    public static StructObject? NullableStructObject { get; set; }
+
+    public static ClassObject ClassObject { get; set; } = new() { Value = "test" };
+
+    public static ClassObject? NullableClassObject { get; set; }
+
+    public static int[] Array { get; set; } = System.Array.Empty<int>();
+
+    public static int[]? NullableArray { get; set; }
+
+    public static IList<int> List { get; set; } = new List<int>();
+
+    public static IReadOnlyList<int> ReadOnlyList { get; set; } = new List<int>().AsReadOnly();
+
+    public static IDictionary<int, string> Dictionary { get; set; } = new Dictionary<int, string>();
+
+    public static IReadOnlyDictionary<int, string> ReadOnlyDictionary { get; set; }
+        = new Dictionary<int, string>().AsReadOnly();
+}
+
+/// <summary>
+/// Tests marshalling struct objects (passed by value).
+/// </summary>
+[JSExport]
+public struct StructObject
+{
+    public string? Value { get; set; }
+
+    public static string? StaticValue { get; set; }
+
+    public StructObject ThisObject() => this;
+}
+
+/// <summary>
+/// Tests marshalling class objects (passed by reference).
+/// </summary>
+[JSExport]
+public class ClassObject
+{
+    public string? Value { get; set; }
+
+    public static string? StaticValue { get; set; }
+
+    public ClassObject ThisObject() => this;
+}

--- a/Test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/Test/TestCases/napi-dotnet/ModuleClass.cs
@@ -13,7 +13,8 @@ namespace NodeApi.TestCases;
 public class ModuleClass : IDisposable
 {
     /// <summary>
-    /// The module class must have a public constructor that takes no parameters.
+    /// The module class must have a public constructor that takes either no parameters
+    /// or a single JSContext parameter.
     /// </summary>
     public ModuleClass()
     {

--- a/Test/TestCases/napi-dotnet/complex_types.js
+++ b/Test/TestCases/napi-dotnet/complex_types.js
@@ -1,0 +1,59 @@
+const assert = require('assert');
+
+// Load the addon module, using either hosted or native AOT mode.
+const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
+const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
+
+/** @type {import('./napi-dotnet')} */
+const binding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
+
+const ComplexTypes = binding.ComplexTypes;
+assert.strictEqual(typeof ComplexTypes, 'object');
+
+assert.strictEqual(ComplexTypes.nullableInt, null);
+ComplexTypes.nullableInt = 1;
+assert.strictEqual(ComplexTypes.nullableInt, 1);
+ComplexTypes.nullableInt = null;
+assert.strictEqual(ComplexTypes.nullableInt, null);
+
+assert.strictEqual(ComplexTypes.nullableString, null);
+ComplexTypes.nullableString = 'test';
+assert.strictEqual(ComplexTypes.nullableString, 'test');
+ComplexTypes.nullableString = null;
+assert.strictEqual(ComplexTypes.nullableString, null);
+
+// Test an exported class.
+const ClassObject = binding.ClassObject;
+assert.strictEqual(typeof ClassObject, 'function');
+const classInstance = new ClassObject();
+assert.strictEqual(classInstance.value, null);
+classInstance.value = 'test';
+assert.strictEqual(classInstance.value, 'test');
+
+// Class instances are passed by reference, so a property change on
+// one reference should be reflected on the other.
+const classInstance2 = classInstance.thisObject();
+assert.strictEqual(classInstance2, classInstance);
+classInstance2.value = 'test2';
+assert.strictEqual(classInstance2.value, classInstance.value);
+assert.strictEqual(classInstance.value, 'test2');
+
+// Test an exported struct.
+const StructObject = binding.StructObject;
+assert.strictEqual(typeof StructObject, 'function');
+
+// Constructing the object in JS does NOT immediately construct a C# instance.
+const structInstance = new StructObject();
+
+// This should be null, after struct initialize callback code is generated.
+assert.strictEqual(structInstance.value, undefined);
+structInstance.value = 'test';
+assert.strictEqual(structInstance.value, 'test');
+
+// Struct instances are passed by value, so a property change on
+// one reference should NOT be reflected on the other.
+const structInstance2 = structInstance.thisObject();
+assert.notStrictEqual(structInstance2, structInstance);
+structInstance2.value = 'test2';
+assert.strictEqual(structInstance2.value, 'test2');
+assert.strictEqual(structInstance.value, 'test');


### PR DESCRIPTION
With these changes it is now possible to export methods with `class` and `struct` parameter types and return types, and have those values automatically marshalled from/to `JSValue`. Class instances are wrapped and marshalled by reference, as you'd expect.

C# `struct` types may now be tagged with `[JSExport]`, and struct instances are marshalled by value in attempt to preserve the C# value-type semantics. That means:
  - Structs do not use `napi_wrap`; when passing an instance across the C#-JS boundary the object properties are (shallowly) copied.
  - There is no link or lifetime relationship between a `struct` instance in C# and a corresponding object in JS.
  - When you construct an exported `struct` object in JS, a C# instance is _not_ immediately created.
  - When you construct an exported `struct` instance in C#, a JS instance is _not_ immediately created.
  - When you invoke an instance method on a `struct` object from JS, the JS object is copied into a newly-instantiated C# `struct` instance before the method is invoked.
      - This can be inefficient, so heavy use of `struct` methods from JS is not recommended. Instead, exported structs should generally be used as a convenient way to pass in/out a temporary bundle of related properties.

Overview of changes:
 - Add `JSStructBuilder<T>`, a parallel to `JSClassBuilder<T>` that supports the marshal-by-value semantics of structs.
 - Add a `JSContext` class that keeps track of constructor functions and class instance wrappers to facilitate the automatic marshalling.
 - Implement module lifetime semantics so that the module class and `JSContext` are disposed when the module is unloaded.
 - Update generated conversion code for parameters and return values to handle classes, structs, and nullables. 
 - Generate code to convert from/to `JSValue` to/from each exported `struct` type by copying/converting all properties.
 - Add direct JSValue conversion operators for nullable primitive types.
 - Update type definitions generator to include exported structs.
 - Add tests for above. (There's some test code for collections, but collections are not implemented yet in the generator.)
