### PR TITLE
Dynamic load & invoke with emitted marshaling code

### DIFF
--- a/Runtime/Hosting/AssemblyExporter.cs
+++ b/Runtime/Hosting/AssemblyExporter.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace NodeApi.Hosting;
+
+using static ManagedHost;
+
+[RequiresUnreferencedCode("Managed host is not used in trimmed assembly.")]
+[RequiresDynamicCode("Managed host is not used in trimmed assembly.")]
+internal class AssemblyExporter
+{
+    private readonly JSReference _assemblyObject;
+    private readonly Dictionary<Type, JSReference> _typeObjects = new();
+    private readonly AssemblyBuilder _assemblyBuilder;
+    private readonly ModuleBuilder _moduleBuilder;
+
+    public AssemblyExporter(Assembly assembly)
+    {
+        Assembly = assembly;
+        _assemblyObject = new JSReference(ExportAssembly());
+        _assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("JS." + assembly.FullName),
+            AssemblyBuilderAccess.Run);
+        _moduleBuilder = _assemblyBuilder.DefineDynamicModule("JS");
+    }
+
+    public Assembly Assembly { get; }
+
+    public JSValue AssemblyObject => _assemblyObject.GetValue()!.Value;
+
+    private JSValue ExportAssembly()
+    {
+        Trace($"> AssemblyExporter.ExportAssembly({Assembly.FullName})");
+
+        // Reflect over public types in the loaded assembly.
+        // Define a property for each type, with a getter that lazily defines the class.
+
+        List<JSPropertyDescriptor> assemblyProperties = new();
+        void AddAssemblyTypeProperty(Type type, Func<Type, JSValue> getter)
+        {
+            assemblyProperties.Add(JSPropertyDescriptor.Accessor(
+                type.FullName!,
+                (_) => getter(type),
+                setter: null,
+                JSPropertyAttributes.Enumerable));
+        }
+
+        foreach (var type in Assembly.GetTypes().Where((t) => t.IsPublic))
+        {
+            if (type.IsClass)
+            {
+                if (type.IsAbstract && type.IsSealed) // static class
+                {
+                    AddAssemblyTypeProperty(type, ExportStaticClass);
+                }
+                else
+                {
+                    AddAssemblyTypeProperty(type, ExportClass);
+                }
+            }
+            else if (type.IsValueType)
+            {
+                if (type.IsEnum)
+                {
+                    AddAssemblyTypeProperty(type, ExportEnum);
+                }
+                else
+                {
+                    AddAssemblyTypeProperty(type, ExportStruct);
+                }
+            }
+        }
+
+        JSObject assemblyObject = new JSObject();
+        assemblyObject.DefineProperties(assemblyProperties);
+
+        Trace($"< AssemblyExporter.ExportAssembly() => [{assemblyProperties.Count}]");
+        return assemblyObject;
+    }
+
+    private JSValue ExportStaticClass(Type classType)
+    {
+        Trace($"> AssemblyExporter.ExportStaticClass({classType.FullName})");
+
+        if (_typeObjects.TryGetValue(classType, out JSReference? typeObjectReference))
+        {
+            Trace($"< AssemblyExporter.ExportStaticClass() => already exported");
+            return typeObjectReference!.GetValue()!.Value;
+        }
+
+        TypeBuilder typeBuilder = _moduleBuilder.DefineType(classType.FullName!.Replace(".", "_"));
+        List<JSPropertyDescriptor> classProperties = new();
+
+        foreach (var member in classType.GetMembers(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (member is MethodInfo method && !method.IsSpecialName)
+            {
+                EmitStaticMethod(typeBuilder, method);
+            }
+            else if (member is PropertyInfo property)
+            {
+                if (property.GetMethod?.IsPublic == true)
+                {
+                    EmitStaticPropertyGet(typeBuilder, property);
+                }
+                if (property.SetMethod?.IsPublic == true)
+                {
+                    EmitStaticPropertySet(typeBuilder, property);
+                }
+            }
+        }
+
+        Type builtType = typeBuilder.CreateType();
+
+        var attributes = JSPropertyAttributes.Enumerable | JSPropertyAttributes.Configurable;
+        foreach (var member in classType.GetMembers(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (member is MethodInfo method && !method.IsSpecialName)
+            {
+                MethodInfo builtMethod = builtType.GetMethod(method.Name)!;
+                var methodDelegate = (JSCallback)builtMethod.CreateDelegate(typeof(JSCallback));
+                classProperties.Add(JSPropertyDescriptor.Function(
+                    member.Name,
+                    methodDelegate,
+                    attributes));
+            }
+            else if (member is PropertyInfo property)
+            {
+                /*
+                JSCallback? getterDelegate = null;
+                if (property.GetMethod != null)
+                {
+                    MethodInfo builtGetMethod = builtType.GetMethod(property.GetMethod.Name)!;
+                    getterDelegate = (JSCallback)builtGetMethod.CreateDelegate(typeof(JSCallback));
+                }
+
+                JSCallback? setterDelegate = null;
+                if (property.SetMethod != null)
+                {
+                    MethodInfo builtSetMethod = builtType.GetMethod(property.SetMethod.Name)!;
+                    setterDelegate = (JSCallback)builtSetMethod.CreateDelegate(typeof(JSCallback));
+                }
+
+                classProperties.Add(JSPropertyDescriptor.Accessor(
+                    member.Name,
+                    getterDelegate,
+                    setterDelegate,
+                    attributes));
+                */
+            }
+        }
+
+        JSObject staticClassObject = new();
+        staticClassObject.DefineProperties(classProperties);
+
+        Trace($"< AssemblyExporter.ExportStaticClass() => [{classProperties.Count}]");
+        return staticClassObject;
+    }
+
+    private JSValue ExportClass(Type classType)
+    {
+        if (_typeObjects.TryGetValue(classType, out JSReference? typeObjectReference))
+        {
+            return typeObjectReference!.GetValue()!.Value;
+        }
+
+        // TODO: Emit static and instance property and method adapter methods,
+        // then define the class.
+
+        return new JSObject();
+    }
+
+    private JSValue ExportStruct(Type structType)
+    {
+        if (_typeObjects.TryGetValue(structType, out JSReference? typeObjectReference))
+        {
+            return typeObjectReference!.GetValue()!.Value;
+        }
+
+        // TODO: Export struct proeprties and methods.
+
+        return new JSObject();
+    }
+
+    private JSValue ExportEnum(Type enumType)
+    {
+        if (_typeObjects.TryGetValue(enumType, out JSReference? typeObjectReference))
+        {
+            return typeObjectReference!.GetValue()!.Value;
+        }
+
+        // TODO: Export enum values as properties on an object.
+
+        return new JSObject();
+    }
+
+    private void EmitStaticMethod(TypeBuilder typeBuilder, MethodInfo method)
+    {
+        MethodBuilder methodBuilder = typeBuilder.DefineMethod(
+            method.Name,
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.Final,
+            returnType: typeof(JSValue),
+            parameterTypes: new[] { typeof(JSCallbackArgs) });
+        ILGenerator il = methodBuilder.GetILGenerator();
+
+        /*
+         * private static JSValue MethodClass_MethodName(JSCallbackArgs __args)
+         * {
+         *     var param0Name = (Param0Type)__args[0];
+         *     ...
+         *     var __result = MethodClass.MethodName(param0, ...);
+         *     return (JSValue)__result;
+         * }
+         */
+
+        var parameters = method.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            il.DeclareLocal(parameters[i].ParameterType);
+        }
+
+        il.Emit(OpCodes.Nop);
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            EmitLoadAndConvertArg(il, argumentIndex: i, parameters[i].ParameterType, localIndex: i);
+        }
+
+        // Load all the local vars onto the stack.
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            il.Emit(OpCodes.Ldloc, i);
+        }
+        il.Emit(OpCodes.Call, method); // Call the target (static) method!
+
+        EmitConvertAndReturnResult(il, method.ReturnType);
+    }
+
+    private void EmitStaticPropertyGet(TypeBuilder typeBuilder, PropertyInfo property)
+    {
+        // TODO
+    }
+
+    private void EmitStaticPropertySet(TypeBuilder typeBuilder, PropertyInfo property)
+    {
+        // TODO
+    }
+
+    private static void EmitLoadAndConvertArg(
+        ILGenerator il,
+        int argumentIndex,
+        Type parameterType,
+        int localIndex)
+    {
+        il.Emit(OpCodes.Ldarg_0);  // Callback args
+        il.Emit(OpCodes.Ldc_I4, argumentIndex);
+
+        // This is a 'callvirt' opcode instead of 'call' because it's a class instance method.
+        // If JSCallbackArgs changes to a struct, this should be 'call'.
+        Debug.Assert(!typeof(JSCallbackArgs).IsValueType);
+        il.Emit(OpCodes.Callvirt, s_getCallbackArg); // Get args[i]
+
+        EmitConvertTo(il, parameterType); // Convert from JSValue to arg type
+        il.Emit(OpCodes.Stloc, localIndex); // Store result in local var [i]
+    }
+
+    private static void EmitConvertAndReturnResult(ILGenerator il, Type returnType)
+    {
+        if (returnType == typeof(void))
+        {
+            il.Emit(OpCodes.Call, s_getUndefined);
+        }
+        else
+        {
+            EmitConvertFrom(il, returnType);
+        }
+
+        il.Emit(OpCodes.Ret);
+    }
+
+    private static void EmitConvertTo(ILGenerator il, Type toType)
+    {
+        EmitCastTo(il, toType);
+
+        // TODO: Emit code for more conversions beyond simple casts.
+    }
+
+    private static void EmitCastTo(ILGenerator il, Type toType)
+    {
+        MethodInfo? castMethod =
+            typeof(JSValue).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where((m) => m.Name == "op_Explicit" && m.ReturnType == toType &&
+                m.GetParameters().Length == 1 &&
+                m.GetParameters()[0].ParameterType == typeof(JSValue))
+            .SingleOrDefault();
+        if (castMethod == null)
+        {
+            throw new NotSupportedException($"Cannot cast to {toType.Name} from JSValue.");
+        }
+
+        il.Emit(OpCodes.Call, castMethod);
+    }
+
+    private static void EmitConvertFrom(ILGenerator il, Type fromType)
+    {
+        EmitCastFrom(il, fromType);
+
+        // TODO: Emit code for more conversions beyond simple casts.
+    }
+
+    private static void EmitCastFrom(ILGenerator il, Type fromType)
+    {
+        MethodInfo? castMethod =
+            typeof(JSValue).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where((m) => m.Name == "op_Implicit" && m.ReturnType == typeof(JSValue) &&
+                m.GetParameters().Length == 1 &&
+                m.GetParameters()[0].ParameterType == fromType)
+            .SingleOrDefault();
+        if (castMethod == null)
+        {
+            throw new NotSupportedException($"Cannot cast from {fromType.Name} to JSValue.");
+        }
+
+        il.Emit(OpCodes.Call, castMethod);
+    }
+
+    private static readonly MethodInfo s_getUndefined =
+        typeof(JSValue).GetMethod("get_Undefined")!;
+
+    private static readonly MethodInfo s_getCallbackArg =
+        typeof(JSCallbackArgs).GetMethod("get_Item")!;
+}

