### PR TITLE
Optimize JS callbacks

### DIFF
--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -292,7 +292,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         s += "{";
         s += "using var scope = new JSValueScope(JSValueScopeType.Root, env);";
         s += "JSContext context = scope.ModuleContext;";
-        s += "JSValue exportsValue = new(scope, exports);";
+        s += "JSValue exportsValue = new(exports, env);";
         s++;
 
         AdapterGenerator adapterGenerator = new(Context);
@@ -311,8 +311,8 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
             string ns = GetNamespace(moduleInitializerMethod);
             string className = moduleInitializerMethod.ContainingType.Name;
             string methodName = moduleInitializerMethod.Name;
-            s += $"return {ns}.{className}.{methodName}(context, (JSObject)exportsValue)";
-            s += "\t.GetCheckedHandle();";
+            s += $"return (napi_value){ns}.{className}.{methodName}(";
+            s += "context, (JSObject)exportsValue);";
         }
         else
         {
@@ -320,7 +320,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
 
             ExportModule(ref s, moduleInitializer as ITypeSymbol, exportItems, adapterGenerator);
             s++;
-            s += "return exportsValue.GetCheckedHandle();";
+            s += "return (napi_value)exportsValue;";
         }
 
         s += "}";
@@ -518,20 +518,21 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         // if the method does not match the `JSCallback` signature.
         string? adapterName = adapterGenerator.GetMethodAdapterName(method);
         string attributes = "JSPropertyAttributes.DefaultMethod" +
-            (method.IsStatic ? "| JSPropertyAttributes.Static" : string.Empty);
+            (method.IsStatic ? " | JSPropertyAttributes.Static" : string.Empty);
         if (adapterName != null)
         {
-            s += $".AddMethod(\"{exportName}\", {adapterName},\n{attributes})";
+            s += $".AddMethod(\"{exportName}\", {adapterName},\n\t{attributes})";
         }
         else if (method.IsStatic)
         {
             string ns = GetNamespace(method);
             string className = method.ContainingType.Name;
-            s += $".AddMethod(\"{exportName}\", () => {ns}.{className}.{method.Name},\n{attributes})";
+            s += $".AddMethod(\"{exportName}\", " +
+                $"() => {ns}.{className}.{method.Name},\n\t{attributes})";
         }
         else
         {
-            s += $".AddMethod(\"{exportName}\", (obj) => obj.{method.Name},\n{attributes})";
+            s += $".AddMethod(\"{exportName}\", (obj) => obj.{method.Name},\n\t{attributes})";
         }
     }
 

--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -292,7 +292,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         s += "{";
         s += "using var scope = new JSValueScope(JSValueScopeType.Root, env);";
         s += "JSContext context = scope.ModuleContext;";
-        s += "JSValue exportsValue = new(exports, env);";
+        s += "JSValue exportsValue = new(exports, scope);";
         s++;
 
         AdapterGenerator adapterGenerator = new(Context);

--- a/Runtime/Hosting/ManagedHost.cs
+++ b/Runtime/Hosting/ManagedHost.cs
@@ -51,7 +51,7 @@ public class ManagedHost : IDisposable
                 e.Name.Split(',')[0] == nameof(NodeApi) ? nodeApiAssembly : null;
 
             using var scope = new JSValueScope(JSValueScopeType.Root, env);
-            var exportsValue = new JSValue(scope, exports);
+            var exportsValue = new JSValue(exports, scope);
             new JSModuleBuilder<ManagedHost>()
                 .AddMethod("require", (host) => host.LoadModule)
                 .AddMethod("loadAssembly", (host) => LoadAssembly)
@@ -115,11 +115,11 @@ public class ManagedHost : IDisposable
         JSValue exports = JSValue.CreateObject();
 
         var result = (napi_value?)initializeMethod.Invoke(
-            null, new object[] { (napi_env)args.Scope, (napi_value)exports });
+            null, new object[] { (napi_env)JSValueScope.Current, (napi_value)exports });
 
         if (result != null && result.Value != default)
         {
-            exports = new JSValue(args.Scope, result.Value);
+            exports = new JSValue(result.Value);
         }
 
         if (exports.IsObject())

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -48,7 +48,7 @@ internal partial class NativeHost : IDisposable
 
             // The managed host defined several properties/methods already.
             // Add on a dispose method implemented by the native host that closes the CLR context.
