### PR TITLE
Dynamic binding to .NET APIs with overload resolution

### DIFF
--- a/Runtime/Hosting/AssemblyExporter.cs
+++ b/Runtime/Hosting/AssemblyExporter.cs
@@ -190,7 +190,7 @@ internal class AssemblyExporter
             JSCallbackDescriptor constructorDescriptor;
             if (constructors.Length == 1)
             {
-                constructorDescriptor = 
+                constructorDescriptor =
                     _marshaler.BuildFromJSConstructorExpression(constructors[0]).Compile();
             }
             else

--- a/Runtime/Hosting/AssemblyExporter.cs
+++ b/Runtime/Hosting/AssemblyExporter.cs
@@ -230,6 +230,7 @@ internal class AssemblyExporter
                 typeof(JSCallback),
                 typeof(JSCallback),
                 typeof(JSPropertyAttributes),
+                typeof(object),
             });
 
         JSPropertyAttributes attributes =
@@ -292,6 +293,7 @@ internal class AssemblyExporter
                         getterDelegate,
                         setterDelegate,
                         propertyAttributes,
+                        null,
                     });
             }
         }

--- a/Runtime/Hosting/TypeExtensions.cs
+++ b/Runtime/Hosting/TypeExtensions.cs
@@ -32,6 +32,14 @@ internal static class TypeExtensions
         Type.MakeGenericMethodParameter(1),
     };
 
+    public static object CreateInstance(
+        this Type type, Type[]? types = null, object?[]? args = null)
+        => type.GetInstanceConstructor(types ?? Array.Empty<Type>()).Invoke(args);
+
+    public static ConstructorInfo GetInstanceConstructor(this Type type, Type[] types)
+        => type.GetConstructor(PublicInstance, types) ??
+            throw new MissingMemberException($"Constructor not found on type {type.Name}.");
+
     public static PropertyInfo GetStaticProperty(this Type type, string name)
         => type.GetProperty(name, PublicStatic) ??
             throw new MissingMemberException(

--- a/Runtime/JSCallback.cs
+++ b/Runtime/JSCallback.cs
@@ -1,5 +1,6 @@
+
 namespace NodeApi;
 
 public delegate JSValue JSCallback(JSCallbackArgs args);
 
-public delegate void JSCallbackAction(JSCallbackArgs args);
+public delegate void JSActionCallback(JSCallbackArgs args);

--- a/Runtime/JSCallbackDescriptor.cs
+++ b/Runtime/JSCallbackDescriptor.cs
@@ -26,6 +26,5 @@ public readonly struct JSCallbackDescriptor
         Data = data;
     }
 
-    public static implicit operator JSCallbackDescriptor(JSCallback callback)
-        => new JSCallbackDescriptor(callback);
+    public static implicit operator JSCallbackDescriptor(JSCallback callback) => new(callback);
 }

--- a/Runtime/JSCallbackDescriptor.cs
+++ b/Runtime/JSCallbackDescriptor.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace NodeApi;
+
+/// <summary>
+/// Descriptor for a callback not associated with an object property, for example a constructor
+/// callback or standalone function callback. Enables passing a data object via the callback
+/// args data.
+/// </summary>
+public readonly struct JSCallbackDescriptor
+{
+    /// <summary>
+    /// Gets the callback that handles invocations from JavaScript.
+    /// </summary>
+    public JSCallback Callback { get; }
+
+    /// <summary>
+    /// Gets the optional data object that will be passed to the callback via
+    /// <see cref="JSCallbackArgs.Data" />.
+    /// </summary>
+    public object? Data { get; }
+
+    public JSCallbackDescriptor(JSCallback callback, object? data = null)
+    {
+        Callback = callback;
+        Data = data;
+    }
+
+    public static implicit operator JSCallbackDescriptor(JSCallback callback)
+        => new JSCallbackDescriptor(callback);
+}

--- a/Runtime/JSCallbackOverload.cs
+++ b/Runtime/JSCallbackOverload.cs
@@ -7,7 +7,7 @@ namespace NodeApi;
 /// Holds overload resolution information (parameter types) for one of multiple overloads
 /// for a .NET method.
 /// </summary>