--- a/Runtime/Hosting/ManagedHost.cs
+++ b/Runtime/Hosting/ManagedHost.cs
@@ -56,7 +56,7 @@ public sealed class ManagedHost : IDisposable
             var exportsValue = new JSValue(exports, scope);
             new JSModuleBuilder<ManagedHost>()
                 .AddMethod("require", (host) => host.LoadModule)
-                .AddMethod("loadAssembly", (host) => host.LoadAssembly)
+                .AddMethod("load", (host) => host.LoadAssembly)
                 .ExportModule(new ManagedHost(), (JSObject)exportsValue);
         }
         catch (Exception ex)

--- a/Runtime/JSObject.cs
+++ b/Runtime/JSObject.cs
@@ -31,6 +31,11 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquata
         _value.DefineProperties(descriptors);
     }
 
+    public void DefineProperties(IReadOnlyCollection<JSPropertyDescriptor> descriptors)
+    {
+        _value.DefineProperties(descriptors);
+    }
+
     public JSObject Wrap(object target)
     {
         JSNativeApi.Wrap(_value, target);

--- a/Test/NativeAotTests.cs
+++ b/Test/NativeAotTests.cs
@@ -12,7 +12,8 @@ public class NativeAotTests
 {
     private static readonly Dictionary<string, string?> s_builtTestModules = new();
 
-    public static IEnumerable<object[]> TestCases { get; } = ListTestCases();
+    public static IEnumerable<object[]> TestCases { get; } = ListTestCases(
+        (testCaseName) => !testCaseName.Contains("/assembly_"));
 
     [Theory]
     [MemberData(nameof(TestCases))]

--- a/Test/TestBuilder.cs
+++ b/Test/TestBuilder.cs
@@ -88,7 +88,7 @@ internal static class TestBuilder
         return testCasesDir;
     }
 
-    public static IEnumerable<object[]> ListTestCases()
+    public static IEnumerable<object[]> ListTestCases(Predicate<string>? filter = null)
     {
         var dirQueue = new Queue<string>();
         dirQueue.Enqueue(TestCasesDirectory);
@@ -113,7 +113,10 @@ internal static class TestBuilder
             {
                 if (jsFile.EndsWith(".d.ts")) continue;
                 string testCaseName = Path.GetFileNameWithoutExtension(jsFile);
-                yield return new[] { moduleName + "/" + testCaseName };
+                if (filter == null || filter(moduleName + "/" + testCaseName))
+                {
+                    yield return new[] { moduleName + "/" + testCaseName };
+                }
             }
         }
     }

