### PR TITLE
Generate adapter code for sets and maps

### DIFF
--- a/Generator/AdapterGenerator.cs
+++ b/Generator/AdapterGenerator.cs
@@ -219,7 +219,7 @@ internal class AdapterGenerator : SourceGenerator
     /// </summary>
     private string GetProxyFieldName(INamedTypeSymbol targetType)
     {
-        string GetTypeName(ITypeSymbol type)
+        static string GetTypeName(ITypeSymbol type)
         {
             string name = type.Name;
             if (type is INamedTypeSymbol namedType && namedType.TypeParameters.Length > 0)

--- a/Generator/AdapterGenerator.cs
+++ b/Generator/AdapterGenerator.cs
@@ -219,11 +219,21 @@ internal class AdapterGenerator : SourceGenerator
     /// </summary>
     private string GetProxyFieldName(INamedTypeSymbol targetType)
     {
-        string fieldName = ProxyPrefix + targetType.Name + "_of";
-        foreach (ITypeSymbol typeArgument in targetType.TypeArguments)
+        string GetTypeName(ITypeSymbol type)
         {
-            fieldName += "_" + typeArgument.Name;
+            string name = type.Name;
+            if (type is INamedTypeSymbol namedType && namedType.TypeParameters.Length > 0)
+            {
+                name += "_of";
+                foreach (ITypeSymbol typeArgument in namedType.TypeArguments)
+                {
+                    name += "_" + GetTypeName(typeArgument);
+                }
+            }
+            return name;
         }
+
+        string fieldName = ProxyPrefix + GetTypeName(targetType);
         if (!_proxiedCollections.ContainsKey(fieldName))
         {
             _proxiedCollections.Add(fieldName, targetType);
@@ -594,29 +604,58 @@ internal class AdapterGenerator : SourceGenerator
          *     LazyThreadSafetyMode.ExecutionAndPublication);
          */
 
-        s += $"private static readonly System.Lazy<JSProxy.Handler> {fieldName} " +
-            "= new(";
+        s += $"private static readonly System.Lazy<JSProxy.Handler> {fieldName} = new(";
 
         ITypeSymbol elementType = targetType.TypeArguments[0];
+        ITypeSymbol keyType = targetType.TypeArguments[0];
+        ITypeSymbol? valueType = targetType.TypeArguments.Length > 1 ? targetType.TypeArguments[1] : null;
         s += targetType.OriginalDefinition.Name switch
         {
             "IEnumerable" =>
-                $"\t() => JSIterable.CreateProxyHandlerForEnumerable<{elementType}>(JSContext.Current, " +
-                $"(item) => {ConvertFrom("item", elementType)}),",
+                $"() => JSIterable.CreateProxyHandlerForEnumerable<{elementType}>(" +
+                "\nJSContext.Current, " +
+                $"\n(item) => {ConvertFrom("item", elementType)}),",
             "IReadOnlyCollection" =>
-                $"\t() => JSIterable.CreateProxyHandlerForReadOnlyCollection<{elementType}>(JSContext.Current, " +
-                $"(item) => {ConvertFrom("item", elementType)}),",
+                $"() => JSIterable.CreateProxyHandlerForReadOnlyCollection<{elementType}>(" +
+                "\nJSContext.Current, " +
+                $"\n(item) => {ConvertFrom("item", elementType)}),",
             "ICollection" =>
-                $"\t() => JSIterable.CreateProxyHandlerForCollection<{elementType}>(JSContext.Current, " +
-                $"(item) => {ConvertFrom("item", elementType)}, " +
-                $"(value) => {ConvertTo("value", elementType)}),",
+                $"() => JSIterable.CreateProxyHandlerForCollection<{elementType}>(" +
+                "\nJSContext.Current, " +
+                $"\n(item) => {ConvertFrom("item", elementType)}, " +
+                $"\n(value) => {ConvertTo("value", elementType)}),",
             "IReadOnlyList" =>
-                $"\t() => JSArray.CreateProxyHandlerForReadOnlyList<{elementType}>(JSContext.Current, " +
-                $"(item) => {ConvertFrom("item", elementType)}),",
+                $"() => JSArray.CreateProxyHandlerForReadOnlyList<{elementType}>(" +
+                "\nJSContext.Current, " +
+                $"\n(item) => {ConvertFrom("item", elementType)}),",
             "IList" =>
-                $"\t() => JSArray.CreateProxyHandlerForList<{elementType}>(JSContext.Current, " +
-                $"(item) => {ConvertFrom("item", elementType)}, " +
-                $"(value) => {ConvertTo("value", elementType)}),",
+                $"() => JSArray.CreateProxyHandlerForList<{elementType}>(" +
+                "\nJSContext.Current, " +
+                $"\n(item) => {ConvertFrom("item", elementType)}, " +
+                $"\n(value) => {ConvertTo("value", elementType)}),",
+            "IReadOnlySet" =>
+                $"() => JSSet.CreateProxyHandlerForReadOnlySet<{elementType}>(" +
+                "\nJSContext.Current, " +
+                $"\n(item) => {ConvertFrom("item", elementType)}, " +
+                $"\n(value) => {ConvertTo("value", elementType)}),",
+            "ISet" =>
+                $"() => JSSet.CreateProxyHandlerForSet<{elementType}>(" +
+                "\nJSContext.Current, " +
+                $"\n(item) => {ConvertFrom("item", elementType)}, " +
+                $"\n(value) => {ConvertTo("value", elementType)}),",
+            "IReadOnlyDictionary" =>
+                $"() => JSMap.CreateProxyHandlerForReadOnlyDictionary<{keyType}, {valueType!}>(" +
+                "\nJSContext.Current, " +
+                $"\n(key) => {ConvertFrom("key", keyType)}, " +
+                $"\n(value) => {ConvertFrom("value", valueType!)}, " +
+                $"\n(key) => {ConvertTo("key", keyType)}),",
+            "IDictionary" =>
+                $"() => JSMap.CreateProxyHandlerForDictionary<{keyType}, {valueType!}>(" +
+                "\nJSContext.Current, " +
+                $"\n(key) => {ConvertFrom("key", keyType)}, " +
+                $"\n(value) => {ConvertFrom("value", valueType!)}, " +
+                $"\n(key) => {ConvertTo("key", keyType)}, " +
+                $"\n(value) => {ConvertTo("value", valueType!)}),",
             _ => throw new NotSupportedException("Unsupported proxy target type: " + targetType),
         };
 
@@ -712,8 +751,8 @@ internal class AdapterGenerator : SourceGenerator
         (toType, bool isNullable) = SplitNullable(toType);
         if (isNullable)
         {
-            return $"({fromExpression}).IsNullOrUndefined() ? " +
-                $"({toType}?)null : {ConvertTo(fromExpression, toType)}";
+            return $"({fromExpression}).IsNullOrUndefined() " +
+                $"?\n({toType}?)null :\n{ConvertTo(fromExpression, toType)}";
         }
 
         if (CanCast(toType!))
@@ -755,32 +794,57 @@ internal class AdapterGenerator : SourceGenerator
         {
             string collectionTypeName = toType.OriginalDefinition.Name;
             if (collectionTypeName == "IList" ||
+                collectionTypeName == "ISet" ||
+                collectionTypeName == "IReadOnlySet" ||
                 collectionTypeName == "ICollection")
             {
                 // A collection passed from JS to C# may be either a previously wrapped/proxied
                 // C# collection object or a regular JS array that needs to be adapted to the
                 // C# collection interface.
                 // Read-write collections require bi-directional element conversion lamdas.
+                string jsTypeName = collectionTypeName.EndsWith("Set") ? "Set" : "Array";
                 ITypeSymbol elementType = namedType.TypeArguments[0];
                 return $"(JSNativeApi.TryUnwrap({fromExpression}, out var __collection) " +
-                    $"? ({toType})__collection! : ((JSArray){fromExpression})" +
+                    $"?\n({toType})__collection! :\n((JS{jsTypeName}){fromExpression})" +
                     $".As{collectionTypeName.Substring(1)}<{elementType}>(" +
-                    $"(value) => {ConvertTo("value", elementType)}, " +
-                    $"(value) => {ConvertFrom("value", elementType)}))";
+                    $"\n(value) => {ConvertTo("value", elementType)}, " +
+                    $"\n(value) => {ConvertFrom("value", elementType)}))";
             }
             else if (collectionTypeName == "IReadOnlyList" ||
                 collectionTypeName == "IReadOnlyCollection" ||
                 collectionTypeName == "IEnumerable")
             {
-                // Read-only collections require an element conversion lamda in only one direction.
+                // Some collections only require an element conversion lamda in one direction.
+                string jsTypeName = collectionTypeName.EndsWith("Enumerable") ? "Iterable" : "Array";
                 ITypeSymbol elementType = namedType.TypeArguments[0];
                 return $"(JSNativeApi.TryUnwrap({fromExpression}, out var __collection) " +
-                    $"? ({toType})__collection! : ((JSArray){fromExpression})" +
+                    $"?\n({toType})__collection! :\n((JS{jsTypeName}){fromExpression})" +
                     $".As{collectionTypeName.Substring(1)}<{elementType}>(" +
-                    $"(value) => {ConvertTo("value", elementType)}))";
+                    $"\n(value) => {ConvertTo("value", elementType)}))";
             }
-
-            // TODO: Handle other generic collection interfaces.
+            else if (collectionTypeName == "IDictionary")
+            {
+                ITypeSymbol keyType = namedType.TypeArguments[0];
+                ITypeSymbol valueType = namedType.TypeArguments[1];
+                return $"(JSNativeApi.TryUnwrap({fromExpression}, out var __collection) " +
+                    $"?\n({toType})__collection! :\n((JSMap){fromExpression})" +
+                    $".AsDictionary<{keyType}, {valueType}>(" +
+                    $"\n(key) => {ConvertTo("key", keyType)}, " +
+                    $"\n(value) => {ConvertTo("value", valueType)}," +
+                    $"\n(key) => {ConvertFrom("key", keyType)}, " +
+                    $"\n(value) => {ConvertFrom("value", valueType)}))";
+            }
+            else if (collectionTypeName == "IReadOnlyDictionary")
+            {
+                ITypeSymbol keyType = namedType.TypeArguments[0];
+                ITypeSymbol valueType = namedType.TypeArguments[1];
+                return $"(JSNativeApi.TryUnwrap({fromExpression}, out var __collection) " +
+                    $"?\n({toType})__collection! :\n((JSMap){fromExpression})" +
+                    $".AsReadOnlyDictionary<{keyType}, {valueType}>(" +
+                    $"\n(key) => {ConvertTo("key", keyType)}, " +
+                    $"\n(value) => {ConvertTo("value", valueType)}," +
+                    $"\n(key) => {ConvertFrom("key", keyType)}))";
+            }
         }
 
         // TODO: Handle other kinds of conversions from JSValue.
@@ -855,6 +919,10 @@ internal class AdapterGenerator : SourceGenerator
             string collectionTypeName = fromType.OriginalDefinition.Name;
             if (collectionTypeName == "IList" ||
                 collectionTypeName == "IReadOnlyList" ||
+                collectionTypeName == "ISet" ||
+                collectionTypeName == "IReadOnlySet" ||
+                collectionTypeName == "IDictionary" ||
+                collectionTypeName == "IReadOnlyDictionary" ||
                 collectionTypeName == "ICollection" ||
                 collectionTypeName == "IReadOnlyCollection" ||
                 collectionTypeName == "IEnumerable")
@@ -865,8 +933,6 @@ internal class AdapterGenerator : SourceGenerator
                 return $"JSContext.Current.GetOrCreateCollectionWrapper({fromExpression}, " +
                     $"{GetProxyFieldName(namedType)}.Value)";
             }
-
-            // TODO: Handle other generic collection interfaces.
         }
 
         // TODO: Handle other kinds of conversions to JSValue.

--- a/Generator/SourceBuilder.cs
+++ b/Generator/SourceBuilder.cs
@@ -49,7 +49,7 @@ internal class SourceBuilder : SourceText
 
     private void AppendLine(string line)
     {
-        if (line.Contains("\n"))
+        if (line.Contains('\n'))
         {
             foreach (string singleLine in line.Split('\n'))
             {

--- a/Generator/SourceBuilder.cs
+++ b/Generator/SourceBuilder.cs
@@ -8,6 +8,7 @@ internal class SourceBuilder : SourceText
 {
     private readonly StringBuilder _text;
     private string _currentIndent = string.Empty;
+    private int _extraIndentLevel;
 
     public SourceBuilder(string indent = "\t")
     {
@@ -48,6 +49,16 @@ internal class SourceBuilder : SourceText
 
     private void AppendLine(string line)
     {
+        if (line.Contains("\n"))
+        {
+            foreach (string singleLine in line.Split('\n'))
+            {
+                AppendLine(singleLine);
+            }
+            ResetExtraIndent();
+            return;
+        }
+
         if (line.StartsWith("}"))
         {
             DecreaseIndent();
@@ -63,6 +74,31 @@ internal class SourceBuilder : SourceText
         if (line.EndsWith("{"))
         {
             IncreaseIndent();
+        }
+        else if (line.EndsWith("(") || line.EndsWith(" ?"))
+        {
+            // The "extra" indent persists until the end of the set of lines appended together
+            // (before the split) or until a line ending with a semicolon."
+            IncreaseExtraIndent();
+        }
+        else if (line.EndsWith(";"))
+        {
+            ResetExtraIndent();
+        }
+    }
+
+    private void IncreaseExtraIndent()
+    {
+        _extraIndentLevel++;
+        IncreaseIndent();
+    }
+
+    private void ResetExtraIndent()
+    {
+        while (_extraIndentLevel > 0)
+        {
+            DecreaseIndent();
+            _extraIndentLevel--;
         }
     }
 

--- a/Runtime/JSArray.As.cs
+++ b/Runtime/JSArray.As.cs
@@ -6,30 +6,30 @@ namespace NodeApi;
 public partial struct JSArray
 {
     /// <summary>
-    /// Creates an enumerable adapter for a JS array object.
+    /// Creates an enumerable adapter for a JS Array object, without copying.
     /// </summary>
     public IEnumerable<T> AsEnumerable<T>(JSValue.To<T> fromJS) => new Enumerable<T>(_value, fromJS);
 
     /// <summary>
-    /// Creates a read-only collection adapter for a JS array object.
+    /// Creates a read-only collection adapter for a JS Array object, without copying.
     /// </summary>
     public IReadOnlyCollection<T> AsReadOnlyCollection<T>(JSValue.To<T> fromJS) =>
         new ReadOnlyCollection<T>(_value, fromJS);
 
     /// <summary>
-    /// Creates a collection adapter for a JS array object.
+    /// Creates a collection adapter for a JS Array object, without copying.
     /// </summary>
     public ICollection<T> AsCollection<T>(JSValue.To<T> fromJS, JSValue.From<T> toJS) =>
         new Collection<T>(_value, fromJS, toJS);
 
     /// <summary>
-    /// Creates a read-only list adapter for a JS array object.
+    /// Creates a read-only list adapter for a JS Array object, without copying.
     /// </summary>
     public IReadOnlyList<T> AsReadOnlyList<T>(JSValue.To<T> fromJS) =>
         new ReadOnlyList<T>(_value, fromJS);
 
     /// <summary>
-    /// Creates a list adapter for a JS array object.
+    /// Creates a list adapter for a JS Array object, without copying.
     /// </summary>
     public IList<T> AsList<T>(JSValue.To<T> fromJS, JSValue.From<T> toJS) =>
         new List<T>(_value, fromJS, toJS);
@@ -40,7 +40,7 @@ public partial struct JSArray
         {
         }
 
-        public int Count => Array.GetArrayLength();
+        public int Count => Value.GetArrayLength();
     }
 
     internal class Collection<T> : ReadOnlyCollection<T>, ICollection<T>
@@ -55,11 +55,11 @@ public partial struct JSArray
 
         public bool IsReadOnly => false;
 
-        public void Add(T item) => Array.CallMethod("push", ToJS(item));
+        public void Add(T item) => Value.CallMethod("push", ToJS(item));
 
-        public void Clear() => Array.CallMethod("splice", 0, Count);
+        public void Clear() => Value.CallMethod("splice", 0, Count);
 
-        public bool Contains(T item) => (bool)Array.CallMethod("includes", ToJS(item));
+        public bool Contains(T item) => (bool)Value.CallMethod("includes", ToJS(item));
 
         public void CopyTo(T[] array, int arrayIndex)
         {
@@ -72,13 +72,13 @@ public partial struct JSArray
 
         public bool Remove(T item)
         {
-            int index = (int)Array.CallMethod("indexOf", ToJS(item));
+            int index = (int)Value.CallMethod("indexOf", ToJS(item));
             if (index < 0)
             {
                 return false;
             }
 
-            Array.CallMethod("splice", index, 1);
+            Value.CallMethod("splice", index, 1);
             return true;
         }
     }
@@ -89,7 +89,7 @@ public partial struct JSArray
         {
         }
 
-        public T this[int index] => FromJS(Array.GetElement(index));
+        public T this[int index] => FromJS(Value.GetElement(index));
     }
 
     internal class List<T> : Collection<T>, IList<T>
@@ -100,15 +100,15 @@ public partial struct JSArray
 
         public T this[int index]
         {
-            get => FromJS(Array.GetElement(index));
-            set => Array.SetElement(index, ToJS(value));
+            get => FromJS(Value.GetElement(index));
+            set => Value.SetElement(index, ToJS(value));
         }
 
-        public int IndexOf(T item) => (int)Array.CallMethod("indexOf", ToJS(item));
+        public int IndexOf(T item) => (int)Value.CallMethod("indexOf", ToJS(item));
 
-        public void Insert(int index, T item) => Array.CallMethod("splice", index, 0, ToJS(item));
+        public void Insert(int index, T item) => Value.CallMethod("splice", index, 0, ToJS(item));
 
-        public void RemoveAt(int index) => Array.CallMethod("splice", index, 1);
+        public void RemoveAt(int index) => Value.CallMethod("splice", index, 1);
     }
 }
 

--- a/Runtime/JSArray.Proxy.cs
+++ b/Runtime/JSArray.Proxy.cs
@@ -36,7 +36,7 @@ public partial struct JSArray
                     }
                 }
 
-                return target[property];
+                return JSIterable.ProxyGet(list, target, property, toJS);
             },
         };
     }
