### PR TITLE
Add async/await support and improved JSContext

### DIFF
--- a/Runtime/JSCallbackArgs.cs
+++ b/Runtime/JSCallbackArgs.cs
@@ -13,7 +13,7 @@ public class JSCallbackArgs
 
     public JSValue ThisArg { get; }
 
-    public object? Data { get; set; } = null;
+    public object? Data { get; set; }
 
     public JSValue GetNewTarget()
     {

--- a/Runtime/JSContext.cs
+++ b/Runtime/JSContext.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using static NodeApi.JSNativeApi;
-using static NodeApi.JSNativeApi.Interop;
+using napi_env = NodeApi.JSNativeApi.Interop.napi_env;
 
 namespace NodeApi;
 
@@ -72,7 +72,7 @@ public sealed class JSContext : IDisposable
 
     public JSContext(napi_env env)
     {
-        Initialize();
+        Interop.Initialize();
         _env = env;
         SetInstanceData(this);
     }
@@ -331,14 +331,14 @@ public sealed class JSContext : IDisposable
         {
             IsDisposed = true;
 
-            DisposeReferences(_objectMap);
-            DisposeReferences(_classMap);
-            DisposeReferences(_structMap);
-
             if (Module is IDisposable module)
             {
                 module.Dispose();
             }
+
+            DisposeReferences(_objectMap);
+            DisposeReferences(_classMap);
+            DisposeReferences(_structMap);
         }
 
         GC.SuppressFinalize(this);

--- a/Runtime/JSModuleBuilderOfT.cs
+++ b/Runtime/JSModuleBuilderOfT.cs
@@ -15,21 +15,21 @@ public class JSModuleBuilder<T>
 {
     static T? IJSObjectUnwrap<T>.Unwrap(JSCallbackArgs _)
     {
-        return (T?)JSNativeApi.GetInstanceData();
+        return (T?)JSContext.Current.Module;
     }
 
     /// <summary>
     /// Exports the built properties to the module exports object.
     /// </summary>
-    /// <param name="context">An object that represents the module instance and is
+    /// <param name="module">An object that represents the module instance and is
     /// used as the 'this' argument for any non-static methods on the module. If the object
     /// implements <see cref="IDisposable"/> then it is also registered for disposal when
     /// the module is unloaded.</param>
     /// <param name="exports">Object to be returned from the module initializer.</param>
     /// <returns>The module exports.</returns>
-    public JSValue ExportModule(T context, JSObject exports)
+    public JSValue ExportModule(T module, JSObject exports)
     {
-        JSNativeApi.SetInstanceData(context);
+        JSContext.Current.Module = module;
         exports.DefineProperties(Properties.ToArray());
         return exports;
     }

--- a/Runtime/JSNativeApi.Interop.cs
+++ b/Runtime/JSNativeApi.Interop.cs
@@ -40,8 +40,15 @@ public static partial class JSNativeApi
         // Specialized pointer types
         //===========================================================================
 
-        public record struct napi_env(nint Handle);
-        public record struct napi_value(nint Handle);
+        public record struct napi_env(nint Handle)
+        {
+            public bool IsNull => Handle == nint.Zero;
+        }
+        public record struct napi_value(nint Handle)
+        {
+            public static napi_value Null => new(nint.Zero);
+            public bool IsNull => Handle == nint.Zero;
+        }
         public record struct napi_ref(nint Handle);
         public record struct napi_handle_scope(nint Handle);
         public record struct napi_escapable_handle_scope(nint Handle);

--- a/Runtime/JSNativeApi.NodeApiInterop.cs
+++ b/Runtime/JSNativeApi.NodeApiInterop.cs
@@ -21,8 +21,8 @@ public static partial class JSNativeApi
 
         public unsafe struct napi_cleanup_hook
         {
-            public delegate* unmanaged[Cdecl]<void* /*arg*/, void> Handle;
-            public napi_cleanup_hook(delegate* unmanaged[Cdecl]<void* /*arg*/, void> handle)
+            public delegate* unmanaged[Cdecl]<nint /*arg*/, void> Handle;
+            public napi_cleanup_hook(delegate* unmanaged[Cdecl]<nint /*arg*/, void> handle)
                 => Handle = handle;
         }
 
@@ -58,9 +58,9 @@ public static partial class JSNativeApi
 
         public unsafe struct napi_threadsafe_function_call_js
         {
-            public delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*js_callback*/, void* /*context*/, void* /*data*/, void> Handle;
+            public delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*js_callback*/, nint /*context*/, nint /*data*/, void> Handle;
             public napi_threadsafe_function_call_js(
-                delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*js_callback*/, void* /*context*/, void* /*data*/, void> handle)
+                delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*js_callback*/, nint /*context*/, nint /*data*/, void> handle)
                 => Handle = handle;
         }
 
@@ -192,10 +192,10 @@ public static partial class JSNativeApi
         internal static unsafe partial napi_status napi_fatal_exception(napi_env env, napi_value err);
 
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_add_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, void* arg);
+        internal static unsafe partial napi_status napi_add_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, nint arg);
 
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_remove_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, void* arg);
+        internal static unsafe partial napi_status napi_remove_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, nint arg);
 
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
         internal static unsafe partial napi_status napi_open_callback_scope(
@@ -215,21 +215,21 @@ public static partial class JSNativeApi
             napi_value async_resource_name,
             nuint max_queue_size,
             nuint initial_thread_count,
-            void* thread_finalize_data,
+            nint thread_finalize_data,
             napi_finalize thread_finalize_cb,
-            void* context,
+            nint context,
             napi_threadsafe_function_call_js call_js_cb,
-            napi_threadsafe_function* result);
+            out napi_threadsafe_function result);
 
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
         internal static unsafe partial napi_status napi_get_threadsafe_function_context(
             napi_threadsafe_function func,
-            void** result);
+            out nint result);
 
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
         internal static unsafe partial napi_status napi_call_threadsafe_function(
             napi_threadsafe_function func,
-            void* data,
+            nint data,
             napi_threadsafe_function_call_mode is_blocking);
 
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/Runtime/JSNativeApi.cs
+++ b/Runtime/JSNativeApi.cs
@@ -758,14 +758,14 @@ public static partial class JSNativeApi
           out napi_value result).ThrowIfFailed(result);
     }
 