-public struct JSCallbackOverload
+public readonly struct JSCallbackOverload
 {
     /// <summary>
     /// Specifies the number of parameters and the .NET type that each JS argument will be

--- a/Runtime/JSCallbackOverload.cs
+++ b/Runtime/JSCallbackOverload.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+
+namespace NodeApi;
+
+/// <summary>
+/// Holds overload resolution information (parameter types) for one of multiple overloads
+/// for a .NET method.
+/// </summary>
+public struct JSCallbackOverload
+{
+    /// <summary>
+    /// Specifies the number of parameters and the .NET type that each JS argument will be
+    /// converted to before invoking the callback.
+    /// </summary>
+    public Type[] ParameterTypes { get; init; }
+
+    /// <summary>
+    /// Callback that expects JS arguments that are convertible to the specified parameter types.
+    /// </summary>
+    public JSCallback Callback { get; init; }
+
+    /// <summary>
+    /// Selects a callback matching the supplied arguments, and invokes the callback.
+    /// </summary>
+    /// <param name="args">Callback arguments including overload info in the
+    /// <see cref="JSCallbackArgs.Data"/> property.</param>
+    /// <returns>Result of the callback invocation.</returns>
+    /// <exception cref="JSException">No overload or multiple overloads were found for the
+    /// supplied arguments.</exception>
+    /// <remarks>
+    /// This method may be use as the <see cref="JSPropertyDescriptor.Method"/> when
+    /// a list of <see cref="JSCallbackOverload" /> entries is also provided via the
+    /// <see cref="JSPropertyDescriptor.Data" /> property.
+    /// </remarks>
+    public static JSValue ResolveAndInvoke(JSCallbackArgs args)
+    {
+        if (args.Data is not IReadOnlyList<JSCallbackOverload> overloads ||
+            overloads.Count == 0)
+        {
+            throw new JSException("Missing overload resolution information.");
+        }
+
+        JSCallback callback = Resolve(args, overloads);
+        return callback(args);
+    }
+
+    /// <summary>
+    /// Selects a callback by finding the best match of the supplied arguments to method parameter
+    /// counts and types.
+    /// </summary>
+    /// <param name="args">Callback arguments that will be matched against overload
+    /// parameter counts and types.</param>
+    /// <param name="overloads">List of overloads to be matched.</param>
+    /// <returns>Callback for the resolved overload.</returns>
+    /// <exception cref="JSException">No overload or multiple overloads were found for the
+    /// supplied arguments.</exception>
+    public static JSCallback Resolve(
+        JSCallbackArgs args, IReadOnlyList<JSCallbackOverload> overloads)
+    {
+        // If there's only one overload in the list, no resolution logic is needed.
+        if (overloads.Count == 1)
+        {
+            return overloads[0].Callback;
+        }
+
+        // First try to match the supplied number of arguments to an overload parameter count.
+        // (Avoid using IEnumerable<> queries to prevent boxing the JSCallbackOverload struct.)
+        int argsCount = args.Length;
+        JSCallback? matchingCallback = null;
+        int matchingCallbackCount = 0;
+        foreach (JSCallbackOverload overload in overloads)
+        {
+            if (overload.ParameterTypes.Length == argsCount)
+            {
+                matchingCallback = overload.Callback;
+                if (++matchingCallbackCount > 1)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (matchingCallbackCount == 1)
+        {
+            return matchingCallback!;
+        }
+        else if (matchingCallbackCount == 0)
+        {
+            throw new JSException(
+                $"No overload was found for the supplied number of arguments ({argsCount}).");
+        }
+
+        // Multiple matches were found for the supplied number of arguments.
+        // Get the JS value type of each arg and try to match them .NET types.
+        Span<JSValueType> argTypes = stackalloc JSValueType[argsCount];
+        for (int i = 0; i < argsCount; i++)
+        {
+            argTypes[i] = args[i].TypeOf();
+        }
+
+        matchingCallback = null;
+        matchingCallbackCount = 0;
+        foreach (JSCallbackOverload overload in overloads)
+        {
+            if (overload.ParameterTypes.Length == argsCount)
+            {
+                bool isMatch = true;
+                for (int i = 0; i < argsCount; i++)
+                {
+                    if (!IsArgumentTypeMatch(argTypes[i], overload.ParameterTypes[i]))
+                    {
+                        isMatch = false;
+                        break;
+                    }
+                }
+
+                if (isMatch)
+                {
+                    matchingCallback = overload.Callback;
+                    if (++matchingCallbackCount > 1)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (matchingCallbackCount == 1)
+        {
+            return matchingCallback!;
+        }
+
+        string argTypesList = string.Join(", ", argTypes.ToArray());
+        if (matchingCallbackCount == 0)
+        {
+            throw new JSException(
+                $"No overload was found for the supplied argument types ({argTypesList}).");
+        }
+        else
+        {
+            // TODO: Try to match types more precisely, potentially using some additional type
+            // metadata supplied with JS arguments.
+
+            throw new JSException(
+                $"Multiple overloads were found for the supplied argument types ({argTypesList}).");
+        }
+    }
+
+    private static bool IsArgumentTypeMatch(JSValueType argumentType, Type parameterType)
+    {
+        static bool IsNullable(Type type) => !type.IsValueType ||
+            (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+
+        return argumentType switch
+        {
+            JSValueType.Boolean => parameterType == typeof(bool),
+            JSValueType.Number => parameterType.IsPrimitive && parameterType != typeof(bool),
+            JSValueType.String => parameterType == typeof(string),
+            JSValueType.Null => IsNullable(parameterType),
+            JSValueType.Undefined => IsNullable(parameterType),
+            JSValueType.Object => !parameterType.IsPrimitive && parameterType != typeof(string),
+            JSValueType.Function => parameterType.BaseType == typeof(Delegate),
+            JSValueType.BigInt => parameterType == typeof(System.Numerics.BigInteger),
+            _ => false,
+        };
+    }
+}

--- a/Runtime/JSContext.cs
+++ b/Runtime/JSContext.cs
@@ -162,10 +162,13 @@ public sealed class JSContext : IDisposable
     /// </summary>
     /// <param name="wrapper">JS object passed as the 'this' argument to the constructor callback
     /// for <see cref="JSNativeApi.DefineClass"/>.</param>
-    /// <param name="obj">New or existing instance of the class to be wrapped.</param>
+    /// <param name="externalInstance">New or existing instance of the class to be wrapped,
+    /// passed as a JS "external" value.</param>
     /// <returns>The JS wrapper.</returns>
-    internal JSValue InitializeObjectWrapper<T>(JSValue wrapper, T obj) where T : class
+    internal JSValue InitializeObjectWrapper(JSValue wrapper, JSValue externalInstance)
     {
+        object obj = externalInstance.GetValueExternal();
+
         // The reference returned by Wrap() is weak (refcount=0), which is good:
         // if the JS object is released then the reference will fail to resolve, and
         // GetOrCreateObjectWrapper() will create a new JS wrapper if requested.

--- a/Runtime/JSPropertyDescriptorListOfT.cs
+++ b/Runtime/JSPropertyDescriptorListOfT.cs
@@ -41,9 +41,10 @@ public abstract class JSPropertyDescriptorList<TDerived, TObject>
       string name,
       JSCallback? getter,
       JSCallback? setter,
-      JSPropertyAttributes attributes = JSPropertyAttributes.DefaultProperty)
+      JSPropertyAttributes attributes = JSPropertyAttributes.DefaultProperty,
+      object? data = null)
     {
-        Properties.Add(JSPropertyDescriptor.Accessor(name, getter, setter, attributes));
+        Properties.Add(JSPropertyDescriptor.Accessor(name, getter, setter, attributes, data));
         return (TDerived)(object)this;
     }
 

--- a/Runtime/JSValue.cs
+++ b/Runtime/JSValue.cs
@@ -140,20 +140,21 @@ public readonly struct JSValue : IEquatable<JSValue>
         }
     }
 
-    public static unsafe JSValue CreateFunction(ReadOnlySpan<byte> utf8Name, JSCallback callback)
+    public static unsafe JSValue CreateFunction(
+        ReadOnlySpan<byte> utf8Name, JSCallback callback, object? callbackData = null)
     {
-        GCHandle callbackHandle = GCHandle.Alloc(callback);
+        GCHandle callbackHandle = GCHandle.Alloc(new JSCallbackDescriptor(callback, callbackData));
         JSValue func = CreateFunction(utf8Name, new napi_callback(&InvokeJSCallback), (nint)callbackHandle);
         func.AddGCHandleFinalizer((nint)callbackHandle);
         return func;
     }
 
-    public static JSValue CreateFunction(string name, JSCallback callback)
+    public static JSValue CreateFunction(string name, JSCallback callback, object? callbackData = null)
     {
         int byteCount = Encoding.UTF8.GetByteCount(name);
         Span<byte> utf8Name = stackalloc byte[byteCount];
         Encoding.UTF8.GetBytes(name, utf8Name);
-        return CreateFunction(utf8Name, callback);
+        return CreateFunction(utf8Name, callback, callbackData);
     }
 
     public static JSValue CreateError(JSValue? code, JSValue message)

--- a/Test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/Test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -8,6 +8,10 @@ const assemblyPath = process.env.TEST_DOTNET_MODULE_PATH.replace(/.node$/, 'dll'
 const Console = dotnet.Console;
 Console.WriteLine('Hello from .NET!');
 
+const version = new dotnet.Version(1, 2, 3); // Invoke overloaded constructor with args.
+assert.strictEqual(version.ToString(), '1.2.3');
+assert.strictEqual(version + '.4', '1.2.3.4'); // Implicit call to .NET ToString()
+
 const assembly = dotnet.load(assemblyPath);
 console.dir(Object.keys(assembly)); // Print all public types in the loaded assembly.
 
@@ -16,3 +20,21 @@ console.dir(Object.keys(Hello)); // Print all public static members of the Hello
 
 const greeting = Hello.Test('assembly'); // Call a static method.
 assert.strictEqual(greeting, 'Hello assembly!');
+
+const ClassObject = assembly.ClassObject;
+assert.strictEqual(typeof ClassObject, 'function');
+const instance = new ClassObject(); // Construct an instance of a class
+assert.strictEqual(instance.Value, null);
+instance.Value = 'test';
+assert.strictEqual(instance.Value, 'test');
+
+const StructObject = assembly.StructObject;
+assert.strictEqual(typeof StructObject, 'function');
+const instance2 = new StructObject(); // Construct an instance of a struct
+assert.strictEqual(instance2.Value, undefined);
+instance2.Value = 'test';
+assert.strictEqual(instance2.Value, 'test');
+
+const TestEnum = assembly.TestEnum;
+assert.strictEqual(TestEnum.Two, 2);
+assert.strictEqual(TestEnum[2], 'Two');


### PR DESCRIPTION
This change fills out more of the implementation of dynamic binding to .NET assemblies, so that it supports most kinds of APIs including classes, structs, enums, properties, and methods. (Dynamic binding for .NET interfaces is still not fully implemented.)

And it adds basic overload resolution for constructors and methods. So for example now you can do this:
```JavaScript
const version = new dotnet.Version(1, 2, 3); // Invoke overloaded constructor with args.
assert.strictEqual(version.ToString(), '1.2.3');
assert.strictEqual(version + '.4', '1.2.3.4'); // Implicit call to .NET ToString()
```

Overload resolution looks first at the number of supplied arguments, then if the call is still ambiguous it tries to match the argument JS value types (number, string, object, etc.) to the .NET parameter types. It does not yet do any matching on object _class_; that will probably be necessary eventually.

One lower level change worth noting is how the constructor callback delegate is now also a `JSCallback`. (A `Func<T>` may still be provided to the class builder, though it gets immediately wrapped in the general callback delegate type.) Overload resolution would have been very messy if it had to work with many types of callback delegates, so that change kept it much simpler. Related to that, constructors and standalone functions now support an optional data object via `JSCallbackDescriptor`. The overload resolution table is passed to the callback that way, but it can be used for other things too.

I haven't done broad testing against many kinds of .NET APIs yet, but I expect there will be a lot of problems and limitations that we'll have to triage and work through to make this more seamless. Another issue now is that binding is done on a per-type basis, not per-member, so if any one property or method fails to bind then the entire type fails to load. That can be fixed later with some proxy magic.