@@ -74,7 +74,7 @@ public partial struct JSArray
                     }
                 }
 
-                return target[property];
+                return JSIterable.ProxyGet(list, target, property, toJS);
             },
             Set = (JSObject target, JSValue property, JSValue value, JSObject receiver) =>
             {

--- a/Runtime/JSArray.cs
+++ b/Runtime/JSArray.cs
@@ -72,6 +72,19 @@ public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
 
     bool ICollection<JSValue>.Remove(JSValue item) => throw new System.NotImplementedException();
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSArray a, JSArray b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSArray a, JSArray b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/Runtime/JSArray.cs
+++ b/Runtime/JSArray.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NodeApi;
 
-public readonly partial struct JSArray : IList<JSValue>
+public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
 {
     private readonly JSValue _value;
 
@@ -12,6 +14,9 @@ public readonly partial struct JSArray : IList<JSValue>
 
     public static explicit operator JSArray(JSObject obj) => (JSArray)(JSValue)obj;
     public static implicit operator JSObject(JSArray arr) => (JSObject)arr._value;
+
+    public static explicit operator JSArray(JSIterable obj) => (JSArray)(JSValue)obj;
+    public static implicit operator JSIterable(JSArray arr) => (JSIterable)arr._value;
 
     private JSArray(JSValue value)
     {
@@ -42,14 +47,10 @@ public readonly partial struct JSArray : IList<JSValue>
 
     public void CopyTo(JSValue[] array, int arrayIndex)
     {
-        int index = arrayIndex;
-        int maxIndex = array.Length - 1;
+        int i = arrayIndex;
         foreach (JSValue item in this)
         {
-            if (index <= maxIndex)
-            {
-                array[index] = item;
-            }
+            array[i++] = item;
         }
     }
 
@@ -70,4 +71,17 @@ public readonly partial struct JSArray : IList<JSValue>
     bool ICollection<JSValue>.Contains(JSValue item) => throw new System.NotImplementedException();
 
     bool ICollection<JSValue>.Remove(JSValue item) => throw new System.NotImplementedException();
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
 }

--- a/Runtime/JSContext.cs
+++ b/Runtime/JSContext.cs
@@ -203,7 +203,7 @@ public sealed class JSContext : IDisposable
         IEnumerable<T> collection,
         JSProxy.Handler proxyHandler)
     {
-        return collection is JSIterable.Enumerable<T> adapter ? adapter.Array :
+        return collection is JSIterable.Enumerable<T> adapter ? adapter.Value :
             GetOrCreateCollectionWrapper(
                 collection, () => new JSProxy(new JSObject(), proxyHandler, collection));
     }
@@ -212,7 +212,7 @@ public sealed class JSContext : IDisposable
         IReadOnlyCollection<T> collection,
         JSProxy.Handler proxyHandler)
     {
-        return collection is JSArray.ReadOnlyCollection<T> adapter ? adapter.Array :
+        return collection is JSArray.ReadOnlyCollection<T> adapter ? adapter.Value :
             GetOrCreateCollectionWrapper(
                 collection, () => new JSProxy(new JSObject(), proxyHandler, collection));
     }
