### PR TITLE
Enable default for JSValue struct.

### DIFF
--- a/Runtime/JSValue.cs
+++ b/Runtime/JSValue.cs
@@ -24,7 +24,7 @@ public readonly struct JSValue
     {
         if (handle.Handle != nint.Zero)
         {
-            ArgumentNullException.ThrowIfNull(nameof(scope));
+            ArgumentNullException.ThrowIfNull(scope);
         }
         _scope = scope;
         _handle = handle;

--- a/Test/TestCases/node-addon-api/basic_types/value.cs
+++ b/Test/TestCases/node-addon-api/basic_types/value.cs
@@ -27,7 +27,7 @@ public class TestBasicTypesValue : TestHelper, ITestObject
 
     // Helper methods
     private static JSValue CreateDefaultValue(JSCallbackArgs _) => default;
-    private static JSValue CreateEmptyValue(JSCallbackArgs _) => new JSValue();
+    private static JSValue CreateEmptyValue(JSCallbackArgs _) => new();
     private static JSValue CreateNonEmptyValue(JSCallbackArgs _) => "non_empty_val";
     private static JSValue CreateExternal(JSCallbackArgs _) => JSValue.CreateExternal(1);
 

--- a/Test/TestCases/node-addon-api/basic_types/value.cs
+++ b/Test/TestCases/node-addon-api/basic_types/value.cs
@@ -26,8 +26,10 @@ public class TestBasicTypesValue : TestHelper, ITestObject
     private static JSValue StrictlyEquals(JSCallbackArgs args) => args[0].StrictEquals(args[1]);
 
     // Helper methods
-    private static JSValue CreateExternal(JSCallbackArgs _) => JSValue.CreateExternal(1);
+    private static JSValue CreateDefaultValue(JSCallbackArgs _) => default;
+    private static JSValue CreateEmptyValue(JSCallbackArgs _) => new JSValue();
     private static JSValue CreateNonEmptyValue(JSCallbackArgs _) => "non_empty_val";
+    private static JSValue CreateExternal(JSCallbackArgs _) => JSValue.CreateExternal(1);
 
 
     public static JSObject Init() => new()
@@ -53,6 +55,8 @@ public class TestBasicTypesValue : TestHelper, ITestObject
 
         Method(StrictlyEquals),
 
+        Method(CreateDefaultValue),
+        Method(CreateEmptyValue),
         Method(CreateNonEmptyValue),
         Method(CreateExternal),
     };

--- a/Test/TestCases/node-addon-api/basic_types/value.js
+++ b/Test/TestCases/node-addon-api/basic_types/value.js
@@ -124,6 +124,9 @@ function test(binding) {
   typeCheckerTest(value.isDataView, 'dataview');
   typeCheckerTest(value.isExternal, 'external');
 
+  assert.strictEqual(value.isUndefined(value.createDefaultValue()), true);
+  assert.strictEqual(value.isUndefined(value.createEmptyValue()), true);
+
   typeConverterTest(value.toBoolean, Boolean);
   assert.strictEqual(value.toBoolean(undefined), false);
   assert.strictEqual(value.toBoolean(null), false);


### PR DESCRIPTION
Add default `JSValue` constructor that uses the default initialization of `JSValue` to zeroes.
The `default` `JSValue` is logically the same as `JSValue.Undefined`.