-    public static unsafe void SetInstanceData(object? data)
+    internal static unsafe void SetInstanceData(object? data)
     {
         napi_get_instance_data(Env, out nint handlePtr).ThrowIfFailed();
         if (handlePtr != nint.Zero)
         {
-            GCHandle handle = GCHandle.FromIntPtr(handlePtr);
-            (handle.Target as IDisposable)?.Dispose();
-            handle.Free();
+            // Current napi_set_instance_data implementation does not call finalizer when we replace existing instance data.
+            // It means that we only remove the GC root, but do not call Dispose.
+            GCHandle.FromIntPtr(handlePtr).Free();
         }
 
         if (data != null)
@@ -779,7 +779,7 @@ public static partial class JSNativeApi
         }
     }
 
-    public static object? GetInstanceData()
+    internal static object? GetInstanceData()
     {
         napi_get_instance_data(Env, out nint data).ThrowIfFailed();
         return (data != nint.Zero) ? GCHandle.FromIntPtr(data).Target : null;

--- a/Runtime/JSReference.cs
+++ b/Runtime/JSReference.cs
@@ -18,21 +18,19 @@ namespace NodeApi;
 /// </remarks>
 public class JSReference : IDisposable
 {
-    private readonly napi_env _env;
+    private readonly JSContext _context;
     private readonly napi_ref _handle;
 
     public bool IsWeak { get; private set; }
 
     public JSReference(JSValue value, bool isWeak = false)
+        : this(napi_create_reference((napi_env)JSValueScope.Current, (napi_value)value, isWeak ? 0u : 1u, out napi_ref handle).ThrowIfFailed(handle), isWeak)
     {
-        _env = (napi_env)value.Scope;
-        napi_create_reference(_env, (napi_value)value, isWeak ? 0u : 1u, out _handle).ThrowIfFailed();
-        IsWeak = isWeak;
     }
 
     public JSReference(napi_ref handle, bool isWeak = false)
     {
-        _env = (napi_env)JSSimpleValueScope.Current;
+        _context = JSContext.Current;
         _handle = handle;
         IsWeak = isWeak;
     }
@@ -42,7 +40,7 @@ public class JSReference : IDisposable
         ThrowIfDisposed();
         if (!IsWeak)
         {
-            napi_reference_unref(_env, _handle, nint.Zero).ThrowIfFailed();
+            napi_reference_unref((napi_env)_context, _handle, nint.Zero).ThrowIfFailed();
             IsWeak = true;
         }
     }
@@ -51,7 +49,7 @@ public class JSReference : IDisposable
         ThrowIfDisposed();
         if (IsWeak)
         {
-            napi_reference_ref(_env, _handle, nint.Zero).ThrowIfFailed();
+            napi_reference_ref((napi_env)_context, _handle, nint.Zero).ThrowIfFailed();
             IsWeak = true;
         }
     }