@@ -221,7 +221,7 @@ public sealed class JSContext : IDisposable
         ICollection<T> collection,
         JSProxy.Handler proxyHandler)
     {
-        return collection is JSArray.Collection<T> adapter ? adapter.Array :
+        return collection is JSArray.Collection<T> adapter ? adapter.Value :
             GetOrCreateCollectionWrapper(
                 collection, () => new JSProxy(new JSObject(), proxyHandler, collection));
     }
@@ -230,7 +230,7 @@ public sealed class JSContext : IDisposable
         IReadOnlyList<T> collection,
         JSProxy.Handler proxyHandler)
     {
-        return collection is JSArray.ReadOnlyList<T> adapter ? adapter.Array :
+        return collection is JSArray.ReadOnlyList<T> adapter ? adapter.Value :
             GetOrCreateCollectionWrapper(
                 collection, () => new JSProxy(new JSArray(), proxyHandler, collection));
     }
@@ -239,9 +239,45 @@ public sealed class JSContext : IDisposable
         IList<T> collection,
         JSProxy.Handler proxyHandler)
     {
-        return collection is JSArray.List<T> adapter ? adapter.Array :
+        return collection is JSArray.List<T> adapter ? adapter.Value :
             GetOrCreateCollectionWrapper(
                 collection, () => new JSProxy(new JSArray(), proxyHandler, collection));
+    }
+
+    public JSValue GetOrCreateCollectionWrapper<T>(
+        IReadOnlySet<T> collection,
+        JSProxy.Handler proxyHandler)
+    {
+        return collection is JSSet.ReadOnlySet<T> adapter ? adapter.Value :
+            GetOrCreateCollectionWrapper(
+                collection, () => new JSProxy(new JSSet(), proxyHandler, collection));
+    }
+
+    public JSValue GetOrCreateCollectionWrapper<T>(
+        ISet<T> collection,
+        JSProxy.Handler proxyHandler)
+    {
+        return collection is JSSet.Set<T> adapter ? adapter.Value :
+            GetOrCreateCollectionWrapper(
+                collection, () => new JSProxy(new JSSet(), proxyHandler, collection));
+    }
+
+    public JSValue GetOrCreateCollectionWrapper<TKey, TValue>(
+        IReadOnlyDictionary<TKey, TValue> collection,
+        JSProxy.Handler proxyHandler)
+    {
+        return collection is JSMap.ReadOnlyDictionary<TKey, TValue> adapter ? adapter.Value :
+            GetOrCreateCollectionWrapper(
+                collection, () => new JSProxy(new JSMap(), proxyHandler, collection));
+    }
+
+    public JSValue GetOrCreateCollectionWrapper<TKey, TValue>(
+        IDictionary<TKey, TValue> collection,
+        JSProxy.Handler proxyHandler)
+    {
+        return collection is JSMap.Dictionary<TKey, TValue> adapter ? adapter.Value :
+            GetOrCreateCollectionWrapper(
+                collection, () => new JSProxy(new JSMap(), proxyHandler, collection));
     }
 
     private JSValue GetOrCreateCollectionWrapper(

--- a/Runtime/JSIterable.As.cs
+++ b/Runtime/JSIterable.As.cs
@@ -7,67 +7,49 @@ namespace NodeApi;
 public partial struct JSIterable
 {
     /// <summary>
-    /// Creates an enumerable adapter for a JS iterable object.
+    /// Creates an enumerable adapter for a JS iterable object, without copying.
     /// </summary>
     public IEnumerable<T> AsEnumerable<T>(JSValue.To<T> fromJS) => new Enumerable<T>(_value, fromJS);
 
-    private class Enumerator<T> : IEnumerator<T>, IEnumerator
+    private sealed class Enumerator<T> : IEnumerator<T>, IEnumerator
     {
-        private readonly JSValue _array;
+        private readonly JSValue _iterable;
         private readonly JSValue.To<T> _fromJS;
-        private readonly int _count;
-        private int _index;
+        private JSValue _iterator;
         private JSValue? _current;
 
-        internal Enumerator(JSValue array, JSValue.To<T> fromJS)
+        internal Enumerator(JSValue iterable, JSValue.To<T> fromJS)
         {
-            _array = array;
+            _iterable = iterable;
             _fromJS = fromJS;
-
-            if (array.IsArray())
-            {
-                _count = array.GetArrayLength();
-            }
-            else
-            {
-                _count = 0;
-            }
-            _index = 0;
+            _iterator = _iterable.CallMethod(JSSymbol.Iterator);
             _current = default;
         }
 
         public bool MoveNext()
         {
-            if (_index < _count)
+            JSValue nextResult = _iterator.CallMethod("next");
+            JSValue done = nextResult["done"];
+            if (done.IsBoolean() && (bool)done)
             {
-                _current = _array.GetElement(_index);
-                _index++;
+                _current = default;
+                return false;
+            }
+            else
+            {
+                _current = nextResult["value"];
                 return true;
             }
-
-            _index = _count + 1;
-            _current = default;
-            return false;
         }
 
         public T Current => _current.HasValue ? _fromJS(_current.Value) :
-            throw new InvalidOperationException("Unexpected enumerator state");
+            throw new InvalidOperationException("Invalid enumerator state");
 
-        object? IEnumerator.Current
-        {
-            get
-            {
-                if (_index == 0 || _index == _count + 1)
-                {
-                    throw new InvalidOperationException("Invalid enumerator state");
-                }
-                return Current;
-            }
-        }
+        object? IEnumerator.Current => Current;
 
         void IEnumerator.Reset()
         {
-            _index = 0;
+            _iterator = _iterable.CallMethod(JSSymbol.Iterator);
             _current = default;
         }
 
@@ -78,19 +60,19 @@ public partial struct JSIterable
 
     internal class Enumerable<T> : IEnumerable<T>, IDisposable
     {
-        internal Enumerable(JSValue array, JSValue.To<T> fromJS)
+        internal Enumerable(JSValue iterable, JSValue.To<T> fromJS)
         {
-            _arrayReference = new JSReference(array);
+            _iterableReference = new JSReference(iterable);
             FromJS = fromJS;
         }
 
-        private readonly JSReference _arrayReference;
+        private readonly JSReference _iterableReference;
 
-        protected internal JSValue Array => _arrayReference.GetValue()!.Value;
+        protected internal JSValue Value => _iterableReference.GetValue()!.Value;
 
         protected JSValue.To<T> FromJS { get; }
 
-        public IEnumerator<T> GetEnumerator() => new Enumerator<T>(Array, FromJS);
+        public IEnumerator<T> GetEnumerator() => new Enumerator<T>(Value, FromJS);
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -109,12 +91,80 @@ public partial struct JSIterable
             {
                 if (disposing)
                 {
-                    _arrayReference.Dispose();
+                    _iterableReference.Dispose();
                 }
 
                 IsDisposed = true;
             }
         }
+    }
 
+    internal class Collection<T> : Enumerable<T>, ICollection<T>
+    {
+        private readonly Func<int> _getCount;
+
+        internal Collection(
+            JSValue iterable,
+            JSValue.To<T> fromJS,
+            Func<int> getCount) : base(iterable, fromJS)
+        {
+            _getCount = getCount;
+        }
+
+        public int Count => _getCount();
+
+        public bool IsReadOnly => true;
+
+        public bool Contains(T item)
+        {
+            foreach (T value in this)
+            {
+                if (value?.Equals(item) ?? item == null)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void CopyTo(T[] array, int arrayIndex) => throw new NotSupportedException();
+
+        public void Add(T item) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public bool Remove(T item) => throw new NotSupportedException();
+    }
+
+    public struct Collection : ICollection<JSValue>, IReadOnlyCollection<JSValue>
+    {
+        private JSIterable _iterable;
+        private Func<int> _getCount;
+
+        internal Collection(JSIterable iterable, Func<int> getCount)
+        {
+            _iterable = iterable;
+            _getCount = getCount;
+        }
+
+        public int Count => _getCount();
+
+        public bool IsReadOnly => true;
+
+        public IEnumerator<JSValue> GetEnumerator() => _iterable.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_iterable).GetEnumerator();
+
+        public bool Contains(JSValue item) => throw new NotImplementedException();
+
+        public void CopyTo(JSValue[] array, int arrayIndex)
+        {
+            int i = arrayIndex;
+            foreach (JSValue item in this)
+            {
+                array[i++] = item;
+            }
+        }
+
+        public void Add(JSValue item) => throw new NotSupportedException();
+        public bool Remove(JSValue item) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
     }
 }

--- a/Runtime/JSIterable.As.cs
+++ b/Runtime/JSIterable.As.cs
@@ -134,10 +134,10 @@ public partial struct JSIterable
         public bool Remove(T item) => throw new NotSupportedException();
     }
 
-    public struct Collection : ICollection<JSValue>, IReadOnlyCollection<JSValue>
+    public readonly struct Collection : ICollection<JSValue>, IReadOnlyCollection<JSValue>
     {
-        private JSIterable _iterable;
-        private Func<int> _getCount;
+        private readonly JSIterable _iterable;
+        private readonly Func<int> _getCount;
 
         internal Collection(JSIterable iterable, Func<int> getCount)
         {

--- a/Runtime/JSIterable.Proxy.cs
+++ b/Runtime/JSIterable.Proxy.cs
@@ -110,13 +110,13 @@ public partial struct JSIterable
         };
     }
 
-    private static JSValue ProxyGet<T>(
+    internal static JSValue ProxyGet<T>(
         IEnumerable<T> enumerable,
         JSObject target,
         JSValue property,
         JSValue.From<T> toJS)
     {
-        if (IsIteratorSymbol(property) ||
+        if (((JSValue)JSSymbol.Iterator).StrictEquals(property) ||
             (property.IsString() && (string)property == "values"))
         {
             return CreateIteratorFunction(enumerable, toJS);
@@ -125,17 +125,7 @@ public partial struct JSIterable
         return target[property];
     }
 
-    private static JSValue GetIteratorSymbol()
-    {
-        return JSValue.Global["Symbol"]["iterator"];
-    }
-
-    private static bool IsIteratorSymbol(JSValue value)
-    {
-        return GetIteratorSymbol().StrictEquals(value);
-    }
-
-    private static JSValue CreateIteratorFunction<T>(
+    internal static JSValue CreateIteratorFunction<T>(
         IEnumerable<T> enumerable,
         JSValue.From<T> toJS)
     {
@@ -144,7 +134,7 @@ public partial struct JSIterable
             IEnumerator<T> enumerator = enumerable.GetEnumerator();
             JSObject iterator = new();
             iterator.DefineProperties(
-                JSPropertyDescriptor.Function(GetIteratorSymbol(), (args) =>
+                JSPropertyDescriptor.Function(JSSymbol.Iterator, (args) =>
                 {
                     // The iterator is also iterable.
                     return args.ThisArg;

--- a/Runtime/JSIterable.cs
+++ b/Runtime/JSIterable.cs
@@ -29,6 +29,19 @@ public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSV
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSIterable a, JSIterable b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSIterable a, JSIterable b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)
@@ -41,4 +54,6 @@ public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSV
         throw new NotSupportedException(
             "Hashing JS values is not supported. Use JSSet or JSMap instead.");
     }
+
+    public static bool operator ==()
 }

--- a/Runtime/JSIterable.cs
+++ b/Runtime/JSIterable.cs
@@ -54,6 +54,4 @@ public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSV
         throw new NotSupportedException(
             "Hashing JS values is not supported. Use JSSet or JSMap instead.");
     }
-
-    public static bool operator ==()
 }

--- a/Runtime/JSIterable.cs
+++ b/Runtime/JSIterable.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NodeApi;
 
-public readonly partial struct JSIterable : IEnumerable<JSValue>
+public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSValue>
 {
     private readonly JSValue _value;
 
@@ -26,4 +28,17 @@ public readonly partial struct JSIterable : IEnumerable<JSValue>
     IEnumerator<JSValue> IEnumerable<JSValue>.GetEnumerator() => GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
 }

--- a/Runtime/JSMap.As.cs
+++ b/Runtime/JSMap.As.cs
@@ -174,6 +174,6 @@ public partial struct JSMap
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
             => TryGetValue(item.Key, out TValue? value) &&
-                (item.Value?.Equals(value) ?? value == null) ? Remove(item.Key) : false;
+                (item.Value?.Equals(value) ?? value == null) && Remove(item.Key);
     }
 }

--- a/Runtime/JSMap.As.cs
+++ b/Runtime/JSMap.As.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NodeApi;
+
+public partial struct JSMap
+{
+    /// <summary>
+    /// Creates a read-only dictionary adapter for a JS Map object, without copying.
+    /// </summary>
+    public IReadOnlyDictionary<TKey, TValue> AsReadOnlyDictionary<TKey, TValue>(
+        JSValue.To<TKey> keyFromJS,
+        JSValue.To<TValue> valueFromJS,
+        JSValue.From<TKey> keyToJS) =>
+        new ReadOnlyDictionary<TKey, TValue>(_value, keyFromJS, valueFromJS, keyToJS);
+
+    /// <summary>
+    /// Creates a dictionary adapter for a JS Map object, without copying.
+    /// </summary>
+    public IDictionary<TKey, TValue> AsDictionary<TKey, TValue>(
+        JSValue.To<TKey> keyFromJS,
+        JSValue.To<TValue> valueFromJS,
+        JSValue.From<TKey> keyToJS,
+        JSValue.From<TValue> valueToJS) =>
+        new Dictionary<TKey, TValue>(_value, keyFromJS, valueFromJS, keyToJS, valueToJS);
+
+    internal class ReadOnlyDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+    {
+        internal ReadOnlyDictionary(
+            JSValue map,
+            JSValue.To<TKey> keyFromJS,
+            JSValue.To<TValue> valueFromJS,
+            JSValue.From<TKey> keyToJS)
+        {
+            _mapReference = new JSReference(map);
+            KeyFromJS = keyFromJS;
+            ValueFromJS = valueFromJS;
+            KeyToJS = keyToJS;
+        }
+
+        private readonly JSReference _mapReference;
+
+        protected internal JSValue Value => _mapReference.GetValue()!.Value;
+
+        protected JSValue.To<TKey> KeyFromJS { get; }
+        protected JSValue.To<TValue> ValueFromJS { get; }
+        protected JSValue.From<TKey> KeyToJS { get; }
+
+        public int Count => (int)Value["size"];
+
+        public IEnumerable<TKey> Keys
+            => ((JSIterable)Value["keys"]).AsEnumerable<TKey>(KeyFromJS);
+
+        public IEnumerable<TValue> Values
+            => ((JSIterable)Value["values"]).AsEnumerable<TValue>(ValueFromJS);
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                JSValue value = Value.CallMethod("get", KeyToJS(key));
+                if (value.IsUndefined())
+                {
+                    throw new KeyNotFoundException();
+                }
+                return ValueFromJS(value);
+            }
+        }
+
+        public bool ContainsKey(TKey key) => (bool)Value.CallMethod("has", KeyToJS(key));
+
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+        {
+            JSValue jsValue = Value.CallMethod("get", KeyToJS(key));
+            if (jsValue.IsUndefined())
+            {
+                value = default;
+                return false;
+            }
+            value = ValueFromJS(jsValue);
+            return true;
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            foreach (KeyValuePair<JSValue, JSValue> pair in (JSMap)Value)
+            {
+                yield return new KeyValuePair<TKey, TValue>(
+                    KeyFromJS(pair.Key), ValueFromJS(pair.Value));
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    internal class Dictionary<TKey, TValue> :
+        ReadOnlyDictionary<TKey, TValue>,
+        IDictionary<TKey, TValue>
+    {
+        internal Dictionary(
+            JSValue map,
+            JSValue.To<TKey> keyFromJS,
+            JSValue.To<TValue> valueFromJS,
+            JSValue.From<TKey> keyToJS,
+            JSValue.From<TValue> valueToJS)
+            : base(map, keyFromJS, valueFromJS, keyToJS)
+        {
+            ValueToJS = valueToJS;
+        }
+
+        public new TValue this[TKey key]
+        {
+            get
+            {
+                JSValue value = Value.CallMethod("get", KeyToJS(key));
+                if (value.IsUndefined())
+                {
+                    throw new KeyNotFoundException();
+                }
+                return ValueFromJS(value);
+            }
+            set
+            {
+                Value.CallMethod("set", KeyToJS(key), ValueToJS(value));
+            }
+        }
+
+        protected JSValue.From<TValue> ValueToJS { get; }
+
+        private int GetCount() => Count;
+
+        public void Add(TKey key, TValue value)
+        {
+            if (ContainsKey(key))
+            {
+                throw new ArgumentException("An item with the same key already exists.");
+            }
+
+            this[key] = value;
+        }
+
+        public bool Remove(TKey key) => (bool)Value.CallMethod("delete", KeyToJS(key));
+
+        public void Clear() => Value.CallMethod("clear");
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys
+            => new JSIterable.Collection<TKey>(
+                (JSIterable)Value["keys"], KeyFromJS, GetCount);
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values
+            => new JSIterable.Collection<TValue>(
+                (JSIterable)Value["values"], ValueFromJS, GetCount);
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+            => Add(item.Key, item.Value);
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+            => TryGetValue(item.Key, out TValue? value) &&
+                (item.Value?.Equals(value) ?? value == null);
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(
+            KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            int i = arrayIndex;
+            foreach (KeyValuePair<TKey, TValue> pair in this)
+            {
+                array[i++] = pair;
+            }
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+            => TryGetValue(item.Key, out TValue? value) &&
+                (item.Value?.Equals(value) ?? value == null) ? Remove(item.Key) : false;
+    }
+}

--- a/Runtime/JSMap.Enumerator.cs
+++ b/Runtime/JSMap.Enumerator.cs
@@ -1,16 +1,17 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace NodeApi;
 
-public partial struct JSIterable
+public partial struct JSMap
 {
-    public struct Enumerator : IEnumerator<JSValue>, IEnumerator
+    public struct Enumerator :
+        IEnumerator<KeyValuePair<JSValue, JSValue>>,
+        System.Collections.IEnumerator
     {
         private readonly JSValue _iterable;
         private JSValue _iterator;
-        private JSValue? _current;
+        private KeyValuePair<JSValue, JSValue>? _current;
 
         internal Enumerator(JSValue iterable)
         {
@@ -30,17 +31,18 @@ public partial struct JSIterable
             }
             else
             {
-                _current = nextResult["value"];
+                JSArray currentEntry = (JSArray)nextResult["value"];
+                _current = new KeyValuePair<JSValue, JSValue>(currentEntry[0], currentEntry[1]);
                 return true;
             }
         }
 
-        public JSValue Current
+        public KeyValuePair<JSValue, JSValue> Current
             => _current ?? throw new InvalidOperationException("Unexpected enumerator state");
 
-        object? IEnumerator.Current => Current;
+        object? System.Collections.IEnumerator.Current => Current;
 
-        void IEnumerator.Reset()
+        void System.Collections.IEnumerator.Reset()
         {
             _iterator = _iterable.CallMethod(JSSymbol.Iterator);
             _current = default;
@@ -51,4 +53,3 @@ public partial struct JSIterable
         }
     }
 }
-

--- a/Runtime/JSMap.Proxy.cs
+++ b/Runtime/JSMap.Proxy.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+
+namespace NodeApi;
+
+public partial struct JSMap
+{
+    /// <summary>
+    /// Creates a proxy handler for a proxy that wraps an
+    /// <see cref="IReadOnlyDictionary{TKey, TValue}"/> as a JS Map.
+    /// </summary>
+    /// <remarks>
+    /// The same handler may be used by multiple <see cref="JSProxy"/> instances, for more
+    /// efficient creation of proxies.
+    /// </remarks>
+    public static JSProxy.Handler CreateProxyHandlerForReadOnlyDictionary<TKey, TValue>(
+        JSContext context,
+        JSValue.From<TKey> keyToJS,
+        JSValue.From<TValue> valueToJS,
+        JSValue.To<TKey> keyFromJS)
+    {
+        return new JSProxy.Handler(
+            context,
+            $"{nameof(IReadOnlyDictionary<TKey, TValue>)}<{typeof(TKey).Name}, {typeof(TValue).Name}>")
+        {
+            Get = (JSObject target, JSValue property, JSObject receiver) =>
+            {
+                IReadOnlyDictionary<TKey, TValue> dictionary =
+                    target.Unwrap<IReadOnlyDictionary<TKey, TValue>>();
+
+                if (property.IsString())
+                {
+                    string propertyName = (string)property;
+                    if (propertyName == "size")
+                    {
+                        return dictionary.Count;
+                    }
+                    else if (propertyName == "has")
+                    {
+                        return JSValue.CreateFunction("has", (args) =>
+                        {
+                            return dictionary.ContainsKey(keyFromJS(args[0]));
+                        });
+                    }
+                    else if (propertyName == "get")
+                    {
+                        return JSValue.CreateFunction("get", (args) =>
+                        {
+                            return dictionary.TryGetValue(keyFromJS(args[0]), out TValue? value) ?
+                                valueToJS(value!) : JSValue.Undefined;
+                        });
+                    }
+
+                    // TODO: More Map methods: keys(), values(), forEach()
+                }
+
+                return ProxyIterableGet(dictionary, target, property, keyToJS, valueToJS);
+            },
+        };
+    }
+
+    /// <summary>
+    /// Creates a proxy handler for a proxy that wraps an <see cref="IDictionary{TKey, TValue}"/>
+    /// as a JS Map.
+    /// </summary>
+    /// <remarks>
+    /// The same handler may be used by multiple <see cref="JSProxy"/> instances, for more
+    /// efficient creation of proxies.
+    /// </remarks>
+    public static JSProxy.Handler CreateProxyHandlerForDictionary<TKey, TValue>(
+        JSContext context,
+        JSValue.From<TKey> keyToJS,
+        JSValue.From<TValue> valueToJS,
+        JSValue.To<TKey> keyFromJS,
+        JSValue.To<TValue> valueFromJS)
+    {
+        return new JSProxy.Handler(
+            context, $"{nameof(IDictionary<TKey, TValue>)}<{typeof(TKey).Name}, {typeof(TValue).Name}>")
+        {
+            Get = (JSObject target, JSValue property, JSObject receiver) =>
+            {
+                IDictionary<TKey, TValue> dictionary = target.Unwrap<IDictionary<TKey, TValue>>();
+
+                if (property.IsString())
+                {
+                    string propertyName = (string)property;
+                    switch (propertyName)
+                    {
+                        case "size":
+                            return dictionary.Count;
+
+                        case "has":
+                            return JSValue.CreateFunction("has", (args) =>
+                            {
+                                return dictionary.ContainsKey(keyFromJS(args[0]));
+                            });
+                        case "get":
+                            return JSValue.CreateFunction("get", (args) =>
+                            {
+                                return dictionary.TryGetValue(keyFromJS(args[0]), out TValue? value) ?
+                                    valueToJS(value!) : JSValue.Undefined;
+                            });
+                        case "set":
+                            return JSValue.CreateFunction("set", (args) =>
+                            {
+                                dictionary.Add(keyFromJS(args[0]), valueFromJS(args[1]));
+                                return target;
+                            });
+                        case "delete":
+                            return JSValue.CreateFunction("delete", (args) =>
+                            {
+                                return dictionary.Remove(keyFromJS(args[0]));
+                            });
+                        case "clear":
+                            return JSValue.CreateFunction("clear", (args) =>
+                            {
+                                dictionary.Clear();
+                                return JSValue.Undefined;
+                            });
+
+                        // TODO: More Map methods: keys(), values(), forEach()
+                    }
+                }
+
+                return ProxyIterableGet(dictionary, target, property, keyToJS, valueToJS);
+            },
+        };
+    }
+
+    private static JSValue ProxyIterableGet<TKey, TValue>(
+        IEnumerable<KeyValuePair<TKey, TValue>> enumerable,
+        JSObject target,
+        JSValue property,
+        JSValue.From<TKey> keyToJS,
+        JSValue.From<TValue> valueToJS)
+    {
+        if (((JSValue)JSSymbol.Iterator).StrictEquals(property) ||
+            (property.IsString() && (string)property == "entries"))
+        {
+            return JSIterable.CreateIteratorFunction(enumerable, (pair) =>
+            {
+                JSArray jsPair = new JSArray(2);
+                jsPair[0] = keyToJS(pair.Key);
+                jsPair[1] = valueToJS(pair.Value);
+                return jsPair;
+            });
+        }
+
+        return target[property];
+    }
+}
+

--- a/Runtime/JSMap.Proxy.cs
+++ b/Runtime/JSMap.Proxy.cs
@@ -117,7 +117,7 @@ public partial struct JSMap
                                 return JSValue.Undefined;
                             });
 
-                        // TODO: More Map methods: keys(), values(), forEach()
+                            // TODO: More Map methods: keys(), values(), forEach()
                     }
                 }
 