--- a/Test/TestCases/napi-dotnet/assembly_load.js
+++ b/Test/TestCases/napi-dotnet/assembly_load.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+const dotnetHost = require(process.env.TEST_DOTNET_HOST_PATH);
+
+// There's a regular .NET assembly .dll file in the same directory as the test .node module.
+const dotnetAssemblyPath = process.env.TEST_DOTNET_MODULE_PATH.replace(/.node$/, 'dll');
+
+const assembly = dotnetHost.loadAssembly(dotnetAssemblyPath);
+console.dir(Object.keys(assembly)); // Print all public types in the loaded assembly.
+
+const Hello = assembly['NodeApi.TestCases.Hello'];
+console.dir(Object.keys(Hello)); // Print all public static members of the Hello class.
+
+const greeting = Hello.Test('assembly'); // Call a static method.
+assert.strictEqual(greeting, 'Hello assembly!');

--- a/Test/TestCases/napi-dotnet/assembly_load.js
+++ b/Test/TestCases/napi-dotnet/assembly_load.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
 
-const dotnetHost = require(process.env.TEST_DOTNET_HOST_PATH);
+const dotnet = require(process.env.TEST_DOTNET_HOST_PATH);
 
 // There's a regular .NET assembly .dll file in the same directory as the test .node module.