-            new JSValue(exports, env).DefineProperties(new JSPropertyDescriptor(
+            new JSValue(exports, scope).DefineProperties(new JSPropertyDescriptor(
                 nameof(NativeHost.Dispose),
                 (_) => { host.Dispose(); return default; }));
         }

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -3,7 +3,6 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using static NodeApi.Hosting.HostFxr;
 using static NodeApi.JSNativeApi.Interop;
 

--- a/Runtime/Hosting/NativeHost.cs
+++ b/Runtime/Hosting/NativeHost.cs
@@ -48,7 +48,7 @@ internal partial class NativeHost : IDisposable
 
             // The managed host defined several properties/methods already.
             // Add on a dispose method implemented by the native host that closes the CLR context.
-            new JSValue(scope, exports).DefineProperties(new JSPropertyDescriptor(
+            new JSValue(exports, env).DefineProperties(new JSPropertyDescriptor(
                 nameof(NativeHost.Dispose),
                 (_) => { host.Dispose(); return default; }));
         }

--- a/Runtime/JSCallback.cs
+++ b/Runtime/JSCallback.cs
@@ -1,3 +1,5 @@
 namespace NodeApi;
 
 public delegate JSValue JSCallback(JSCallbackArgs args);
+
+public delegate void JSCallbackAction(JSCallbackArgs args);

--- a/Runtime/JSCallbackArgs.cs
+++ b/Runtime/JSCallbackArgs.cs
@@ -1,51 +1,57 @@
+using System;
 using System.Runtime.InteropServices;
 using static NodeApi.JSNativeApi.Interop;
 
 namespace NodeApi;
 
-public class JSCallbackArgs
+public readonly ref struct JSCallbackArgs
 {
-    private readonly JSValue[] _args;
+    private readonly Span<JSValue> _args;
+
+    internal JSCallbackArgs(JSValue thisArg, Span<JSValue> args, object? data = null)
+    {
+        ThisArg = thisArg;
+        _args = args;
+        Data = data;
+    }
+
+    public JSValue ThisArg { get; }
 
     public JSValue this[int index] => _args[index];
 
     public int Length => _args.Length;
 
-    public JSValue ThisArg { get; }
+    public object? Data { get; }
 
-    public object? Data { get; set; }
-
-    public JSValue GetNewTarget()
+    internal static unsafe void GetDataAndLength(
+        napi_env scope,
+        napi_callback_info callbackInfo,
+        out object? data,
+        out int length)
     {
-        napi_get_new_target((napi_env)Scope, CallbackInfo, out napi_value result).ThrowIfFailed();
-        return result;
+        nuint argc = 0;
+        nint dataPointer;
+        napi_get_cb_info(scope, callbackInfo, &argc, null, null, &dataPointer)
+            .ThrowIfFailed();
+        data = dataPointer != 0 ? GCHandle.FromIntPtr(dataPointer).Target : null;
+        length = (int)argc;
     }
 
-    internal JSValueScope Scope { get; }
-
-    internal napi_callback_info CallbackInfo { get; }
-
-    public JSCallbackArgs(JSValueScope scope, napi_callback_info callbackInfo)
+    internal static unsafe void GetArgs(
+        napi_env scope,
+        napi_callback_info callbackInfo,
+        out JSValue thisArg,
+        ref Span<JSValue> args)
     {
-        Scope = scope;
-        CallbackInfo = callbackInfo;
-        unsafe
+        nuint argc = (nuint)args.Length;
+        napi_value* argv = stackalloc napi_value[args.Length];
+        napi_value thisArgHandle;
+        napi_get_cb_info(scope, callbackInfo, &argc, argv, &thisArgHandle, null)
+            .ThrowIfFailed();
+        for (int i = 0; i < args.Length; i++)
         {
-            nuint argc = 0;
-            napi_get_cb_info((napi_env)scope, callbackInfo, &argc, null, null, nint.Zero).ThrowIfFailed();
-            napi_value* argv = stackalloc napi_value[(int)argc];
-            napi_value thisArg;
-            nint data;
-            napi_get_cb_info((napi_env)scope, callbackInfo, &argc, argv, &thisArg, new nint(&data)).ThrowIfFailed();
-
-            _args = new JSValue[(int)argc];
-            for (int i = 0; i < (int)argc; ++i)
-            {
-                _args[i] = argv[i];
-            }
-
-            ThisArg = thisArg;
-            Data = data != nint.Zero ? GCHandle.FromIntPtr(data).Target : null;
+            args[i] = i < (int)argc ? new JSValue(argv[i], scope) : default;
         }
+        thisArg = new JSValue(thisArgHandle, scope);
     }
 }

--- a/Runtime/JSCallbackArgs.cs
+++ b/Runtime/JSCallbackArgs.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using static System.Formats.Asn1.AsnWriter;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 using static NodeApi.JSNativeApi.Interop;
 
 namespace NodeApi;
@@ -13,11 +11,11 @@ public readonly ref struct JSCallbackArgs
     private readonly ReadOnlySpan<napi_value> _args;
 
     internal unsafe JSCallbackArgs(JSValueScope scope,
-                                   napi_env env,
                                    napi_callback_info callbackInfo,
                                    Span<napi_value> args,
                                    object? data = null)                    
     {
+        napi_env env = (napi_env)scope;
         nint dataPointer;
         napi_value thisArgHandle;
         if (args.Length == 0)

--- a/Runtime/JSCallbackArgs.cs
+++ b/Runtime/JSCallbackArgs.cs
@@ -13,7 +13,7 @@ public readonly ref struct JSCallbackArgs
     internal unsafe JSCallbackArgs(JSValueScope scope,
                                    napi_callback_info callbackInfo,
                                    Span<napi_value> args,
-                                   object? data = null)                    
+                                   object? data = null)
     {
         napi_env env = (napi_env)scope;
         nint dataPointer;

--- a/Runtime/JSClassBuilderOfT.cs
+++ b/Runtime/JSClassBuilderOfT.cs
@@ -12,17 +12,20 @@ public class JSClassBuilder<T>
 
     public string ClassName { get; }
 
-    private readonly Func<T>? _constructor;
-    private readonly Func<JSCallbackArgs, T>? _constructorWithArgs;
+    public delegate T Constructor();
+    public delegate T ConstructorWithArgs(JSCallbackArgs args);
 
-    public JSClassBuilder(JSContext context, string className, Func<T>? constructor = null)
+    private readonly Constructor? _constructor;
+    private readonly ConstructorWithArgs? _constructorWithArgs;
+
+    public JSClassBuilder(JSContext context, string className, Constructor? constructor = null)
     {
         Context = context;
         ClassName = className;
         _constructor = constructor;
     }
 
-    public JSClassBuilder(JSContext context, string className, Func<JSCallbackArgs, T> constructor)
+    public JSClassBuilder(JSContext context, string className, ConstructorWithArgs constructor)
     {
         Context = context;
         ClassName = className;
@@ -96,6 +99,7 @@ public class JSClassBuilder<T>
 
         JSValue obj = JSValue.CreateObject();
         obj.DefineProperties(Properties.ToArray());
+        Context.RegisterStaticClass(ClassName, obj);
         return obj;
     }
 

--- a/Runtime/JSNativeApi.Interop.cs
+++ b/Runtime/JSNativeApi.Interop.cs
@@ -417,7 +417,7 @@ public static partial class JSNativeApi
         //     void** data)               // [out] Receives the data pointer for the callback.
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
         internal static unsafe partial napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
-          nuint* argc, napi_value* argv, napi_value* this_arg, nint data);
+          nuint* argc, napi_value* argv, napi_value* this_arg, nint* data);
 
         [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
         internal static partial napi_status napi_get_new_target(napi_env env, napi_callback_info cbinfo, out napi_value result);

--- a/Runtime/JSNativeApi.cs
+++ b/Runtime/JSNativeApi.cs
@@ -822,16 +822,16 @@ public static partial class JSNativeApi
     private static napi_env Env => (napi_env)JSValueScope.Current;
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-    internal static unsafe napi_value InvokeJSCallback(napi_env env, napi_callback_info callbackInfo)
+    internal static unsafe napi_value InvokeJSCallback(
+        napi_env env, napi_callback_info callbackInfo)
     {
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         try
         {
             JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
             Span<napi_value> args = stackalloc napi_value[length];
-            JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
             JSCallback callback = (JSCallback)data!;
-            return (napi_value)callback(new JSCallbackArgs(scope, thisArg, args));
+            return (napi_value)callback(new JSCallbackArgs(scope, env, callbackInfo, args));
         }
         catch (JSException ex)
         {
@@ -847,10 +847,9 @@ public static partial class JSNativeApi
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
         Span<napi_value> args = stackalloc napi_value[length];
-        JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
         return (napi_value)desc.Method!.Invoke(
-            new JSCallbackArgs(scope, thisArg, args, desc.Data));
+            new JSCallbackArgs(scope, env, callbackInfo, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -859,10 +858,9 @@ public static partial class JSNativeApi
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
         Span<napi_value> args = stackalloc napi_value[length];
-        JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
         return (napi_value)desc.Getter!.Invoke(
-            new JSCallbackArgs(scope, thisArg, args, desc.Data));
+            new JSCallbackArgs(scope, env, callbackInfo, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -871,10 +869,9 @@ public static partial class JSNativeApi
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
         Span<napi_value> args = stackalloc napi_value[length];
-        JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
         return (napi_value)desc.Setter!.Invoke(
-            new JSCallbackArgs(scope, thisArg, args, desc.Data));
+            new JSCallbackArgs(scope, env, callbackInfo, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/Runtime/JSNativeApi.cs
+++ b/Runtime/JSNativeApi.cs
@@ -827,9 +827,11 @@ public static partial class JSNativeApi
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         try
         {
-            JSCallbackArgs args = new(scope, callbackInfo);
-            JSCallback callback = (JSCallback)args.Data!;
-            return (napi_value)callback(args);
+            JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
+            Span<JSValue> args = stackalloc JSValue[length];
+            JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+            JSCallback callback = (JSCallback)data!;
+            return (napi_value)callback(new JSCallbackArgs(thisArg, args));
         }
         catch (JSException ex)
         {
@@ -843,30 +845,33 @@ public static partial class JSNativeApi
     private static unsafe napi_value InvokeJSMethod(napi_env env, napi_callback_info callbackInfo)
     {
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
-        JSCallbackArgs args = new(scope, callbackInfo);
-        JSPropertyDescriptor desc = (JSPropertyDescriptor)args.Data!;
-        args.Data = desc.Data;
-        return (napi_value)desc.Method!.Invoke(args);
+        JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
+        Span<JSValue> args = stackalloc JSValue[length];
+        JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+        JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
+        return (napi_value)desc.Method!.Invoke(new JSCallbackArgs(thisArg, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static unsafe napi_value InvokeJSGetter(napi_env env, napi_callback_info callbackInfo)
     {
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
-        JSCallbackArgs args = new(scope, callbackInfo);
-        JSPropertyDescriptor desc = (JSPropertyDescriptor)args.Data!;
-        args.Data = desc.Data;
-        return (napi_value)desc.Getter!.Invoke(args);
+        JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
+        Span<JSValue> args = stackalloc JSValue[length];
+        JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+        JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
+        return (napi_value)desc.Getter!.Invoke(new JSCallbackArgs(thisArg, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static unsafe napi_value InvokeJSSetter(napi_env env, napi_callback_info callbackInfo)
     {
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
-        JSCallbackArgs args = new(scope, callbackInfo);
-        JSPropertyDescriptor desc = (JSPropertyDescriptor)args.Data!;
-        args.Data = desc.Data;
-        return (napi_value)desc.Setter!.Invoke(args);
+        JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
+        Span<JSValue> args = stackalloc JSValue[length];
+        JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+        JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
+        return (napi_value)desc.Setter!.Invoke(new JSCallbackArgs(thisArg, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/Runtime/JSNativeApi.cs
+++ b/Runtime/JSNativeApi.cs
@@ -831,7 +831,7 @@ public static partial class JSNativeApi
             JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
             Span<napi_value> args = stackalloc napi_value[length];
             JSCallback callback = (JSCallback)data!;
-            return (napi_value)callback(new JSCallbackArgs(scope, env, callbackInfo, args));
+            return (napi_value)callback(new JSCallbackArgs(scope, callbackInfo, args));
         }
         catch (JSException ex)
         {
@@ -849,7 +849,7 @@ public static partial class JSNativeApi
         Span<napi_value> args = stackalloc napi_value[length];
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
         return (napi_value)desc.Method!.Invoke(
-            new JSCallbackArgs(scope, env, callbackInfo, args, desc.Data));
+            new JSCallbackArgs(scope, callbackInfo, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -860,7 +860,7 @@ public static partial class JSNativeApi
         Span<napi_value> args = stackalloc napi_value[length];
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
         return (napi_value)desc.Getter!.Invoke(
-            new JSCallbackArgs(scope, env, callbackInfo, args, desc.Data));
+            new JSCallbackArgs(scope, callbackInfo, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -871,7 +871,7 @@ public static partial class JSNativeApi
         Span<napi_value> args = stackalloc napi_value[length];
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
         return (napi_value)desc.Setter!.Invoke(
-            new JSCallbackArgs(scope, env, callbackInfo, args, desc.Data));
+            new JSCallbackArgs(scope, callbackInfo, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/Runtime/JSNativeApi.cs
+++ b/Runtime/JSNativeApi.cs
@@ -828,10 +828,10 @@ public static partial class JSNativeApi
         try
         {
             JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
-            Span<JSValue> args = stackalloc JSValue[length];
-            JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+            Span<napi_value> args = stackalloc napi_value[length];
+            JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
             JSCallback callback = (JSCallback)data!;
-            return (napi_value)callback(new JSCallbackArgs(thisArg, args));
+            return (napi_value)callback(new JSCallbackArgs(scope, thisArg, args));
         }
         catch (JSException ex)
         {
@@ -846,10 +846,11 @@ public static partial class JSNativeApi
     {
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
-        Span<JSValue> args = stackalloc JSValue[length];
-        JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+        Span<napi_value> args = stackalloc napi_value[length];
+        JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
-        return (napi_value)desc.Method!.Invoke(new JSCallbackArgs(thisArg, args, desc.Data));
+        return (napi_value)desc.Method!.Invoke(
+            new JSCallbackArgs(scope, thisArg, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -857,10 +858,11 @@ public static partial class JSNativeApi
     {
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
-        Span<JSValue> args = stackalloc JSValue[length];
-        JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+        Span<napi_value> args = stackalloc napi_value[length];
+        JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
-        return (napi_value)desc.Getter!.Invoke(new JSCallbackArgs(thisArg, args, desc.Data));
+        return (napi_value)desc.Getter!.Invoke(
+            new JSCallbackArgs(scope, thisArg, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -868,10 +870,11 @@ public static partial class JSNativeApi
     {
         using var scope = new JSValueScope(JSValueScopeType.Callback, env);
         JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
-        Span<JSValue> args = stackalloc JSValue[length];
-        JSCallbackArgs.GetArgs(env, callbackInfo, out JSValue thisArg, ref args);
+        Span<napi_value> args = stackalloc napi_value[length];
+        JSCallbackArgs.GetArgs(env, callbackInfo, out napi_value thisArg, ref args);
         JSPropertyDescriptor desc = (JSPropertyDescriptor)data!;
-        return (napi_value)desc.Setter!.Invoke(new JSCallbackArgs(thisArg, args, desc.Data));
+        return (napi_value)desc.Setter!.Invoke(
+            new JSCallbackArgs(scope, thisArg, args, desc.Data));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/Runtime/JSPromise.cs
+++ b/Runtime/JSPromise.cs
@@ -146,20 +146,23 @@ public readonly struct JSPromise : IEquatable<JSValue>
         public void Resolve(JSValue resolution)
         {
             // _handle becomes invalid after this call
-            napi_resolve_deferred((napi_env)resolution.Scope, _handle, (napi_value)resolution).ThrowIfFailed();
+            napi_resolve_deferred((napi_env)JSValueScope.Current, _handle, (napi_value)resolution)
+                .ThrowIfFailed();
         }
 
         public void Reject(JSValue rejection)
         {
             // _handle becomes invalid after this call
-            napi_resolve_deferred((napi_env)rejection.Scope, _handle, (napi_value)rejection).ThrowIfFailed();
+            napi_resolve_deferred((napi_env)JSValueScope.Current, _handle, (napi_value)rejection)
+                .ThrowIfFailed();
         }
 
         public void Reject(Exception ex)
         {
             // TODO: Create JSError type?
             JSValue error = JSValue.Global["Error"].CallAsConstructor(ex.Message);
-            napi_resolve_deferred((napi_env)JSValueScope.Current, _handle, error.GetCheckedHandle()).ThrowIfFailed();
+            napi_resolve_deferred((napi_env)JSValueScope.Current, _handle, (napi_value)error)
+                .ThrowIfFailed();
         }
     }
 }

--- a/Runtime/JSPropertyDescriptorListOfT.cs
+++ b/Runtime/JSPropertyDescriptorListOfT.cs
@@ -101,7 +101,7 @@ public abstract class JSPropertyDescriptorList<TDerived, TObject>
 
     public TDerived AddMethod(
       string name,
-      Func<TObject, Action<JSCallbackArgs>> getMethod,
+      Func<TObject, JSCallbackAction> getMethod,
       JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod)
     {
         return AddMethod(
@@ -148,7 +148,7 @@ public abstract class JSPropertyDescriptorList<TDerived, TObject>
 
     public TDerived AddMethod(
       string name,
-      Func<TObject, Func<JSCallbackArgs, JSValue>> getMethod,
+      Func<TObject, JSCallback> getMethod,
       JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod)
     {
         return AddMethod(
@@ -174,7 +174,7 @@ public abstract class JSPropertyDescriptorList<TDerived, TObject>
 
     public TDerived AddMethod(
       string name,
-      Func<Action<JSCallbackArgs>> getMethod,
+      Func<JSCallbackAction> getMethod,
       JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod | JSPropertyAttributes.Static)
     {
         return AddMethod(
@@ -200,7 +200,7 @@ public abstract class JSPropertyDescriptorList<TDerived, TObject>
 
     public TDerived AddMethod(
       string name,
-      Func<Func<JSCallbackArgs, JSValue>> getMethod,
+      Func<JSCallback> getMethod,
       JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod | JSPropertyAttributes.Static)
     {
         return AddMethod(

--- a/Runtime/JSValueScope.cs
+++ b/Runtime/JSValueScope.cs
@@ -95,7 +95,7 @@ public sealed class JSValueScope : IDisposable
             new napi_escapable_handle_scope(_scopeHandle),
             (napi_value)value,
             out napi_value result);
-        return new JSValue(_parentScope, result);
+        return new JSValue(result, _parentScope);
     }
 
     public static explicit operator napi_env(JSValueScope? scope)

--- a/Test/TestCases/napi-dotnet/AsyncMethods.cs
+++ b/Test/TestCases/napi-dotnet/AsyncMethods.cs
@@ -9,9 +9,9 @@ public static class AsyncMethods
     [JSExport("async_method")]
     public static JSValue JSTest(JSCallbackArgs args)
     {
+        string greeter = (string)args[0];
         return new JSPromise(async (resolve) =>
         {
-            string greeter = (string)args[0];
             await Task.Delay(50);
             resolve((JSValue)$"Hey {greeter}!");
         });


### PR DESCRIPTION
 - Change `JSCallbackArgs` from a `class` with heap-allocated args array to a `ref struct` with stack-allocated args span.
 - Fix an issue uncovered by the perf test (due to new timing or memory use patterns I guess?) in which the JS GC could collect the static class object that caused the `JSPropertyDescriptor` GC handle to be finalized even though JS code could still call the method afterward.

With these changes, performance on the edgejs scenario is 10-15% faster.