@@ -138,9 +138,11 @@ public partial struct JSMap
         {
             return JSIterable.CreateIteratorFunction(enumerable, (pair) =>
             {
-                JSArray jsPair = new JSArray(2);
-                jsPair[0] = keyToJS(pair.Key);
-                jsPair[1] = valueToJS(pair.Value);
+                JSArray jsPair = new(2)
+                {
+                    [0] = keyToJS(pair.Key),
+                    [1] = valueToJS(pair.Value)
+                };
                 return jsPair;
             });
         }

--- a/Runtime/JSMap.cs
+++ b/Runtime/JSMap.cs
@@ -67,9 +67,9 @@ public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable
         return !value.IsUndefined();
     }
 
-    public JSIterable.Collection Keys => new JSIterable.Collection((JSIterable)_value["keys"], GetCount);
+    public JSIterable.Collection Keys => new((JSIterable)_value["keys"], GetCount);
 
-    public JSIterable.Collection Values => new JSIterable.Collection((JSIterable)_value["values"], GetCount);
+    public JSIterable.Collection Values => new((JSIterable)_value["values"], GetCount);
 
     private int GetCount() => Count;
 
@@ -104,8 +104,21 @@ public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable
     }
 
     bool ICollection<KeyValuePair<JSValue, JSValue>>.Remove(KeyValuePair<JSValue, JSValue> item)
