### PR TITLE
Perf comparison

### DIFF
--- a/Test/TestCases/edgejs-perf/Edge.Performance.cs
+++ b/Test/TestCases/edgejs-perf/Edge.Performance.cs
@@ -1,0 +1,53 @@
+// Ported from https://github.com/agracio/edge-js/blob/master/performance/performance.cs
+
+using System;
+using NodeApi;
+
+
+namespace Edge.Performance
+{
+    [JSExport]
+    public static class Startup
+    {
+        public static Book Invoke(Book input)
+        {
+            var book = new Book
+            {
+                Title = "Run .NET and node.js in-process with edge.js",
+                Author = new Person
+                {
+                    First = "Anonymous",
+                    Last = "Author"
+                },
+                Year = 2013,
+                Price = 24.99,
+                Available = true,
+                Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus posuere tincidunt felis, et mattis mauris ultrices quis. Cras molestie, quam varius tincidunt tincidunt, mi magna imperdiet lacus, quis elementum ante nibh quis orci. In posuere erat sed tellus lacinia luctus. Praesent sodales tellus mauris, et egestas justo. In blandit, metus non congue adipiscing, est orci luctus odio, non sagittis erat orci ac sapien. Proin ut est id enim mattis volutpat. Vivamus ultrices dapibus feugiat. In dictum tincidunt eros, non pretium nisi rhoncus in. Duis a lacus et elit feugiat ullamcorper. Mauris tempor turpis nulla. Nullam nec facilisis elit.",
+                Picture = new byte[16000],
+                Tags = new[] { ".NET", "node.js", "CLR", "V8", "interop" },
+            };
+
+            return book;
+        }
+    }
+
+    [JSExport]
+    public struct Book
+    {
+        public string Title { get; set; }
+        public Person Author { get; set; }
+        public int Year { get; set; }
+        public double Price { get; set; }
+        public bool Available { get; set; }
+        public string Description { get; set; }
+        public Memory<byte> Picture { get; set; }
+        public string[] Tags { get; set; }
+    }
+
+    [JSExport]
+    public struct Person
+    {
+        public string First { get; set; }
+        public string Last { get; set; }
+    }
+}

--- a/Test/TestCases/edgejs-perf/Edge.Performance.cs
+++ b/Test/TestCases/edgejs-perf/Edge.Performance.cs
@@ -3,6 +3,7 @@
 using System;
 using NodeApi;
 
+#pragma warning disable IDE0060 // Unused parameter 'input'
 
 namespace Edge.Performance
 {

--- a/Test/TestCases/edgejs-perf/measure-latency.js
+++ b/Test/TestCases/edgejs-perf/measure-latency.js
@@ -1,5 +1,9 @@
 // Ported from https://github.com/agracio/edge-js/blob/master/performance/marshal_clr2v8.js
 
+// If using the test runner, the measurement results can be found in:
+// out/obj\$(Configuration)\TestCases\edgejs-perf\hosted-measure-latency.log
+// out/obj\$(Configuration)\TestCases\edgejs-perf\aot-measure-latency.log
+
 // Load the addon module, using either hosted or native AOT mode.
 const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
 const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];

--- a/Test/TestCases/edgejs-perf/measure-latency.js
+++ b/Test/TestCases/edgejs-perf/measure-latency.js
@@ -1,0 +1,50 @@
+// Ported from https://github.com/agracio/edge-js/blob/master/performance/marshal_clr2v8.js
+
+// Load the addon module, using either hosted or native AOT mode.
+const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
+const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
+
+/** @type {import('./edgejs-perf')} */
+const binding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
+
+const callCount = process.env.EDGE_CALL_COUNT || 100000;
+
+const measure = function (func) {
+	var start = Date.now();
+	var i = 0;
+
+	function one() {
+		func({
+			title: 'Run .NET and node.js in-process with edge.js',
+			author: {
+				first: 'Anonymous',
+				last: 'Author'
+			},
+			year: 2013,
+			price: 24.99,
+			available: true,
+			description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus posuere tincidunt felis, et mattis mauris ultrices quis. Cras molestie, quam varius tincidunt tincidunt, mi magna imperdiet lacus, quis elementum ante nibh quis orci. In posuere erat sed tellus lacinia luctus. Praesent sodales tellus mauris, et egestas justo. In blandit, metus non congue adipiscing, est orci luctus odio, non sagittis erat orci ac sapien. Proin ut est id enim mattis volutpat. Vivamus ultrices dapibus feugiat. In dictum tincidunt eros, non pretium nisi rhoncus in. Duis a lacus et elit feugiat ullamcorper. Mauris tempor turpis nulla. Nullam nec facilisis elit.',
+			picture: Buffer.alloc(16000),
+			tags: [ '.NET', 'node.js', 'CLR', 'V8', 'interop']
+		}, function (error, callbck) {
+			if (error) throw error;
+			if (++i < callCount) setImmediate(one);
+			else finish();
+		});
+	}
+
+	function finish() {
+		var delta = Date.now() - start;
+		var result = process.memoryUsage();
+		result.latency = delta / callCount;
+		console.log(result);
+	}
+
+	one();
+};
+
+const invoke = binding.Startup.invoke;
+measure((input, callback) => {
+  const result = invoke(input);
+  callback(null, result);
+});

--- a/Test/TestCases/edgejs-perf/measure-latency.js
+++ b/Test/TestCases/edgejs-perf/measure-latency.js
@@ -11,7 +11,7 @@ const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
 /** @type {import('./edgejs-perf')} */
 const binding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
 
-const callCount = process.env.EDGE_CALL_COUNT || 100000;
+const callCount = process.env.EDGE_CALL_COUNT || 10000;
 
 const measure = function (func) {
 	var start = Date.now();


### PR DESCRIPTION
I ported the perf measurement script from `edge-js`, and took some measurements using release builds. Numbers are microseconds per function call, averaged over 100,000 iterations.

| Run #          | js-baseline | edge-js | napi-clr | napi-aot |
|--------------|-----------|---------|---------|----------|
| 1                 | 16.78       | 92.67   | 52.9     | 51.93 |
| 2                 | 16.37       | 95.84   | 53.34    | 51.77 |
| 3                 | 15.78       | 87.93   | 49.67    | 48.65 |
| 4                 | 16.24       | 95.13   | 51.97    | 48.70 |
| 5                 | 15.31       | 95.09   | 49.51    | 48.53 |
| average      | 16.10      | 93.33  | 51.48  | 49.92 |


| | Relative performance | 
|------------------------|------|
| edge-js/baseline  | 579.8%      | 
| napi-aot/baseline | 310.1%      | 
| napi-aot/edge-js  | 53.5%       |
| napi-clr/napi-aot | 97.2%       | 

Interpretation
 - The edge-js/baseline ratio is consistent with the "6x" difference [reported in the original Edge project](https://github.com/tjanczuk/edge/wiki/Performance).
 - `napi-dotnet` is about twice as fast as edge-js, or 3x slower than plain in-engine JS function calls, in this scenario.
 - The `napi-dotnet` AOT compiled build is consistently about 3% faster than the CLR build. I'd expect a greater difference for a smaller number of iterations, since AOT has the biggest impact on startup time.
 - I'd expect more advanced scenarios to show a larger advantage for `napi-dotnet` because it supports shared-memory typed-arrays and marshalling classes by reference, whereas edge-js serializes everything.