@@ -59,7 +57,7 @@ public class JSReference : IDisposable
     public JSValue? GetValue()
     {
         ThrowIfDisposed();
-        napi_get_reference_value(_env, _handle, out napi_value result).ThrowIfFailed();
+        napi_get_reference_value((napi_env)_context, _handle, out napi_value result).ThrowIfFailed();
         return result;
     }
 
@@ -89,16 +87,11 @@ public class JSReference : IDisposable
     {
         if (!IsDisposed)
         {
-            // The reference handle should be deleted regardless of the `disposing` argument.
-            napi_status status = napi_delete_reference(_env, _handle);
-
-            // Ignore errors when finalizing.
-            if (disposing)
-            {
-                status.ThrowIfFailed();
-            }
-
             IsDisposed = true;
+            if (disposing && !_context.IsDisposed)
+            {
+                napi_delete_reference((napi_env)_context, _handle).ThrowIfFailed();
+            }
         }
     }
 

--- a/Runtime/JSReference.cs
+++ b/Runtime/JSReference.cs
@@ -88,7 +88,7 @@ public class JSReference : IDisposable
         if (!IsDisposed)
         {
             IsDisposed = true;
-            if (disposing && !_context.IsDisposed)
+            if (!_context.IsDisposed)
             {
                 napi_delete_reference((napi_env)_context, _handle).ThrowIfFailed();
             }

--- a/Runtime/JSSynchronizationContext.cs
+++ b/Runtime/JSSynchronizationContext.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+
+namespace NodeApi;
+
+public class JSSynchronizationContext : SynchronizationContext, IDisposable
+{
+    private readonly JSThreadSafeFunction _tsfn;
+    private readonly SynchronizationContext? _previousSyncContext;
+
+    public bool IsDisposed { get; private set; }
+
+    public JSSynchronizationContext()
+    {
+        _tsfn = JSThreadSafeFunction.New(
+            maxQueueSize: 0,
+            initialThreadCount: 1,
+            asyncResourceName: (JSValue)"SynchronizationContext");
+
+        _previousSyncContext = Current;
+        SetSynchronizationContext(this);
+    }
+
+    ~JSSynchronizationContext()
+    {
+        Dispose(disposing: false);
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    public override void Post(SendOrPostCallback callback, object? state)
+    {
+        if (!IsDisposed)
+        {
+            _tsfn.NonBlockingCall(() => callback(state));
+        }
+    }
+
+    public override void Send(SendOrPostCallback callback, object? state)
+    {
+        if (this == Current)
+        {
+            callback(state);
+        }
+        else
+        {
+            Post(callback, state);
+        }
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!IsDisposed)
+        {
+            IsDisposed = true;
+            if (disposing)
+            {
+                SetSynchronizationContext(_previousSyncContext);
+            }
+
+            _tsfn.Release();
+        }
+    }
+}

--- a/Runtime/JSThreadSafeFunction.cs
+++ b/Runtime/JSThreadSafeFunction.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static NodeApi.JSNativeApi.Interop;
+using static NodeApi.JSNativeApi.NodeApiInterop;
+
+namespace NodeApi;
+
+public delegate void JSThreadSafeCallback(JSValue jsFunction, object? functionContext, object? callbackData);
+
+public delegate void JSThreadSafeFinalizeCallback(object? functionContext);
+
+public struct JSThreadSafeFunction
+{
+    private napi_threadsafe_function _tsfn;
+
+    public static explicit operator napi_threadsafe_function(JSThreadSafeFunction function) => function._tsfn;
+    public static implicit operator JSThreadSafeFunction(napi_threadsafe_function tsfn) => new(tsfn);
+
+    private JSThreadSafeFunction(napi_threadsafe_function tsfn) => _tsfn = tsfn;
+
+    // This API may only be called from the main thread.
+    public static unsafe JSThreadSafeFunction New(int maxQueueSize,
+                                                  int initialThreadCount,
+                                                  in JSValue asyncResourceName,
+                                                  in JSValue? jsFunction = null,
+                                                  in JSObject? asyncResource = null,
+                                                  JSThreadSafeFinalizeCallback? finalize = null,
+                                                  object? functionContext = null,
+                                                  JSThreadSafeCallback? jsCaller = null)
+    {
+        FunctionData functionData = new()
+        {
+            FunctionContext = functionContext,
+            Finalize = finalize,
+            JSCaller = jsCaller
+        };
+        GCHandle functionDataHandle = GCHandle.Alloc(functionData);
+        napi_status status = napi_create_threadsafe_function(
+                                 (napi_env)JSValueScope.Current,
+                                 (napi_value)jsFunction,
+                                 (napi_value)(JSValue)(asyncResource is JSObject obj ? obj : new JSObject()),
+                                 (napi_value)asyncResourceName,
+                                 (nuint)maxQueueSize,
+                                 (nuint)initialThreadCount,
+                                 thread_finalize_data: nint.Zero,
+                                 new napi_finalize(&FinalizeFunctionData),
+                                 (nint)functionDataHandle,
+                                 (jsCaller != null)
+                                     ? new napi_threadsafe_function_call_js(&CustomCallJS)
+                                     : new napi_threadsafe_function_call_js(&DefaultCallJS),
+                                 out napi_threadsafe_function tsfn);
+        if (status != napi_status.napi_ok)
+        {
+            functionDataHandle.Free();
+            status.ThrowIfFailed();
+        }
+
+        return new JSThreadSafeFunction(tsfn);
+    }
+
+
+    // This API may be called from any thread.
+    public object? GetFunctionContext()
+    {
+        napi_get_threadsafe_function_context(_tsfn, out nint handle).ThrowIfFailed();
+        FunctionData functionData = (FunctionData)GCHandle.FromIntPtr(handle).Target!;
+        return functionData.FunctionContext;
+    }
+
+    // This API may be called from any thread.
+    public void BlockingCall()
+    {
+        CallInternal(null, napi_threadsafe_function_call_mode.napi_tsfn_blocking).ThrowIfFailed();
+    }
+
+    // This API may be called from any thread.
+    public void BlockingCall(object? data)
+    {
+        CallInternal(data, napi_threadsafe_function_call_mode.napi_tsfn_blocking).ThrowIfFailed();
+    }
+
+    // This API may be called from any thread.
+    public void BlockingCall(Action callback)
+    {
+        CallInternal(callback, napi_threadsafe_function_call_mode.napi_tsfn_blocking).ThrowIfFailed();
+    }
+
+    // This API may be called from any thread.
+    public void BlockingCall(Action<JSValue?, object?> callback)
+    {
+        CallInternal(callback, napi_threadsafe_function_call_mode.napi_tsfn_blocking).ThrowIfFailed();
+    }
+
+    // This API may be called from any thread.
+    public bool NonBlockingCall()
+    {
+        return NonBlockingCall(CallInternal(null, napi_threadsafe_function_call_mode.napi_tsfn_nonblocking));
+    }
+
+    // This API may be called from any thread.
+    public bool NonBlockingCall(object? data)
+    {
+        return NonBlockingCall(CallInternal(data, napi_threadsafe_function_call_mode.napi_tsfn_nonblocking));
+    }
+
+    // This API may be called from any thread.
+    public bool NonBlockingCall(Action callback)
+    {
+        return NonBlockingCall(CallInternal(callback, napi_threadsafe_function_call_mode.napi_tsfn_nonblocking));
+    }
+
+    // This API may be called from any thread.
+    public bool NonBlockingCall(Action<JSValue?, object?> callback)
+    {
+        return NonBlockingCall(CallInternal(callback, napi_threadsafe_function_call_mode.napi_tsfn_nonblocking));
+    }
+
+    // This API may only be called from the main thread.
+    public void Ref()
+    {
+        if (_tsfn.Handle != nint.Zero)
+        {
+            napi_ref_threadsafe_function((napi_env)JSValueScope.Current, _tsfn).ThrowIfFailed();
+        }
+    }
+
+    // This API may only be called from the main thread.
+    public void Unref()
+    {
+        if (_tsfn.Handle != nint.Zero)
+        {
+            napi_unref_threadsafe_function((napi_env)JSValueScope.Current, _tsfn).ThrowIfFailed();
+        }
+    }
+
+    // This API may be called from any thread.
+    public napi_status Acquire()
+    {
+        return napi_acquire_threadsafe_function(_tsfn);
+    }
+
+    // This API may be called from any thread.
+    public napi_status Release()
+    {
+        return napi_release_threadsafe_function(_tsfn, napi_threadsafe_function_release_mode.napi_tsfn_release);
+    }
+
+    // This API may be called from any thread.
+    public napi_status Abort()
+    {
+        return napi_release_threadsafe_function(_tsfn, napi_threadsafe_function_release_mode.napi_tsfn_abort);
+    }
+
+    private static bool NonBlockingCall(napi_status status)
+    {
+        if (status == napi_status.napi_ok)
+        {
+            return true;
+        }
+        else if (status != napi_status.napi_queue_full)
+        {
+            status.ThrowIfFailed();
+        }
+        return false;
+    }
+
+    private napi_status CallInternal(object? callbackOrData, napi_threadsafe_function_call_mode mode)
+    {
+        GCHandle callbackOrDataHandle = GCHandle.Alloc(callbackOrData);
+        napi_status status = napi_call_threadsafe_function(_tsfn, (nint)callbackOrDataHandle, mode);
+        if (status != napi_status.napi_ok && callbackOrData != null)
+        {
+            (callbackOrData as IDisposable)?.Dispose();
+            callbackOrDataHandle.Free();
+        }
+
+        return status;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static unsafe void FinalizeFunctionData(napi_env env, nint _, nint hint)
+    {
+        GCHandle functionDataHandle = GCHandle.FromIntPtr(hint);
+        if (functionDataHandle.Target is FunctionData functionData && functionData.Finalize is not null)
+        {
+            functionData.Finalize(functionData.FunctionContext);
+        }
+
+        functionDataHandle.Free();
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static unsafe void CustomCallJS(napi_env env, napi_value jsCallback, nint context, nint data)
+    {
+        if (env.IsNull && jsCallback.IsNull)
+        {
+            return;
+        }
+
+        try
+        {
+            using JSValueScope scope = new(env);
+
+            object? callbackData = null;
+            if (data != nint.Zero)
+            {
+                GCHandle dataHandle = GCHandle.FromIntPtr(data);
+                callbackData = dataHandle.Target!;
+                dataHandle.Free();
+            }
+
+            GCHandle contextHandle = GCHandle.FromIntPtr(context);
+            FunctionData functionData = (FunctionData)contextHandle.Target!;
+            functionData.JSCaller!((JSValue)jsCallback, functionData.FunctionContext, callbackData);
+        }
+        catch
+        {
+            //TODO: terminate - there is no way to propagate exceptions
+        }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static unsafe void DefaultCallJS(napi_env env, napi_value jsCallback, nint context, nint data)
+    {
+        if (env.IsNull && jsCallback.IsNull)
+        {
+            return;
+        }
+
+        try
+        {
+            using JSValueScope scope = new(env);
+
+            if (data != nint.Zero)
+            {
+                GCHandle dataHandle = GCHandle.FromIntPtr(data);
+                object dataObject = dataHandle.Target!;
+                dataHandle.Free();
+                if (dataObject is Action action)
+                {
+                    action();
+                }
+                else if (dataObject is Action<JSValue?, object?> callback)
+                {
+                    GCHandle contextHandle = GCHandle.FromIntPtr(context);
+                    FunctionData functionData = (FunctionData)contextHandle.Target!;
+                    callback((JSValue?)jsCallback, functionData.FunctionContext);
+                }
+                else
+                {
+                    throw new ArgumentException("Unexpected data parameter");
+                }
+            }
+            else if (jsCallback.Handle != nint.Zero)
+            {
+                ((JSValue)jsCallback).Call();
+            }
+        }
+        catch
+        {
+            //TODO: terminate - there is no way to propagate exceptions
+        }
+    }
+
+    private class FunctionData
+    {
+        public object? FunctionContext { get; init; }
+        public JSThreadSafeFinalizeCallback? Finalize { get; init; }
+        public JSThreadSafeCallback? JSCaller { get; init; }
+    }
+}

--- a/Test/TestCases/napi-dotnet/AsyncMethod.cs
+++ b/Test/TestCases/napi-dotnet/AsyncMethod.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+
+namespace NodeApi.TestCases;
+
+public static class AsyncMethod
+{
+    // This method calls C# async method and returns JS Promise
+    [JSExport("async_method")]
+    public static JSValue Test(JSCallbackArgs args)
+    {
+        JSValue result = JSValue.CreatePromise(out JSDeferred deferred);
+        AsyncGreeter(deferred, (string)args[0]);
+        return result;
+    }
+
+    // The async method must create JSSynchronizationContext at the beginning to use
+    // the JS thread after we return from a background thread.
+    // Below the `Task.Delay(50)` is executed in a background thread.
+    private static async void AsyncGreeter(JSDeferred deferred, string greeter)
+    {
+        using JSSynchronizationContext context = new();
+        await Task.Delay(50);
+        deferred.Resolve((JSValue)$"Hey {greeter}!");
+    }
+}

--- a/Test/TestCases/napi-dotnet/async_method.js
+++ b/Test/TestCases/napi-dotnet/async_method.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const common = require('../node-addon-api/common');
+
+common.runTest(async function (binding) {
+  const result = await binding.async_method('buddy');
+  assert.strictEqual(result, 'Hey buddy!');
+});
+


### PR DESCRIPTION
The main goal of this PR is to introduce support for C# async/await.
To implement it we are adding a new class `JSSynchronizationContext`. 
It can be created in the beginning of C# async function to be captured by `await` to continue execution on it after returning from a background thread. See the `async_method.js` and `AsyncMethod.cs` test as an example.

The `JSSynchronizationContext` is based on the new `JSThreadSafeFunction` wrapper for `napi_threadsafe_function`.
The `napi_threadsafe_function` has a ref count for threads that use it. It is controlled by the Acquire/Release calls.
If we have any thread that still uses the `napi_threadsafe_function`, then the environment cannot be shutdown.
Thus, I could not find a way to have a pseudo-global `JSSynchronizationContext` which is kept in `JSContext` for a lifetime of a module. So far, the only solution that works is to explicitly create the `JSSynchronizationContext` along with `JSThreadSafeFunction` when needed. I hope it should be possible to do in the generated code around async methods in future.

Since I was playing with the `JSContext` where I planned to store the `JSSynchronizationContext`, this PR also contains `JSContext` improvements:
- `JSContext` is not global. It is created per module.
- `JSContext` wraps up `napi_env`.
- `napi_env` encapsulates `JSContext` as its instance data. Thus, we can easily go between `JSContext` and `napi_env`.
- Since `JSContext` is storing itself as an instance data, it must be created after we establish `JSValueScope`. 
- `JSContext.Current` implementation is based on the `JSValueScope.Current`. We use it to get `napi_env` and then retrieve its instance data.
- `napi_env` in `JSReference` is replaced by `JSContext`. We can check `JSContext.IsDisposed` to see if we are allowed to do any `napi_ref` operations. In some sense the `JSContext` to `JSReference` as the `JSValueContext` to `JSValue`.
- `JSContext` holds the Module and responsible for its disposing.
- A number of other changes to code gen and hosting classes to enable this `JSContext` design improvements.