-        => TryGetValue(item.Key, out JSValue value) && item.Value.Equals(value) ? Remove(item.Key) : false;
+        => TryGetValue(item.Key, out JSValue value) && item.Value.Equals(value) && Remove(item.Key);
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSMap a, JSMap b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSMap a, JSMap b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/Runtime/JSMap.cs
+++ b/Runtime/JSMap.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NodeApi;
+
+public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable<JSValue>
+{
+    private readonly JSValue _value;
+
+    public static explicit operator JSMap(JSValue value) => new(value);
+    public static implicit operator JSValue(JSMap map) => map._value;
+
+    public static explicit operator JSMap(JSObject obj) => (JSMap)(JSValue)obj;
+    public static implicit operator JSObject(JSMap map) => (JSObject)map._value;
+
+    private JSMap(JSValue value)
+    {
+        _value = value;
+    }
+
+    /// <summary>
+    /// Creates a new empty JS Map.
+    /// </summary>
+    public JSMap()
+    {
+        _value = JSValue.Global["Map"].CallAsConstructor();
+    }
+
+    /// <summary>
+    /// Creates a new JS Map with entries from an iterable (such as another map) whose elements
+    /// are key-value pairs.
+    /// </summary>
+    public JSMap(JSIterable iterable)
+    {
+        _value = JSValue.Global["Map"].CallAsConstructor(iterable);
+    }
+
+    public int Count => (int)_value["size"];
+
+    public Enumerator GetEnumerator() => new(_value);
+
+    IEnumerator<KeyValuePair<JSValue, JSValue>> IEnumerable<KeyValuePair<JSValue, JSValue>>.GetEnumerator() => GetEnumerator();
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public JSValue this[JSValue key]
+    {
+        get
+        {
+            JSValue value = _value.CallMethod("get", key);
+            if (value.IsUndefined())
+            {
+                throw new KeyNotFoundException();
+            }
+            return value;
+        }
+        set
+        {
+            _value.CallMethod("set", key, value);
+        }
+    }
+
+    public bool TryGetValue(JSValue key, [MaybeNullWhen(false)] out JSValue value)
+    {
+        value = _value.CallMethod("get", key);
+        return !value.IsUndefined();
+    }
+
+    public JSIterable.Collection Keys => new JSIterable.Collection((JSIterable)_value["keys"], GetCount);
+
+    public JSIterable.Collection Values => new JSIterable.Collection((JSIterable)_value["values"], GetCount);
+
+    private int GetCount() => Count;
+
+    public bool ContainsKey(JSValue key) => (bool)_value.CallMethod("has", key);
+
+    public void Add(JSValue key, JSValue value) => this[key] = value;
+
+    public bool Remove(JSValue key) => (bool)_value.CallMethod("delete", key);
+
+    public void Clear() => _value.CallMethod("clear");
+
+    ICollection<JSValue> IDictionary<JSValue, JSValue>.Keys => Keys;
+
+    ICollection<JSValue> IDictionary<JSValue, JSValue>.Values => Values;
+
+    bool ICollection<KeyValuePair<JSValue, JSValue>>.IsReadOnly => false;
+
+    void ICollection<KeyValuePair<JSValue, JSValue>>.Add(KeyValuePair<JSValue, JSValue> item)
+        => Add(item.Key, item.Value);
+
+    bool ICollection<KeyValuePair<JSValue, JSValue>>.Contains(KeyValuePair<JSValue, JSValue> item)
+        => TryGetValue(item.Key, out JSValue value) && item.Value.Equals(value);
+
+    void ICollection<KeyValuePair<JSValue, JSValue>>.CopyTo(
+        KeyValuePair<JSValue, JSValue>[] array, int arrayIndex)
+    {
+        int i = arrayIndex;
+        foreach (KeyValuePair<JSValue, JSValue> pair in this)
+        {
+            array[i++] = pair;
+        }
+    }
+
+    bool ICollection<KeyValuePair<JSValue, JSValue>>.Remove(KeyValuePair<JSValue, JSValue> item)
+        => TryGetValue(item.Key, out JSValue value) && item.Value.Equals(value) ? Remove(item.Key) : false;
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
+}

