### PR TITLE
Generate adapter code for arrays and typed arrays

### DIFF
--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -57,8 +57,8 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
             // No type definitions are generated when using a custom init function.
             if (moduleInitializer is not IMethodSymbol)
             {
-                SourceText typeDefinitions = TypeDefinitionsGenerator.GenerateTypeDefinitions(
-                    exportItems);
+                TypeDefinitionsGenerator tsGenerator = new(exportItems);
+                SourceText typeDefinitions = tsGenerator.GenerateTypeDefinitions();
                 if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue(
                     "build_property.TargetPath", out string? targetPath))
                 {

--- a/Generator/TypeDefinitionsGenerator.cs
+++ b/Generator/TypeDefinitionsGenerator.cs
@@ -14,13 +14,20 @@ internal class TypeDefinitionsGenerator : SourceGenerator
     private static readonly Regex s_summaryRegex = new("<summary>(.*)</summary>");
     private static readonly Regex s_remarksRegex = new("<remarks>(.*)</remarks>");
 
-    internal static SourceText GenerateTypeDefinitions(IEnumerable<ISymbol> exportItems)
+    private readonly IEnumerable<ISymbol> exportItems;
+
+    public TypeDefinitionsGenerator(IEnumerable<ISymbol> exportItems)
+    {
+        this.exportItems = exportItems;
+    }
+
+    internal SourceText GenerateTypeDefinitions()
     {
         var s = new SourceBuilder();
 
         s += "// Generated type definitions for .NET module";
 
-        foreach (ISymbol exportItem in exportItems)
+        foreach (ISymbol exportItem in this.exportItems)
         {
             if (exportItem is ITypeSymbol exportType &&
                 (exportType.TypeKind == TypeKind.Class || exportType.TypeKind == TypeKind.Struct))
@@ -50,7 +57,7 @@ internal class TypeDefinitionsGenerator : SourceGenerator
         return s;
     }
 
-    private static void GenerateClassTypeDefinitions(ref SourceBuilder s, ITypeSymbol exportClass)
+    private void GenerateClassTypeDefinitions(ref SourceBuilder s, ITypeSymbol exportClass)
     {
         s++;
         GenerateDocComments(ref s, exportClass);
@@ -117,8 +124,10 @@ internal class TypeDefinitionsGenerator : SourceGenerator
         s += "}";
     }
 
-    private static string GetTSType(ITypeSymbol type)
+    private string GetTSType(ITypeSymbol type)
     {
+        string tsType = "unknown";
+
         string? specialType = type.SpecialType switch
         {
             SpecialType.System_Void => "void",
@@ -137,25 +146,93 @@ internal class TypeDefinitionsGenerator : SourceGenerator
             ////SpecialType.System_DateTime => "Date",
             _ => null,
         };
+
         if (specialType != null)
         {
-            return specialType;
-        }
-
-        if (type.TypeKind == TypeKind.Class)
-        {
-            // TODO: Check if class is exported.
+            tsType = specialType;
         }
         else if (type.TypeKind == TypeKind.Array)
         {
-            // TODO: Get element type.
-            return "any[]";
+            ITypeSymbol elementType = ((IArrayTypeSymbol)type).ElementType;
+            tsType = GetTSType(elementType) + "[]";
+        }
+        else if (type is INamedTypeSymbol namedType && namedType.TypeParameters.Length > 0)
+        {
+            if (namedType.OriginalDefinition.Name == "Nullable")
+            {
+                tsType = GetTSType(namedType.TypeArguments[0]) + " | null";
+            }
+            else if (namedType.OriginalDefinition.Name == "Memory")
+            {
+                ITypeSymbol elementType = namedType.TypeArguments[0];
+                tsType = elementType.SpecialType switch
+                {
+                    SpecialType.System_SByte => "Int8Array",
+                    SpecialType.System_Int16 => "Int16Array",
+                    SpecialType.System_Int32 => "Int32Array",
+                    SpecialType.System_Int64 => "BigInt64Array",
+                    SpecialType.System_Byte => "Uint8Array",
+                    SpecialType.System_UInt16 => "Uint16Array",
+                    SpecialType.System_UInt32 => "Uint32Array",
+                    SpecialType.System_UInt64 => "BigUint64Array",
+                    SpecialType.System_Single => "Float32Array",
+                    SpecialType.System_Double => "Float64Array",
+                    _ => "unknown",
+                };
+            }
+            else if (namedType.OriginalDefinition.Name == "IList")
+            {
+                tsType = GetTSType(namedType.TypeArguments[0]) + "[]";
+            }
+            else if (namedType.OriginalDefinition.Name == "IReadOnlyList")
+            {
+                tsType = "readonly " + GetTSType(namedType.TypeArguments[0]) + "[]";
+            }
+            else if (namedType.OriginalDefinition.Name == "ICollection" ||
+                namedType.OriginalDefinition.Name == "ISet")
+            {
+                string elementTsType = GetTSType(namedType.TypeArguments[0]);
+                return $"Set<{elementTsType}>";
+            }
+            else if (namedType.OriginalDefinition.Name == "IReadOnlyCollection" ||
+                namedType.OriginalDefinition.Name == "IReadOnlySet")
+            {
+                string elementTsType = GetTSType(namedType.TypeArguments[0]);
+                return $"ReadonlySet<{elementTsType}>";
+            }
+            else if (namedType.OriginalDefinition.Name == "IEnumerable")
+            {
+                string elementTsType = GetTSType(namedType.TypeArguments[0]);
+                return $"Iterable<{elementTsType}>";
+            }
+            else if (namedType.OriginalDefinition.Name == "IDictionary")
+            {
+                string keyTSType = GetTSType(namedType.TypeArguments[0]);
+                string valueTSType = GetTSType(namedType.TypeArguments[1]);
+                tsType = $"Map<{keyTSType}, {valueTSType}>";
+            }
+            else if (namedType.OriginalDefinition.Name == "IReadOnlyDictionary")
+            {
+                string keyTSType = GetTSType(namedType.TypeArguments[0]);
+                string valueTSType = GetTSType(namedType.TypeArguments[1]);
+                tsType = $"ReadonlyMap<{keyTSType}, {valueTSType}>";
+            }
+        }
+        else if (this.exportItems.Contains(type, SymbolEqualityComparer.Default))
+        {
+            tsType = type.Name;
         }
 
-        return "any";
+        if (type.NullableAnnotation == NullableAnnotation.Annotated &&
+            tsType != "any" && !tsType.EndsWith(" | null"))
+        {
+            tsType += " | null";
+        }
+
+        return tsType;
     }
 
-    private static string GetTSParameters(IMethodSymbol method, string indent)
+    private string GetTSParameters(IMethodSymbol method, string indent)
     {
         if (method.Parameters.Length == 0)
         {
@@ -180,7 +257,7 @@ internal class TypeDefinitionsGenerator : SourceGenerator
         return s.ToString();
     }
 
-    private static void GenerateDocComments(ref SourceBuilder s, ISymbol symbol)
+    private void GenerateDocComments(ref SourceBuilder s, ISymbol symbol)
     {
         string? comment = symbol.GetDocumentationCommentXml();
         if (string.IsNullOrEmpty(comment))

--- a/Generator/TypeDefinitionsGenerator.cs
+++ b/Generator/TypeDefinitionsGenerator.cs
@@ -8,6 +8,9 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace NodeApi.Generator;
 
+// An analyzer bug results in incorrect reports of CA1822 against methods in this class.
+#pragma warning disable CA1822 // Mark members as static
+
 internal class TypeDefinitionsGenerator : SourceGenerator
 {
     private static readonly Regex s_newlineRegex = new("\n *");

--- a/Generator/TypeDefinitionsGenerator.cs
+++ b/Generator/TypeDefinitionsGenerator.cs
@@ -14,11 +14,11 @@ internal class TypeDefinitionsGenerator : SourceGenerator
     private static readonly Regex s_summaryRegex = new("<summary>(.*)</summary>");
     private static readonly Regex s_remarksRegex = new("<remarks>(.*)</remarks>");
 
-    private readonly IEnumerable<ISymbol> exportItems;
+    private readonly IEnumerable<ISymbol> _exportItems;
 
     public TypeDefinitionsGenerator(IEnumerable<ISymbol> exportItems)
     {
-        this.exportItems = exportItems;
+        _exportItems = exportItems;
     }
 
     internal SourceText GenerateTypeDefinitions()
@@ -27,7 +27,7 @@ internal class TypeDefinitionsGenerator : SourceGenerator
 
         s += "// Generated type definitions for .NET module";
 
-        foreach (ISymbol exportItem in this.exportItems)
+        foreach (ISymbol exportItem in _exportItems)
         {
             if (exportItem is ITypeSymbol exportType &&
                 (exportType.TypeKind == TypeKind.Class || exportType.TypeKind == TypeKind.Struct))
@@ -218,7 +218,7 @@ internal class TypeDefinitionsGenerator : SourceGenerator
                 tsType = $"ReadonlyMap<{keyTSType}, {valueTSType}>";
             }
         }
-        else if (this.exportItems.Contains(type, SymbolEqualityComparer.Default))
+        else if (_exportItems.Contains(type, SymbolEqualityComparer.Default))
         {
             tsType = type.Name;
         }
@@ -257,7 +257,7 @@ internal class TypeDefinitionsGenerator : SourceGenerator
         return s.ToString();
     }
 
-    private void GenerateDocComments(ref SourceBuilder s, ISymbol symbol)
+    private static void GenerateDocComments(ref SourceBuilder s, ISymbol symbol)
     {
         string? comment = symbol.GetDocumentationCommentXml();
         if (string.IsNullOrEmpty(comment))

--- a/Runtime/JSArray.cs
+++ b/Runtime/JSArray.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 namespace NodeApi;
 
-public partial struct JSArray : IList<JSValue>
+public readonly partial struct JSArray : IList<JSValue>
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSArray(JSValue value) => new JSArray(value);
+    public static explicit operator JSArray(JSValue value) => new(value);
     public static implicit operator JSValue(JSArray arr) => arr._value;
 
     public static explicit operator JSArray(JSObject obj) => (JSArray)(JSValue)obj;

--- a/Runtime/JSArray.cs
+++ b/Runtime/JSArray.cs
@@ -5,29 +5,32 @@ namespace NodeApi;
 
 public partial struct JSArray : IList<JSValue>
 {
-    private JSValue _value;
+    private readonly JSValue _value;
 
-    public static explicit operator JSArray(JSValue value) => new() { _value = value };
+    public static explicit operator JSArray(JSValue value) => new JSArray(value);
     public static implicit operator JSValue(JSArray arr) => arr._value;
 
     public static explicit operator JSArray(JSObject obj) => (JSArray)(JSValue)obj;
     public static implicit operator JSObject(JSArray arr) => (JSObject)arr._value;
 
-    public JSArray()
+    private JSArray(JSValue value)
     {
-        _value = JSValue.CreateArray();
+        _value = value;
     }
 
-    public JSArray(int length)
+    public JSArray() : this(JSValue.CreateArray())
     {
-        _value = JSValue.CreateArray(length);
+    }
+
+    public JSArray(int length) : this(JSValue.CreateArray(length))
+    {
     }
 
     public int Length => _value.GetArrayLength();
 
-    public int Count => _value.GetArrayLength();
+    int ICollection<JSValue>.Count => _value.GetArrayLength();
 
-    public bool IsReadOnly => false;
+    bool ICollection<JSValue>.IsReadOnly => false;
 
     public JSValue this[int index]
     {

--- a/Runtime/JSObject.cs
+++ b/Runtime/JSObject.cs
@@ -4,20 +4,24 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace NodeApi;
 
-public partial struct JSObject : IDictionary<JSValue, JSValue>
+public readonly partial struct JSObject : IDictionary<JSValue, JSValue>
 {
-    private JSValue _value;
+    private readonly JSValue _value;
 
     public int Count => throw new System.NotImplementedException();
 
     public bool IsReadOnly => throw new System.NotImplementedException();
 
-    public static explicit operator JSObject(JSValue value) => new() { _value = value };
+    public static explicit operator JSObject(JSValue value) => new(value);
     public static implicit operator JSValue(JSObject obj) => obj._value;
 
-    public JSObject()
+    private JSObject(JSValue value)
     {
-        _value = JSValue.CreateObject();
+        _value = value;
+    }
+
+    public JSObject() : this(JSValue.CreateObject())
+    {
     }
 
     public void DefineProperties(params JSPropertyDescriptor[] descriptors)

--- a/Runtime/JSReference.cs
+++ b/Runtime/JSReference.cs
@@ -5,8 +5,8 @@ namespace NodeApi;
 
 public class JSReference : IDisposable
 {
-    private napi_env _env;
-    private napi_ref _handle;
+    private readonly napi_env _env;
+    private readonly napi_ref _handle;
 
     public bool IsWeak { get; private set; }
 

--- a/Runtime/JSTypedArray.cs
+++ b/Runtime/JSTypedArray.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace NodeApi;
+
+public struct JSTypedArray<T> where T : struct
+{
+    private readonly JSValue _value;
+
+    public static explicit operator JSTypedArray<T>(JSValue value) => new JSTypedArray<T>(value);
+    public static implicit operator JSValue(JSTypedArray<T> arr) => arr._value;
+
+    private static int ElementSize { get; } = default(T) switch
+    {
+        sbyte => sizeof(sbyte),
+        byte => sizeof(byte),
+        short => sizeof(short),
+        ushort => sizeof(ushort),
+        int => sizeof(int),
+        uint => sizeof(uint),
+        long => sizeof(long),
+        ulong => sizeof(ulong),
+        float => sizeof(float),
+        double => sizeof(double),
+        _ => throw new InvalidCastException("Invalid typed-array type: " + typeof(T)),
+    };
+
+    private static JSTypedArrayType ArrayType { get; } = default(T) switch
+    {
+        sbyte => JSTypedArrayType.Int8,
+        byte => JSTypedArrayType.UInt8,
+        short => JSTypedArrayType.Int16,
+        ushort => JSTypedArrayType.UInt16,
+        int => JSTypedArrayType.Int32,
+        uint => JSTypedArrayType.UInt32,
+        long => JSTypedArrayType.BigInt64,
+        ulong => JSTypedArrayType.BigUInt64,
+        float => JSTypedArrayType.Float32,
+        double => JSTypedArrayType.Float64,
+        _ => throw new InvalidCastException("Invalid typed-array type: " + typeof(T)),
+    };
+
+    private JSTypedArray(JSValue value)
+    {
+        _value = value;
+    }
+
+    /// <summary>
+    /// Creates a new typed array of specified length, with newly allocated memroy.
+    /// </summary>
+    public JSTypedArray(int length)
+    {
+        JSValue arrayBuffer = JSValue.CreateArrayBuffer(length * ElementSize);
+        _value = JSValue.CreateTypedArray(ArrayType, length, arrayBuffer, 0);
+    }
+
+    /// <summary>
+    /// Creates a typed-array over memory, without copying.
+    /// </summary>
+    public JSTypedArray(Memory<T> data)
+    {
+        JSValue arrayBuffer = JSValue.CreateExternalArrayBuffer(data);
+        _value = JSValue.CreateTypedArray(ArrayType, data.Length, arrayBuffer, 0);
+    }
+
+    /// <summary>
+    /// Creates a typed-array over an array, without copying.
+    /// </summary>
+    public JSTypedArray(T[] data) : this(data.AsMemory())
+    {
+    }
+
+    /// <summary>
+    /// Creates a typed-array over an array, without copying.
+    /// </summary>
+    public JSTypedArray(T[] data, int start, int length) : this(data.AsMemory().Slice(start, length))
+    {
+    }
+
+    public int Length => _value.GetTypedArrayLength(out _);
+
+    public T this[int index]
+    {
+        get => Span[index];
+        set => Span[index] = value;
+    }
+
+    public Span<T> Span => _value.GetTypedArrayData<T>();
+
+    /// <summary>
+    /// Copies the typed-array data into a new array and returns the array.
+    /// </summary>
+    public T[] ToArray() => Span.ToArray();
+
+    /// <summary>
+    /// Copies the typed-array data into an array.
+    /// </summary>
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        Span.CopyTo(new Span<T>(array, arrayIndex, array.Length - arrayIndex));
+    }
+
+    public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
+
+    /// <summary>
+    /// Gets the typed-array values as memory, without copying.
+    /// </summary>
+    public Memory<T> AsMemory()
+    {
+        JSReference typedArrayReference = new JSReference(_value);
+        return new MemoryManager(typedArrayReference).Memory;
+    }
+
+    /// <summary>
+    /// Holds a reference to a typed-array value until the memory is disposed.
+    /// </summary>
+    private class MemoryManager : MemoryManager<T>
+    {
+        private readonly JSReference _typedArrayReference;
+
+        public MemoryManager(JSReference typedArrayReference)
+        {
+            _typedArrayReference = typedArrayReference;
+        }
+
+        public override Span<T> GetSpan()
+        {
+            JSValue value = _typedArrayReference.GetValue() ??
+                throw new ObjectDisposedException(nameof(JSTypedArray<T>));
+            return ((JSTypedArray<T>)value).Span;
+        }
+
+        public override unsafe MemoryHandle Pin(int elementIndex = 0)
+        {
+            // Do TypedArray or ArrayBuffer support pinning?
+            // This code assumes the memory buffer is not moveable.
+            void* pointer = Unsafe.AsPointer(ref MemoryMarshal.GetReference(GetSpan()));
+            return new MemoryHandle(pointer, handle: default, pinnable: this);
+        }
+
+        public override void Unpin() { }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _typedArrayReference.Dispose();
+            }
+        }
+    }
+}

--- a/Runtime/JSTypedArray.cs
+++ b/Runtime/JSTypedArray.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 
 namespace NodeApi;
 
-public struct JSTypedArray<T> where T : struct
+public readonly struct JSTypedArray<T> where T : struct
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSTypedArray<T>(JSValue value) => new JSTypedArray<T>(value);
+    public static explicit operator JSTypedArray<T>(JSValue value) => new(value);
     public static implicit operator JSValue(JSTypedArray<T> arr) => arr._value;
 
     private static int ElementSize { get; } = default(T) switch
@@ -109,7 +109,7 @@ public struct JSTypedArray<T> where T : struct
     /// </summary>
     public Memory<T> AsMemory()
     {
-        JSReference typedArrayReference = new JSReference(_value);
+        JSReference typedArrayReference = new(_value);
         return new MemoryManager(typedArrayReference).Memory;
     }
 

--- a/Runtime/JSTypedArrayType.cs
+++ b/Runtime/JSTypedArrayType.cs
@@ -1,17 +1,17 @@
 namespace NodeApi;
 
-// Matches to napi_typed_arraytype
+// Matches to napi_typedarray_type
 public enum JSTypedArrayType : int
 {
-    SByteArray,
-    ByteArray,
-    ByteClampedArray,
-    Int16Array,
-    UInt16Array,
-    Int32Array,
-    UInt32Array,
-    SingleArray,
-    DoubleArray,
-    BigInt64Array,
-    BigUInt64Array,
+    Int8,
+    UInt8,
+    UInt8Clamped,
+    Int16,
+    UInt16,
+    Int32,
+    UInt32,
+    Float32,
+    Float64,
+    BigInt64,
+    BigUInt64,
 }

--- a/Runtime/JSValue.cs
+++ b/Runtime/JSValue.cs
@@ -8,7 +8,7 @@ namespace NodeApi;
 
 public struct JSValue
 {
-    private napi_value _handle;
+    private readonly napi_value _handle;
 
     public JSValueScope Scope { get; }
 
@@ -188,9 +188,9 @@ public struct JSValue
         return result;
     }
 
-    public static unsafe JSValue CreateExternalArrayBuffer(object? external, ReadOnlyMemory<byte> memory)
+    public static unsafe JSValue CreateExternalArrayBuffer<T>(Memory<T> memory, object? external = null) where T : struct
     {
-        var pinnedMemory = new PinnedReadOnlyMemory(external, memory);
+        var pinnedMemory = new PinnedMemory<T>(memory, external);
         return napi_create_external_arraybuffer(
             Env,
             pinnedMemory.Pointer,

--- a/Runtime/JSValue.cs
+++ b/Runtime/JSValue.cs
@@ -6,7 +6,7 @@ using static NodeApi.JSNativeApi.Interop;
 
 namespace NodeApi;
 
-public struct JSValue
+public readonly struct JSValue
 {
     private readonly napi_value _handle;
 

--- a/Runtime/JSValueScope.cs
+++ b/Runtime/JSValueScope.cs
@@ -5,7 +5,7 @@ namespace NodeApi;
 
 public class JSValueScope : IDisposable
 {
-    private napi_env _env;
+    private readonly napi_env _env;
     [ThreadStatic] private static JSValueScope? s_current;
 
     public JSValueScope? ParentScope { get; }

--- a/Test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/Test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace NodeApi.TestCases;
 
@@ -23,9 +21,9 @@ public static class ComplexTypes
 
     public static ClassObject? NullableClassObject { get; set; }
 
-    public static int[] Array { get; set; } = System.Array.Empty<int>();
+    public static string[] StringArray { get; set; } = Array.Empty<string>();
 
-    public static int[]? NullableArray { get; set; }
+    public static Memory<uint> UIntArray { get; set; }
 
     public static IList<int> List { get; set; } = new List<int>();
 
@@ -35,6 +33,9 @@ public static class ComplexTypes
 
     public static IReadOnlyDictionary<int, string> ReadOnlyDictionary { get; set; }
         = new Dictionary<int, string>().AsReadOnly();
+
+    public static IDictionary<string, IList<ClassObject>> ObjectListDictionary { get; set; }
+        = new Dictionary<string, IList<ClassObject>>();
 }
 
 /// <summary>

--- a/Test/TestCases/napi-dotnet/complex_types.js
+++ b/Test/TestCases/napi-dotnet/complex_types.js
@@ -57,3 +57,35 @@ assert.notStrictEqual(structInstance2, structInstance);
 structInstance2.value = 'test2';
 assert.strictEqual(structInstance2.value, 'test2');
 assert.strictEqual(structInstance.value, 'test');
+
+// C# arrays are copied to/from JS, so modifying the returned array doesn't affect the original.
+const stringArrayValue = ComplexTypes.stringArray;
+assert(Array.isArray(stringArrayValue));
+assert.strictEqual(stringArrayValue.length, 0);
+ComplexTypes.stringArray = [ 'test' ];
+assert.notStrictEqual(ComplexTypes.stringArray, stringArrayValue);
+assert.strictEqual(ComplexTypes.stringArray[0], 'test');
+ComplexTypes.stringArray[0] = 'test2';
+assert.strictEqual(ComplexTypes.stringArray[0], 'test');
+
+// C# Memory<T> maps to/from JS TypedArray (without copying) for valid typed-array element types.
+const uintArrayValue = ComplexTypes.uIntArray;
+assert(uintArrayValue instanceof Uint32Array);
+assert.strictEqual(uintArrayValue.length, 0);
+const uintArrayValue2 = new Uint32Array([0, 1, 2]);
+ComplexTypes.uIntArray = uintArrayValue2;
+assert.strictEqual(ComplexTypes.uIntArray.length, 3);
+assert.strictEqual(ComplexTypes.uIntArray[1], 1);
+
+/*
+// C# IList<T> maps to/from JS Array<T> (without copying).
+const listValue = ComplexTypes.list;
+assert(Array.isArray(listValue));
+assert.strictEqual(listValue.length, 0);
+ComplexTypes.list = [0];
+assert.notStrictEqual(ComplexTypes.list, listValue);
+assert.strictEqual(ComplexTypes.list[0], 0);
+listValue = ComplexTypes.list;
+ComplexTypes.list[0] = 1;
+assert.strictEqual(listValue[0], 1);
+*/


### PR DESCRIPTION
 - Generate adapter code for arrays: C# `T[]` <-> JS `T[]` for any `T` that can be converted including primitives, structs, classes, etc.
   - Unfortunately array data must be copied because it's impossible to create a C# array over external memory.
 - Add `JSTypedArray<T>` value type.
 - Generate adapter code for typed arrays: C# `Memory<T>` <-> JS TypedArrays, where `T` is one of the valid typed-array element types, for example `Memory<int>` <-> `Int32Array`.
   - Typed arrays can be passed back and forth without copying the data, with some careful marshalling and lifetime management -- see `JSTypedArray.MemoryManager`.
 - Generate TS type definitions for arrays, typed arrays, and collections.

(Runtime adapter code is not yet generated for collections; I'm planning to work on that next. Collections should be adaptable without copying, by leveraging JS Proxy objects.)