-const dotnetAssemblyPath = process.env.TEST_DOTNET_MODULE_PATH.replace(/.node$/, 'dll');
+const assemblyPath = process.env.TEST_DOTNET_MODULE_PATH.replace(/.node$/, 'dll');
 
-const assembly = dotnetHost.loadAssembly(dotnetAssemblyPath);
+const assembly = dotnet.load(assemblyPath);
 console.dir(Object.keys(assembly)); // Print all public types in the loaded assembly.
 
 const Hello = assembly['NodeApi.TestCases.Hello'];


### PR DESCRIPTION
This is an experiment / proof of concept for an alternative way of calling C# APIs from JS, that doesn't rely on source generation at the time the C# code is built. It uses reflection to scan the APIs but then _emits IL code_ for the JS marshaling layer. That means that while the initial load may be slower, subsequent API calls are just as fast as the source-generation approach.

So far it works only for the simplest case: invoking static methods with primitive parameter types. (See the `assembly_load.js` test case.) It does not yet support all the more complex marshaling scenarios handled by the source generator, but all that is possible.

I can imagine this approach being used in a few ways:
 1. You're writing some quick (non-type-checked) JavaScript and you need to invoke some .NET API. You can just load the assembly from a file path and start calling APIs in it:
```JavaScript
const dotnet = require('node-api-dotnet');
const assembly = dotnet.loadAssembly('path/to/ExampleAssembly.dll');
const ExampleClass = assembly['Namespace.ExampleClass'];
ExampleClass.ExampleMethod(...args);
```
 2. You're writing TypeScript (or JS with type-checking) and you want intellisense and type checking for .NET API calls. So you run the (future) Node API type-definitions generator tool on the .NET assembly, and that outputs a `.d.ts` file along with a small corresponding `.js` assembly loader that makes it possible to `import` the .NET library and use it naturally from TypeScript code:
```bash
$ node-api-ts-gen "path/to/ExampleAssembly.dll"
Generated ExampleAssembly.js
Generated ExampleAssembly.d.ts
```
```TypeScript
import { ExampleClass } from './ExampleAssembly';
ExampleClass.ExampleMethod(...args); // This is type-checked!
```
 3. Eventually, somebody might create an npm package feed (or scope in the global feed) that is full of pre-generated and packaged type definitions and loader scripts for popular .NET libraries:
```bash
npm install "@node-api-dotnet/ExampleAssembly"
```

I don't think dynamic emitting of IL marshaling code at runtime would completely replace the use of build-time source generation, since the latter is still more efficient for applications that are developing both C# and JS code together. Anyway it's much easier to implement marshaling logic in the source generator first, then look at the IL code compiled from that to inform development of the dynamic loader. (The **ILSpy** tool can show a nice view of decompiled C# with inline IL.) Also, source generation is the only approach compatible with AoT compilation, since neither reflection nor IL emitting is supported in that environment.