--- a/Runtime/JSNativeApi.cs
+++ b/Runtime/JSNativeApi.cs
@@ -300,7 +300,8 @@ public static partial class JSNativeApi
     public static int GetArrayLength(this JSValue thisValue)
         => napi_get_array_length(Env, (napi_value)thisValue, out uint result).ThrowIfFailed((int)result);
 
-    public static bool StrictEquals(this JSValue thisValue, JSValue other)
+    // Internal because JSValue structs all implement IEquatable<JSValue>, which calls this method.
+    internal static bool StrictEquals(this JSValue thisValue, JSValue other)
         => napi_strict_equals(Env, (napi_value)thisValue, (napi_value)other, out c_bool result).ThrowIfFailed((bool)result);
 
     public static unsafe JSValue Call(this JSValue thisValue)

--- a/Runtime/JSObject.cs
+++ b/Runtime/JSObject.cs
@@ -1,16 +1,13 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace NodeApi;
 
-public readonly partial struct JSObject : IDictionary<JSValue, JSValue>
+public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquatable<JSValue>
 {
     private readonly JSValue _value;
-
-    public int Count => throw new System.NotImplementedException();
-
-    public bool IsReadOnly => throw new System.NotImplementedException();
 
     public static explicit operator JSObject(JSValue value) => new(value);
     public static implicit operator JSValue(JSObject obj) => obj._value;
@@ -23,6 +20,11 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>
     public JSObject() : this(JSValue.CreateObject())
     {
     }
+
+    int ICollection<KeyValuePair<JSValue, JSValue>>.Count
+        => _value.GetPropertyNames().GetArrayLength();
+
+    bool ICollection<KeyValuePair<JSValue, JSValue>>.IsReadOnly => false;
 
     public void DefineProperties(params JSPropertyDescriptor[] descriptors)
     {
@@ -82,14 +84,10 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>
 
     public void CopyTo(KeyValuePair<JSValue, JSValue>[] array, int arrayIndex)
     {
-        int index = arrayIndex;
-        int maxIndex = array.Length - 1;
-        foreach (KeyValuePair<JSValue, JSValue> entry in this)
+        int i = arrayIndex;
+        foreach (KeyValuePair<JSValue, JSValue> item in this)
         {
-            if (index <= maxIndex)
-            {
-                array[index] = entry;
-            }
+            array[i++] = item;
         }
     }
 
@@ -97,13 +95,27 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>
 
     public Enumerator GetEnumerator() => new(_value);
 
-    ICollection<JSValue> IDictionary<JSValue, JSValue>.Keys => throw new System.NotImplementedException();
+    ICollection<JSValue> IDictionary<JSValue, JSValue>.Keys => (JSArray)_value.GetPropertyNames();
 
-    ICollection<JSValue> IDictionary<JSValue, JSValue>.Values => throw new System.NotImplementedException();
+    ICollection<JSValue> IDictionary<JSValue, JSValue>.Values => throw new NotSupportedException();
 
-    void ICollection<KeyValuePair<JSValue, JSValue>>.Clear() => throw new System.NotImplementedException();
+    void ICollection<KeyValuePair<JSValue, JSValue>>.Clear() => throw new NotSupportedException();
 
-    IEnumerator<KeyValuePair<JSValue, JSValue>> IEnumerable<KeyValuePair<JSValue, JSValue>>.GetEnumerator() => GetEnumerator();
+    IEnumerator<KeyValuePair<JSValue, JSValue>> IEnumerable<KeyValuePair<JSValue, JSValue>>.GetEnumerator()
+        => GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
 }

--- a/Runtime/JSObject.cs
+++ b/Runtime/JSObject.cs
@@ -106,6 +106,19 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquata
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSObject a, JSObject b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSObject a, JSObject b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/Runtime/JSProxy.cs
+++ b/Runtime/JSProxy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace NodeApi;
@@ -7,7 +8,7 @@ namespace NodeApi;
 /// <summary>
 /// Enables creation of JS Proxy objects with C# handler callbacks.
 /// </summary>
-public readonly partial struct JSProxy
+public readonly partial struct JSProxy : IEquatable<JSValue>
 {
     private readonly JSValue _value;
     private readonly JSValue _revoke;
@@ -268,5 +269,18 @@ public readonly partial struct JSProxy
         {
             return $"{nameof(JSProxy)}.{nameof(Handler)} \"{Name}\"";
         }
+    }
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
     }
 }

--- a/Runtime/JSProxy.cs
+++ b/Runtime/JSProxy.cs
@@ -271,6 +271,19 @@ public readonly partial struct JSProxy : IEquatable<JSValue>
         }
     }
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSProxy a, JSProxy b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSProxy a, JSProxy b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/Runtime/JSSet.As.cs
+++ b/Runtime/JSSet.As.cs
@@ -119,14 +119,4 @@ public partial struct JSSet
             return Count > countBeforeAdd;
         }
     }
-
-    public static bool operator ==(JSSet left, JSSet right)
-    {
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(JSSet left, JSSet right)
-    {
-        return !(left == right);
-    }
 }

--- a/Runtime/JSSet.As.cs
+++ b/Runtime/JSSet.As.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+
+namespace NodeApi;
+
+public partial struct JSSet
+{
+    /// <summary>
+    /// Creates an enumerable adapter for a JS Set object, without copying.
+    /// </summary>
+    public IEnumerable<T> AsEnumerable<T>(JSValue.To<T> fromJS)
+        => new JSIterable.Enumerable<T>(_value, fromJS);
+
+    /// <summary>
+    /// Creates a read-only collection adapter for a JS Set object, without copying.
+    /// </summary>
+    public IReadOnlyCollection<T> AsReadOnlyCollection<T>(JSValue.To<T> fromJS) =>
+        new ReadOnlyCollection<T>(_value, fromJS);
+
+    /// <summary>
+    /// Creates a collection adapter for a JS Set object, without copying.
+    /// </summary>
+    public ICollection<T> AsCollection<T>(JSValue.To<T> fromJS, JSValue.From<T> toJS) =>
+        new Collection<T>(_value, fromJS, toJS);
+
+    /// <summary>
+    /// Creates a read-only set adapter for a JS Set object, without copying.
+    /// </summary>
+    public IReadOnlySet<T> AsReadOnlySet<T>(JSValue.To<T> fromJS, JSValue.From<T> toJS) =>
+        new ReadOnlySet<T>(_value, fromJS, toJS);
+
+    /// <summary>
+    /// Creates a set adapter for a JS Set object, without copying.
+    /// </summary>
+    public ISet<T> AsSet<T>(JSValue.To<T> fromJS, JSValue.From<T> toJS) =>
+        new Set<T>(_value, fromJS, toJS);
+
+    internal class ReadOnlyCollection<T> : JSIterable.Enumerable<T>, IReadOnlyCollection<T>
+    {
+        internal ReadOnlyCollection(JSValue value, JSValue.To<T> fromJS) : base(value, fromJS)
+        {
+        }
+
+        public int Count => (int)Value["size"];
+    }
+
+    internal class Collection<T> : ReadOnlyCollection<T>, ICollection<T>
+    {
+        internal Collection(JSValue value, JSValue.To<T> fromJS, JSValue.From<T> toJS)
+            : base(value, fromJS)
+        {
+            ToJS = toJS;
+        }
+
+        protected JSValue.From<T> ToJS { get; }
+
+        bool ICollection<T>.IsReadOnly => false;
+
+        public void Add(T item) => Value.CallMethod("add", ToJS(item));
+
+        public void Clear() => Value.CallMethod("clear");
+
+        public bool Contains(T item) => (bool)Value.CallMethod("has", ToJS(item));
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            int i = arrayIndex;
+            foreach (T item in this)
+            {
+                array[i++] = item;
+            }
+        }
+
+        public bool Remove(T item) => (bool)Value.CallMethod("delete", ToJS(item));
+    }
+
+    internal class ReadOnlySet<T> : ReadOnlyCollection<T>, IReadOnlySet<T>
+    {
+        internal ReadOnlySet(JSValue value, JSValue.To<T> fromJS, JSValue.From<T> toJS)
+            : base(value, fromJS)
+        {
+            ToJS = toJS;
+        }
+
+        protected JSValue.From<T> ToJS { get; }
+
+        public bool Contains(T item) => (bool)Value.CallMethod("has", ToJS(item));
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool IsProperSupersetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool IsSubsetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool IsSupersetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool Overlaps(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool SetEquals(IEnumerable<T> other) => throw new NotImplementedException();
+    }
+
+    internal class Set<T> : Collection<T>, ISet<T>
+    {
+        internal Set(JSValue value, JSValue.To<T> fromJS, JSValue.From<T> toJS)
+            : base(value, fromJS, toJS)
+        {
+        }
+
+        public void ExceptWith(IEnumerable<T> other) => throw new NotImplementedException();
+        public void IntersectWith(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool IsProperSubsetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool IsProperSupersetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool IsSubsetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool IsSupersetOf(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool Overlaps(IEnumerable<T> other) => throw new NotImplementedException();
+        public bool SetEquals(IEnumerable<T> other) => throw new NotImplementedException();
+        public void SymmetricExceptWith(IEnumerable<T> other) => throw new NotImplementedException();
+        public void UnionWith(IEnumerable<T> other) => throw new NotImplementedException();
+
+        public new bool Add(T item)
+        {
+            int countBeforeAdd = Count;
+            Value.CallMethod("add", ToJS(item));
+            return Count > countBeforeAdd;
+        }
+    }
+}

--- a/Runtime/JSSet.As.cs
+++ b/Runtime/JSSet.As.cs
@@ -119,4 +119,14 @@ public partial struct JSSet
             return Count > countBeforeAdd;
         }
     }
+
+    public static bool operator ==(JSSet left, JSSet right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(JSSet left, JSSet right)
+    {
+        return !(left == right);
+    }
 }

--- a/Runtime/JSSet.Proxy.cs
+++ b/Runtime/JSSet.Proxy.cs
@@ -97,7 +97,7 @@ public partial struct JSSet
                                 return JSValue.Undefined;
                             });
 
-                        // TODO: More Set methods: keys(), entries(), forEach()
+                            // TODO: More Set methods: keys(), entries(), forEach()
                     }
                 }
 

--- a/Runtime/JSSet.Proxy.cs
+++ b/Runtime/JSSet.Proxy.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+
+namespace NodeApi;
+
+public partial struct JSSet
+{
+    /// <summary>
+    /// Creates a proxy handler for a proxy that wraps an <see cref="IReadOnlySet{T}"/>
+    /// as a JS Set.
+    /// </summary>
+    /// <remarks>
+    /// The same handler may be used by multiple <see cref="JSProxy"/> instances, for more
+    /// efficient creation of proxies.
+    /// </remarks>
+    public static JSProxy.Handler CreateProxyHandlerForReadOnlySet<T>(
+        JSContext context,
+        JSValue.From<T> toJS,
+        JSValue.To<T> fromJS)
+    {
+        return new JSProxy.Handler(
+            context, $"{nameof(IReadOnlySet<T>)}<{typeof(T).Name}>")
+        {
+            Get = (JSObject target, JSValue property, JSObject receiver) =>
+            {
+                IReadOnlySet<T> set = target.Unwrap<IReadOnlySet<T>>();
+
+                if (property.IsString())
+                {
+                    string propertyName = (string)property;
+                    if (propertyName == "size")
+                    {
+                        return set.Count;
+                    }
+                    else if (propertyName == "has")
+                    {
+                        return JSValue.CreateFunction("has", (args) =>
+                        {
+                            return set.Contains(fromJS(args[0]));
+                        });
+                    }
+
+                    // TODO: More Set methods: keys(), entries(), forEach()
+                }
+
+                return JSIterable.ProxyGet(set, target, property, toJS);
+            },
+        };
+    }
+
+    /// <summary>
+    /// Creates a proxy handler for a proxy that wraps an <see cref="ISet{T}"/>
+    /// as a JS Set.
+    /// </summary>
+    /// <remarks>
+    /// The same handler may be used by multiple <see cref="JSProxy"/> instances, for more
+    /// efficient creation of proxies.
+    /// </remarks>
+    public static JSProxy.Handler CreateProxyHandlerForSet<T>(
+        JSContext context,
+        JSValue.From<T> toJS,
+        JSValue.To<T> fromJS)
+    {
+        return new JSProxy.Handler(
+            context, $"{nameof(ISet<T>)}<{typeof(T).Name}>")
+        {
+            Get = (JSObject target, JSValue property, JSObject receiver) =>
+            {
+                ISet<T> set = target.Unwrap<ISet<T>>();
+
+                if (property.IsString())
+                {
+                    string propertyName = (string)property;
+                    switch (propertyName)
+                    {
+                        case "size":
+                            return set.Count;
+
+                        case "has":
+                            return JSValue.CreateFunction("has", (args) =>
+                            {
+                                return set.Contains(fromJS(args[0]));
+                            });
+                        case "add":
+                            return JSValue.CreateFunction("add", (args) =>
+                            {
+                                return set.Add(fromJS(args[0]));
+                            });
+                        case "delete":
+                            return JSValue.CreateFunction("delete", (args) =>
+                            {
+                                return set.Remove(fromJS(args[0]));
+                            });
+                        case "clear":
+                            return JSValue.CreateFunction("clear", (args) =>
+                            {
+                                set.Clear();
+                                return JSValue.Undefined;
+                            });
+
+                        // TODO: More Set methods: keys(), entries(), forEach()
+                    }
+                }
+
+                return JSIterable.ProxyGet(set, target, property, toJS);
+            },
+        };
+    }
+}
+

--- a/Runtime/JSSet.cs
+++ b/Runtime/JSSet.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace NodeApi;
+
+public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
+{
+    private readonly JSValue _value;
+
+    public static explicit operator JSSet(JSValue value) => new(value);
+    public static implicit operator JSValue(JSSet set) => set._value;
+
+    public static explicit operator JSSet(JSObject obj) => (JSSet)(JSValue)obj;
+    public static implicit operator JSObject(JSSet set) => (JSObject)set._value;
+
+    public static explicit operator JSSet(JSIterable obj) => (JSSet)(JSValue)obj;
+    public static implicit operator JSIterable(JSSet set) => (JSIterable)set._value;
+
+
+    private JSSet(JSValue value)
+    {
+        _value = value;
+    }
+
+    /// <summary>
+    /// Creates a new empty JS Set.
+    /// </summary>
+    public JSSet()
+    {
+        _value = JSValue.Global["Set"].CallAsConstructor();
+    }
+
+    /// <summary>
+    /// Creates a new JS Set with values from an iterable (such as another set).
+    /// </summary>
+    public JSSet(JSIterable iterable)
+    {
+        _value = JSValue.Global["Set"].CallAsConstructor(iterable);
+    }
+
+    public int Count => (int)_value["size"];
+
+    bool ICollection<JSValue>.IsReadOnly => false;
+
+    public JSIterable.Enumerator GetEnumerator() => new(_value);
+
+    IEnumerator<JSValue> IEnumerable<JSValue>.GetEnumerator() => GetEnumerator();
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public bool Add(JSValue item)
+    {
+        int countBeforeAdd = Count;
+        _value.CallMethod("add", item);
+        return Count > countBeforeAdd;
+    }
+
+    void ICollection<JSValue>.Add(JSValue item)
+    {
+        _value.CallMethod("add", item);
+    }
+
+    public bool Remove(JSValue item) => (bool)_value.CallMethod("delete", item);
+
+    public void Clear() => _value.CallMethod("clear");
+
+    public bool Contains(JSValue item) => (bool)_value.CallMethod("has", item);
+
+    public void CopyTo(JSValue[] array, int arrayIndex)
+    {
+        int i = arrayIndex;
+        foreach (JSValue item in this)
+        {
+            array[i++] = item;
+        }
+    }
+
+    public void ExceptWith(IEnumerable<JSValue> other)
+    {
+        foreach (JSValue item in other)
+        {
+            Remove(item);
+        }
+    }
+
+    public void IntersectWith(IEnumerable<JSValue> other)
+    {
+        List<JSValue> itemsToRemove = new List<JSValue>();
+        foreach (JSValue item in this)
+        {
+            if (!other.Contains(item))
+            {
+                itemsToRemove.Add(item);
+            }
+        }
+
+        foreach (JSValue item in itemsToRemove)
+        {
+            Remove(item);
+        }
+    }
+
+    public bool IsProperSubsetOf(IEnumerable<JSValue> other)
+    {
+        JSSet thisSet = this; // Required for anonymous lambda.
+        return IsSubsetOf(other) && other.Any((item) => !thisSet.Contains(item));
+    }
+
+    public bool IsProperSupersetOf(IEnumerable<JSValue> other)
+    {
+        if (!IsSupersetOf(other))
+        {
+            return false;
+        }
+
+        // Not using this.Any() to avoid boxing.
+        foreach (var item in this)
+        {
+            if (!other.Contains(item))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool IsSubsetOf(IEnumerable<JSValue> other)
+    {
+        // Not using this.All() to avoid boxing.
+        foreach (JSValue item in this)
+        {
+            if (!other.Contains(item))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public bool IsSupersetOf(IEnumerable<JSValue> other)
+    {
+        JSSet thisSet = this; // Required for anonymous lambda.
+        return other.All((item) => thisSet.Contains(item));
+    }
+
+    public bool Overlaps(IEnumerable<JSValue> other)
+    {
+        JSSet thisSet = this; // Required for anonymous lambda.
+        return other.Any((item) => thisSet.Contains(item));
+    }
+
+    public bool SetEquals(IEnumerable<JSValue> other)
+        => IsSubsetOf(other) && IsSupersetOf(other);
+
+    public void SymmetricExceptWith(IEnumerable<JSValue> other)
+    {
+        foreach (JSValue item in other)
+        {
+            if (!Remove(item))
+            {
+                Add(item);
+            }
+        }
+    }
+
+    public void UnionWith(IEnumerable<JSValue> other)
+    {
+        foreach (JSValue item in other)
+        {
+            _value.CallMethod("add", item);
+        }
+    }
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
+}

--- a/Runtime/JSSet.cs
+++ b/Runtime/JSSet.cs
@@ -87,7 +87,7 @@ public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
 
     public void IntersectWith(IEnumerable<JSValue> other)
     {
-        List<JSValue> itemsToRemove = new List<JSValue>();
+        List<JSValue> itemsToRemove = new();
         foreach (JSValue item in this)
         {
             if (!other.Contains(item))
@@ -116,7 +116,7 @@ public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
         }
 
         // Not using this.Any() to avoid boxing.
-        foreach (var item in this)
+        foreach (JSValue item in this)
         {
             if (!other.Contains(item))
             {
@@ -174,6 +174,19 @@ public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
         }
     }
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSSet a, JSSet b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSSet a, JSSet b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/Runtime/JSSymbol.cs
+++ b/Runtime/JSSymbol.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NodeApi;
+
+public readonly struct JSSymbol : IEquatable<JSValue>
+{
+    private readonly JSValue _value;
+
+    private static readonly Lazy<JSReference> _iteratorSymbol =
+        new(new JSReference(JSValue.Global["Symbol"]["iterator"]));
+
+    public static explicit operator JSSymbol(JSValue value) => new(value);
+    public static implicit operator JSValue(JSSymbol symbol) => symbol._value;
+
+    private JSSymbol(JSValue value)
+    {
+        _value = value;
+    }
+
+    public JSSymbol(string? description = null)
+    {
+        _value = JSValue.CreateSymbol(description ?? JSValue.Undefined);
+    }
+
+    public static JSSymbol For(ReadOnlySpan<byte> utf8Name)
+    {
+        return new JSSymbol(JSValue.SymbolFor(utf8Name));
+    }
+
+    public static JSSymbol Iterator => (JSSymbol)_iteratorSymbol.Value.GetValue()!;
+
+    // TODO: Add static properties for other well-known symbols.
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
+}

--- a/Runtime/JSSymbol.cs
+++ b/Runtime/JSSymbol.cs
@@ -7,7 +7,7 @@ public readonly struct JSSymbol : IEquatable<JSValue>
 {
     private readonly JSValue _value;
 
-    private static readonly Lazy<JSReference> _iteratorSymbol =
+    private static readonly Lazy<JSReference> s_iteratorSymbol =
         new(new JSReference(JSValue.Global["Symbol"]["iterator"]));
 
     public static explicit operator JSSymbol(JSValue value) => new(value);
@@ -28,10 +28,23 @@ public readonly struct JSSymbol : IEquatable<JSValue>
         return new JSSymbol(JSValue.SymbolFor(utf8Name));
     }
 
-    public static JSSymbol Iterator => (JSSymbol)_iteratorSymbol.Value.GetValue()!;
+    public static JSSymbol Iterator => (JSSymbol)s_iteratorSymbol.Value.GetValue()!;
 
     // TODO: Add static properties for other well-known symbols.
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSSymbol a, JSSymbol b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSSymbol a, JSSymbol b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/Runtime/JSTypedArray.cs
+++ b/Runtime/JSTypedArray.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace NodeApi;
 
-public readonly struct JSTypedArray<T> where T : struct
+public readonly struct JSTypedArray<T> : IEquatable<JSValue> where T : struct
 {
     private readonly JSValue _value;
 
@@ -135,6 +136,20 @@ public readonly struct JSTypedArray<T> where T : struct
     }
 
     public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
+
+
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
 
     /// <summary>
     /// Gets the typed-array values as memory, without copying.

--- a/Runtime/JSTypedArray.cs
+++ b/Runtime/JSTypedArray.cs
@@ -138,6 +138,19 @@ public readonly struct JSTypedArray<T> : IEquatable<JSValue> where T : struct
     public Span<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
 
 
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSTypedArray<T> a, JSTypedArray<T> b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSTypedArray<T> a, JSTypedArray<T> b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/Runtime/JSValue.cs
+++ b/Runtime/JSValue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
 using static NodeApi.JSNativeApi;
@@ -6,7 +7,7 @@ using static NodeApi.JSNativeApi.Interop;
 
 namespace NodeApi;
 
-public readonly struct JSValue
+public readonly struct JSValue : IEquatable<JSValue>
 {
     private readonly napi_value _handle;
     private readonly JSValueScope? _scope;
@@ -314,4 +315,30 @@ public readonly struct JSValue
     /// Delegate that provides a conversion from a JS value to some type.
     /// </summary>
     public delegate T To<T>(JSValue value);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSValue a, JSValue b) => a.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSValue a, JSValue b) => !a.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public bool Equals(JSValue other) => this.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
 }

--- a/Test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/Test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -35,6 +35,10 @@ public static class ComplexTypes
 
     public static IReadOnlyList<int> ReadOnlyList { get; set; } = new List<int>().AsReadOnly();
 
+    public static ISet<int> Set { get; set; } = new HashSet<int>();
+
+    public static IReadOnlySet<int> ReadOnlySet { get; set; } = new HashSet<int>();
+
     public static IDictionary<int, string> Dictionary { get; set; } = new Dictionary<int, string>();
 
     public static IReadOnlyDictionary<int, string> ReadOnlyDictionary { get; set; }

--- a/Test/TestCases/napi-dotnet/complex_types.js
+++ b/Test/TestCases/napi-dotnet/complex_types.js
@@ -117,3 +117,36 @@ assert.strictEqual(ComplexTypes.list[0], 0);
 const listValue2 = ComplexTypes.list;
 ComplexTypes.list[0] = 1;
 assert.strictEqual(listValue2[0], 1);
+
+// C# ISet<T> maps to/from JS Set<T> (without copying).
+const setValue = ComplexTypes.set;
+assert(setValue instanceof Set);
+assert.strictEqual(setValue.size, 0);
+assert.strictEqual(ComplexTypes.set, setValue);
+ComplexTypes.set = new Set([0, 1, 2]);
+assert.notStrictEqual(ComplexTypes.set, setValue);
+assert.strictEqual(ComplexTypes.set.size, 3);
+assert(ComplexTypes.set.has(1));
+const setValue2 = ComplexTypes.set;
+ComplexTypes.set.add(3);
+assert(setValue2.has(3));
+const setEnumerableResult = [];
+for (let value of setValue2) setEnumerableResult.push(value);
+assert.deepStrictEqual(setEnumerableResult, [0, 1, 2, 3]);
+
+// C# IDictionary<TKey, TValue> maps to/from JS Map<TKey, TValue> (without copying).
+const mapValue = ComplexTypes.dictionary;
+assert(mapValue instanceof Map);
+assert.strictEqual(mapValue.size, 0);
+assert.strictEqual(ComplexTypes.dictionary, mapValue);
+ComplexTypes.dictionary = new Map([[0, 'zero'], [1, 'one'], [2, 'two']]);
+assert.notStrictEqual(ComplexTypes.dictionary, mapValue);
+assert.strictEqual(ComplexTypes.dictionary.size, 3);
+assert(ComplexTypes.dictionary.has(1));
+const mapValue2 = ComplexTypes.dictionary;
+ComplexTypes.dictionary.set(3, 'three');
+ComplexTypes.dictionary.delete(0);
+assert.strictEqual(mapValue2.get(3), 'three');
+const mapEnumerableResult = [];
+for (let value of mapValue2) mapEnumerableResult.push(value);
+assert.deepStrictEqual(mapEnumerableResult, [[1, 'one'], [2, 'two'], [3, 'three']]);

--- a/Test/TestCases/node-addon-api/basic_types/value.cs
+++ b/Test/TestCases/node-addon-api/basic_types/value.cs
@@ -23,7 +23,7 @@ public class TestBasicTypesValue : TestHelper, ITestObject
     private static JSValue ToString(JSCallbackArgs args) => args[0].CoerceToString();
     private static JSValue ToObject(JSCallbackArgs args) => args[0].CoerceToObject();
 
-    private static JSValue StrictlyEquals(JSCallbackArgs args) => args[0].StrictEquals(args[1]);
+    private static JSValue StrictlyEquals(JSCallbackArgs args) => args[0].Equals(args[1]);
 
     // Helper methods
     private static JSValue CreateDefaultValue(JSCallbackArgs _) => default;


### PR DESCRIPTION
 - Add `JSSet` type with 2-way proxy/adapter code.
 - Add `JSMap` type with 2-way proxy/adapter code.
 - Add `JSSymbol` type. Cache a reference to the iterator symbol that is used by collection proxies.
 - Implement `IEquatable<JSValue>` in all JS value types.
 - Improve formatting of generated code so that it doesn't form super long lines.
