### PR TITLE
JSNativeApi.Interop to bind functions from a specified module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ExampleClass.ExampleMethod(...args); // This call is type-checked!
 For reference, there is a [list of C# type projections to TypeScript](/Docs/typescript.md).
 
 ### Full async support
-JavaScript code can `await` a call to a .NET method that returns a `Task`. The marshaler
+JavaScript code can `await` a call to a .NET method that returns a `Task`. The marshaller
 automatically sets up a `SynchronizationContext` so that the .NET result is returned back to the
 JS thread.
 ```TypeScript
@@ -118,7 +118,7 @@ There are two ways to get automatic marshaling between C# and JavaScript types:
   from that reflection and IL emitting, but subsequent calls to the same APIs may be just as fast
   as the pre-compiled marshaling code (and are just as likely to be JITted).
 
-The marshaler uses the strong typing information from the C# API declarations as hints about how to
+The marshaller uses the strong typing information from the C# API declarations as hints about how to
 convert values beteen JavaScript and C#. Here's a general summary of conversions:
   - Primitives (numbers, strings, etc.) are passed by value directy.
   - C# structs have all properties passed by value (shallow copied).

--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 /// </summary>
 internal class AssemblyExporter
 {
-    private readonly JSMarshaler _marshaler;
+    private readonly JSMarshaller _marshaller;
     private readonly JSReference _assemblyObject;
     private readonly Dictionary<Type, JSReference> _typeObjects = new();
 
@@ -21,16 +21,16 @@ internal class AssemblyExporter
     /// Creates a new instance of the <see cref="AssemblyExporter" /> class.
     /// </summary>
     /// <param name="assembly">The assembly to be exported.</param>
-    /// <param name="marshaler">Marshaler that supports dynamic binding to .NET APIs.</param>
+    /// <param name="marshaller">Marshaller that supports dynamic binding to .NET APIs.</param>
     /// <param name="target">Proxy target object; any properties/methods on this object
     /// will be exposed on the exported assembly object in addition to assembly types.</param>
     public AssemblyExporter(
         Assembly assembly,
-        JSMarshaler marshaler,
+        JSMarshaller marshaller,
         JSObject target)
     {
         Assembly = assembly;
-        _marshaler = marshaler;
+        _marshaller = marshaller;
 
         JSProxy proxy = new(target, CreateProxyHandler());
         _assemblyObject = new JSReference(proxy);
@@ -189,13 +189,13 @@ internal class AssemblyExporter
             if (constructors.Length == 1)
             {
                 constructorDescriptor =
-                    _marshaler.BuildFromJSConstructorExpression(constructors[0]).Compile();
+                    _marshaller.BuildFromJSConstructorExpression(constructors[0]).Compile();
             }
             else
             {
                 // Multiple constructors require overload resolution.
                 constructorDescriptor =
-                    _marshaler.BuildConstructorOverloadDescriptor(constructors);
+                    _marshaller.BuildConstructorOverloadDescriptor(constructors);
             }
 
             classBuilder = classBuilderType.CreateInstance(
@@ -271,7 +271,7 @@ internal class AssemblyExporter
                 if (property.GetMethod != null)
                 {
                     LambdaExpression lambda =
-                        _marshaler.BuildFromJSPropertyGetExpression(property);
+                        _marshaller.BuildFromJSPropertyGetExpression(property);
                     getterDelegate = (JSCallback)lambda.Compile();
                 }
 
@@ -279,7 +279,7 @@ internal class AssemblyExporter
                 if (property.SetMethod != null)
                 {
                     LambdaExpression lambda =
-                        _marshaler.BuildFromJSPropertySetExpression(property);
+                        _marshaller.BuildFromJSPropertySetExpression(property);
                     setterDelegate = (JSCallback)lambda.Compile();
                 }
 
@@ -337,7 +337,7 @@ internal class AssemblyExporter
                 Trace($"    {(methodIsStatic ? "static " : string.Empty)}{methodName}(" +
                     string.Join(", ", method.GetParameters().Select((p) => p.ParameterType)) + ")");
 
-                methodDescriptor = _marshaler.BuildFromJSMethodExpression(method).Compile();
+                methodDescriptor = _marshaller.BuildFromJSMethodExpression(method).Compile();
             }
             else
             {
@@ -351,7 +351,7 @@ internal class AssemblyExporter
 
                 }
 
-                methodDescriptor = _marshaler.BuildMethodOverloadDescriptor(methods);
+                methodDescriptor = _marshaller.BuildMethodOverloadDescriptor(methods);
             }
 
             addMethodMethod.Invoke(

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
@@ -10,7 +10,7 @@ namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 /// <summary>
 /// Supports dynamic implementation of .NET interfaces by JavaScript.
 /// </summary>
-internal static class JSInterfaceMarshaler
+internal static class JSInterfaceMarshaller
 {
     private static readonly ConcurrentDictionary<Type, Type> s_interfaceTypes = new();
     private static readonly AssemblyBuilder s_assemblyBuilder =
@@ -24,20 +24,20 @@ internal static class JSInterfaceMarshaler
     /// Defines a class type that extends <see cref="JSInterface" /> and implements the requested
     /// interface type by forwarding all member access to the JS value.
     /// </summary>
-    public static Type Implement(Type interfaceType, JSMarshaler marshaler)
+    public static Type Implement(Type interfaceType, JSMarshaller marshaller)
     {
         return s_interfaceTypes.GetOrAdd(
             interfaceType,
-            (t) => BuildInterfaceImplementation(interfaceType, marshaler));
+            (t) => BuildInterfaceImplementation(interfaceType, marshaller));
     }
 
-#pragma warning disable IDE0060 // Unused parameter 'marshaler'
-    private static Type BuildInterfaceImplementation(Type interfaceType, JSMarshaler marshaler)
+#pragma warning disable IDE0060 // Unused parameter 'marshaller'
+    private static Type BuildInterfaceImplementation(Type interfaceType, JSMarshaller marshaller)
 #pragma warning restore IDE0060 // Unused parameter
     {
         TypeBuilder typeBuilder = s_moduleBuilder.DefineType(
             "proxy_" +
-            JSMarshaler.FullTypeName(interfaceType),
+            JSMarshaller.FullTypeName(interfaceType),
             TypeAttributes.Class | TypeAttributes.Sealed,
             typeof(JSInterface),
             new[] { interfaceType });
@@ -75,7 +75,7 @@ internal static class JSInterfaceMarshaler
 
         Type implementationType = typeBuilder.CreateType();
 
-        // TODO: Get implementation delegates from the marshaler and assign to static properties.
+        // TODO: Get implementation delegates from the marshaller and assign to static properties.
 
         return implementationType;
     }
@@ -163,7 +163,7 @@ internal static class JSInterfaceMarshaler
         // TODO: Method IL
         // Define a static property for a delegate for each method.
         // Emit IL to invoke the delegate, passing args and returning result.
-        // After building the type, get delegates from the marshaler and assign to static properties.
+        // After building the type, get delegates from the marshaller and assign to static properties.
 
         il.Emit(OpCodes.Ret);
 

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -20,7 +20,7 @@ namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 /// <para/>
 /// All methods on this class are thread-safe.
 /// </remarks>
-public class JSMarshaler
+public class JSMarshaller
 {
     private readonly ConcurrentDictionary<Type, Delegate> _fromJSDelegates = new();
     private readonly ConcurrentDictionary<Type, Delegate> _toJSDelegates = new();
@@ -143,7 +143,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build expression for conversion from JS value.", toType, ex);
         }
     }
@@ -175,7 +175,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build expression for conversion to JS value.", fromType, ex);
         }
     }
@@ -262,7 +262,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build JS callback adapter expression for .NET method.", method, ex);
         }
     }
@@ -292,7 +292,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build JS callback adapter for .NET property getter.", property, ex);
         }
     }
@@ -322,7 +322,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build JS callback adapter for .NET property getter.", property, ex);
         }
     }
@@ -449,7 +449,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build .NET adapter for JS method.", method, ex);
         }
     }
@@ -516,7 +516,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build .NET adapter for JS property getter.", property, ex);
         }
     }
@@ -589,7 +589,7 @@ public class JSMarshaler
         }
         catch (Exception ex)
         {
-            throw new JSMarshalerException(
+            throw new JSMarshallerException(
                 "Failed to build .NET adapter for JS property setter.", property, ex);
         }
     }
@@ -1115,7 +1115,7 @@ public class JSMarshaler
             // It could be either a wrapped .NET object passed back from JS or a JS object
             // that implements a .NET interface. For the latter case, dynamically build
             // a class that implements the interface by proxying member access to JS.
-            Type adapterType = JSInterfaceMarshaler.Implement(toType, this);
+            Type adapterType = JSInterfaceMarshaller.Implement(toType, this);
             ConstructorInfo adapterConstructor =
                 adapterType.GetConstructor(new[] { typeof(JSValue) })!;
             statements = new[]

--- a/src/NodeApi.DotNetHost/JSMarshallerException.cs
+++ b/src/NodeApi.DotNetHost/JSMarshallerException.cs
@@ -4,18 +4,18 @@ using System.Reflection;
 namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
-/// Exception thrown by <see cref="JSMarshaler" /> about a failure while dynamically generating
+/// Exception thrown by <see cref="JSMarshaller" /> about a failure while dynamically generating
 /// marshaling expressions.
 /// </summary>
-public class JSMarshalerException : JSException
+public class JSMarshallerException : JSException
 {
-    public JSMarshalerException(string message, Type type, Exception? innerException = null)
+    public JSMarshallerException(string message, Type type, Exception? innerException = null)
         : base(message + $" Type: {type}", innerException)
     {
         Type = type;
     }
 
-    public JSMarshalerException(string message, MemberInfo member, Exception? innerException = null)
+    public JSMarshallerException(string message, MemberInfo member, Exception? innerException = null)
         : base(message + $" Type: {member.DeclaringType}, Member: {member}", innerException)
     {
         Type = member.DeclaringType!;

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -22,10 +22,10 @@ public sealed class ManagedHost : IDisposable
     private readonly AssemblyLoadContext _loadContext = new(name: default);
 
     /// <summary>
-    /// The marshaler dynamically generates adapter delegates for calls to & from JS,
+    /// The marshaller dynamically generates adapter delegates for calls to & from JS,
     /// for assemblies that were not pre-built as Node API modules.
     /// </summary>
-    private readonly JSMarshaler _marshaler = new();
+    private readonly JSMarshaller _marshaller = new();
 
     private readonly Dictionary<string, JSReference> _loadedModules = new();
     private readonly Dictionary<string, AssemblyExporter> _loadedAssemblies = new();
@@ -44,7 +44,7 @@ public sealed class ManagedHost : IDisposable
             JSPropertyDescriptor.ForValue("load", JSValue.CreateFunction("load", LoadAssembly)));
 
         // Export the .NET core library assembly by default, along with additional methods above.
-        _systemAssembly = new AssemblyExporter(typeof(object).Assembly, _marshaler, exports);
+        _systemAssembly = new AssemblyExporter(typeof(object).Assembly, _marshaller, exports);
     }
 
     public static bool IsTracingEnabled { get; } =
@@ -223,7 +223,7 @@ public sealed class ManagedHost : IDisposable
         }
 
         Assembly assembly = _loadContext.LoadFromAssemblyPath(assemblyFilePath);
-        assemblyExporter = new(assembly, _marshaler, target: new JSObject());
+        assemblyExporter = new(assembly, _marshaller, target: new JSObject());
         _loadedAssemblies.Add(assemblyFilePath, assemblyExporter);
         JSValue assemblyValue = assemblyExporter.AssemblyObject;
 

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -277,9 +277,9 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         // The main initialization entrypoint is called by the `ManagedHost`, and by the unmanaged entrypoint.
         s += $"public static napi_value {ModuleInitializeMethodName}(napi_env env, napi_value exports)";
         s += "{";
+        s += "using var scope = new JSValueScope(JSValueScopeType.Root, env);";
         s += "try";
         s += "{";
-        s += "using var scope = new JSValueScope(JSValueScopeType.Root, env);";
         s += "JSContext context = scope.ModuleContext;";
         s += "JSValue exportsValue = new(exports, scope);";
         s++;

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -22,7 +22,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
     private const string ModuleInitializeMethodName = "Initialize";
     private const string ModuleRegisterFunctionName = "napi_register_module_v1";
 
-    private readonly JSMarshaler _marshaler = new();
+    private readonly JSMarshaller _marshaller = new();
     private readonly Dictionary<string, LambdaExpression> _callbackAdapters = new();
     private readonly List<ITypeSymbol> _exportedInterfaces = new();
 
@@ -325,7 +325,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         foreach (ITypeSymbol interfaceSymbol in _exportedInterfaces)
         {
             s++;
-            GenerateInterfaceAdapter(ref s, interfaceSymbol, _marshaler);
+            GenerateInterfaceAdapter(ref s, interfaceSymbol, _marshaller);
         }
 
         s += "}";
@@ -399,7 +399,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                     if (IsConstructorCallbackAdapterRequired(exportClass))
                     {
                         // TODO: Overload resolution if more than one constructor.
-                        LambdaExpression adapter = _marshaler.BuildFromJSConstructorExpression(
+                        LambdaExpression adapter = _marshaller.BuildFromJSConstructorExpression(
                             exportClass.GetMembers().OfType<IMethodSymbol>()
                                 .Where((m) => m.MethodKind == MethodKind.Constructor)
                                 .First().AsConstructorInfo());
@@ -524,7 +524,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         if (IsMethodCallbackAdapterRequired(method))
         {
             Expression<JSCallback> adapter =
-                _marshaler.BuildFromJSMethodExpression(method.AsMethodInfo());
+                _marshaller.BuildFromJSMethodExpression(method.AsMethodInfo());
             _callbackAdapters.Add(adapter.Name!, adapter);
             s += $".AddMethod(\"{exportName}\", {adapter.Name},\n\t{attributes})";
         }
@@ -575,7 +575,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         else if (property.Type.AsType() != typeof(JSValue))
         {
             Expression<JSCallback> adapter =
-                _marshaler.BuildFromJSMethodExpression(property.AsPropertyInfo().GetMethod!);
+                _marshaller.BuildFromJSMethodExpression(property.AsPropertyInfo().GetMethod!);
             _callbackAdapters.Add(adapter.Name!, adapter);
             s += $"getter: {adapter.Name},";
         }
@@ -595,7 +595,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         else if (property.Type.AsType() != typeof(JSValue))
         {
             Expression<JSCallback> adapter =
-                _marshaler.BuildFromJSMethodExpression(property.AsPropertyInfo().SetMethod!);
+                _marshaller.BuildFromJSMethodExpression(property.AsPropertyInfo().SetMethod!);
             _callbackAdapters.Add(adapter.Name!, adapter);
             s += $"setter: {adapter.Name},";
         }
@@ -704,7 +704,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
     private static void GenerateInterfaceAdapter(
         ref SourceBuilder s,
         ITypeSymbol interfaceType,
-        JSMarshaler _marshaler)
+        JSMarshaller _marshaller)
     {
         string ns = GetNamespace(interfaceType);
         string adapterName = $"proxy_{ns.Replace('.', '_')}_{interfaceType.Name}";
@@ -737,7 +737,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                 if (!property.IsWriteOnly)
                 {
                     LambdaExpression getterAdapter =
-                        _marshaler.BuildToJSPropertyGetExpression(property.AsPropertyInfo());
+                        _marshaller.BuildToJSPropertyGetExpression(property.AsPropertyInfo());
                     s += "get";
                     string cs = ReplaceMethodVariables(getterAdapter.ToCS());
                     s += string.Join("\n", cs.Split("\n").Skip(1));
@@ -746,7 +746,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                 if (!property.IsReadOnly)
                 {
                     LambdaExpression setterAdapter =
-                        _marshaler.BuildToJSPropertySetExpression(property.AsPropertyInfo());
+                        _marshaller.BuildToJSPropertySetExpression(property.AsPropertyInfo());
                     s += "set";
                     string cs = ReplaceMethodVariables(setterAdapter.ToCS());
                     s += string.Join("\n", cs.Split("\n").Skip(1));
@@ -760,7 +760,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                 s++;
 
                 LambdaExpression methodAdapter =
-                    _marshaler.BuildToJSMethodExpression(method.AsMethodInfo());
+                    _marshaller.BuildToJSMethodExpression(method.AsMethodInfo());
                 s += ReplaceMethodVariables(methodAdapter.ToCS());
             }
         }

--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -163,7 +163,7 @@ internal static class SymbolExtensions
             }
         }
 
-        // Preserve JS attributes, which might be referenced by the marshaler.
+        // Preserve JS attributes, which might be referenced by the marshaller.
         foreach (AttributeData attribute in typeSymbol.GetAttributes())
         {
             if (attribute.AttributeClass!.ContainingAssembly.Name ==

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -43,7 +43,7 @@ internal partial class NativeHost : IDisposable
         using JSValueScope scope = new(JSValueScopeType.RootNoContext, env);
         try
         {
-            JSNativeApi.Interop.Initialize();
+            JSNativeApi.Interop.Initialize(NativeLibrary.GetMainProgramHandle());
 
             NativeHost host = new();
 

--- a/src/NodeApi/Interop/JSContext.cs
+++ b/src/NodeApi/Interop/JSContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using static Microsoft.JavaScript.NodeApi.Interop.JSCollectionProxies;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi;
 using napi_env = Microsoft.JavaScript.NodeApi.JSNativeApi.Interop.napi_env;
@@ -88,7 +89,9 @@ public sealed class JSContext : IDisposable
 
     public JSContext(napi_env env)
     {
-        JSNativeApi.Interop.Initialize();
+        // TODO: Move this Initialize call to the creators of JSContext
+        JSNativeApi.Interop.Initialize(NativeLibrary.GetMainProgramHandle());
+
         _env = env;
         SetInstanceData(env, this);
         SynchronizationContext = new JSSynchronizationContext();

--- a/src/NodeApi/Interop/JSThreadSafeFunction.cs
+++ b/src/NodeApi/Interop/JSThreadSafeFunction.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
-using static Microsoft.JavaScript.NodeApi.JSNativeApi.NodeApiInterop;
 
 namespace Microsoft.JavaScript.NodeApi.Interop;
 

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
-using static Microsoft.JavaScript.NodeApi.JSNativeApi.NodeApiInterop;
 
 namespace Microsoft.JavaScript.NodeApi;
 
@@ -17,7 +16,8 @@ file record struct JSErrorInfo(string? Message, napi_status Status)
     {
         napi_get_last_error_info(
             (napi_env)JSValueScope.Current,
-            out napi_extended_error_info* errorInfo).ThrowIfFailed();
+            out nint errorInfoHandle).ThrowIfFailed();
+        var errorInfo = (napi_extended_error_info*)errorInfoHandle;
         if (errorInfo == null)
         {
             return new JSErrorInfo(null, napi_status.napi_ok);
@@ -211,11 +211,7 @@ public struct JSError
                              [CallerMemberName] string memberName = "",
                              [CallerFilePath] string sourceFilePath = "",
                              [CallerLineNumber] int sourceLineNumber = 0)
-        => napi_fatal_error(
-            $"{memberName} at {sourceFilePath}:{sourceLineNumber}",
-            NAPI_AUTO_LENGTH,
-            message,
-            NAPI_AUTO_LENGTH);
+        => napi_fatal_error($"{memberName} at {sourceFilePath}:{sourceLineNumber}", message);
 
     private static JSReference CreateErrorReference(JSValue error)
     {

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -32,19 +32,25 @@ public readonly struct JSValue : IEquatable<JSValue>
         _scope = scope;
     }
 
-    public napi_value? Handle => !Scope.IsDisposed ? (_handle.Handle != nint.Zero ? _handle : Undefined._handle) : null;
+    public napi_value? Handle
+        => !Scope.IsDisposed ? (_handle.Handle != nint.Zero ? _handle : Undefined._handle) : null;
 
     public napi_value GetCheckedHandle()
-        => Handle ?? throw new InvalidOperationException("The value handle is invalid because its scope is closed");
+        => Handle ?? throw new InvalidOperationException(
+                        "The value handle is invalid because its scope is closed");
 
     private static napi_env Env => (napi_env)JSValueScope.Current;
 
-    public static JSValue Undefined => napi_get_undefined(Env, out napi_value result).ThrowIfFailed(result);
-    public static JSValue Null => napi_get_null(Env, out napi_value result).ThrowIfFailed(result);
-    public static JSValue Global => napi_get_global(Env, out napi_value result).ThrowIfFailed(result);
+    public static JSValue Undefined
+        => napi_get_undefined(Env, out napi_value result).ThrowIfFailed(result);
+    public static JSValue Null
+        => napi_get_null(Env, out napi_value result).ThrowIfFailed(result);
+    public static JSValue Global
+        => napi_get_global(Env, out napi_value result).ThrowIfFailed(result);
     public static JSValue True => GetBoolean(true);
     public static JSValue False => GetBoolean(false);
-    public static JSValue GetBoolean(bool value) => napi_get_boolean(Env, value, out napi_value result).ThrowIfFailed(result);
+    public static JSValue GetBoolean(bool value)
+        => napi_get_boolean(Env, value, out napi_value result).ThrowIfFailed(result);
 
     public JSObject Properties => (JSObject)this;
 
@@ -75,7 +81,8 @@ public readonly struct JSValue : IEquatable<JSValue>
         => napi_create_array(Env, out napi_value result).ThrowIfFailed(result);
 
     public static JSValue CreateArray(int length)
-        => napi_create_array_with_length(Env, (nuint)length, out napi_value result).ThrowIfFailed(result);
+        => napi_create_array_with_length(Env, (nuint)length, out napi_value result)
+        .ThrowIfFailed(result);
 
     public static JSValue CreateNumber(double value)
         => napi_create_double(Env, value, out napi_value result).ThrowIfFailed(result);
@@ -93,7 +100,9 @@ public readonly struct JSValue : IEquatable<JSValue>
     {
         fixed (byte* spanPtr = value)
         {
-            return napi_create_string_latin1(Env, spanPtr, (nuint)value.Length, out napi_value result).ThrowIfFailed(result);
+            return napi_create_string_latin1(
+                Env, spanPtr, (nuint)value.Length, out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 
@@ -101,7 +110,9 @@ public readonly struct JSValue : IEquatable<JSValue>
     {
         fixed (byte* spanPtr = value)
         {
-            return napi_create_string_utf8(Env, spanPtr, (nuint)value.Length, out napi_value result).ThrowIfFailed(result);
+            return napi_create_string_utf8(
+                Env, spanPtr, (nuint)value.Length, out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 
@@ -109,18 +120,22 @@ public readonly struct JSValue : IEquatable<JSValue>
     {
         fixed (char* spanPtr = value)
         {
-            return napi_create_string_utf16(Env, spanPtr, (nuint)value.Length, out napi_value result).ThrowIfFailed(result);
+            return napi_create_string_utf16(
+                Env, spanPtr, (nuint)value.Length, out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 
     public static JSValue CreateSymbol(JSValue description)
-        => napi_create_symbol(Env, (napi_value)description, out napi_value result).ThrowIfFailed(result);
+        => napi_create_symbol(
+            Env, (napi_value)description, out napi_value result).ThrowIfFailed(result);
 
     public static unsafe JSValue SymbolFor(ReadOnlySpan<byte> utf8Name)
     {
         fixed (byte* name = utf8Name)
         {
-            return node_api_symbol_for(Env, name, (nuint)utf8Name.Length, out napi_value result).ThrowIfFailed(result);
+            return node_api_symbol_for(Env, name, (nuint)utf8Name.Length, out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 
@@ -132,19 +147,16 @@ public readonly struct JSValue : IEquatable<JSValue>
         fixed (byte* namePtr = utf8Name)
         {
             return napi_create_function(
-                Env,
-                namePtr,
-                (nuint)utf8Name.Length,
-                callback,
-                data,
-                out napi_value result).ThrowIfFailed(result);
+                Env, namePtr, (nuint)utf8Name.Length, callback, data, out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 
     public static unsafe JSValue CreateFunction(
         ReadOnlySpan<byte> utf8Name, JSCallback callback, object? callbackData = null)
     {
-        GCHandle descriptorHandle = GCHandle.Alloc(new JSCallbackDescriptor(callback, callbackData));
+        GCHandle descriptorHandle = GCHandle.Alloc(
+            new JSCallbackDescriptor(callback, callbackData));
         JSValue func = CreateFunction(
             utf8Name,
             new napi_callback(
@@ -155,7 +167,8 @@ public readonly struct JSValue : IEquatable<JSValue>
         return func;
     }
 
-    public static JSValue CreateFunction(string name, JSCallback callback, object? callbackData = null)
+    public static JSValue CreateFunction(
+        string name, JSCallback callback, object? callbackData = null)
     {
         int byteCount = Encoding.UTF8.GetByteCount(name);
         Span<byte> utf8Name = stackalloc byte[byteCount];
@@ -182,39 +195,52 @@ public readonly struct JSValue : IEquatable<JSValue>
     public static unsafe JSValue CreateExternal(object value)
     {
         GCHandle valueHandle = GCHandle.Alloc(value);
-        return napi_create_external(Env, (nint)valueHandle, new napi_finalize(&FinalizeGCHandle), nint.Zero, out napi_value result).ThrowIfFailed(result);
+        return napi_create_external(
+            Env,
+            (nint)valueHandle,
+            new napi_finalize(&FinalizeGCHandle),
+            nint.Zero,
+            out napi_value result)
+            .ThrowIfFailed(result);
     }
 
     public static unsafe JSValue CreateArrayBuffer(int byteLength)
     {
-        napi_create_arraybuffer(Env, (nuint)byteLength, out void* _, out napi_value result).ThrowIfFailed();
+        napi_create_arraybuffer(Env, (nuint)byteLength, out nint _, out napi_value result)
+            .ThrowIfFailed();
         return result;
     }
 
     public static unsafe JSValue CreateArrayBuffer(ReadOnlySpan<byte> data)
     {
-        napi_create_arraybuffer(Env, (nuint)data.Length, out void* buffer, out napi_value result).ThrowIfFailed();
-        data.CopyTo(new Span<byte>(buffer, data.Length));
+        napi_create_arraybuffer(Env, (nuint)data.Length, out nint buffer, out napi_value result)
+            .ThrowIfFailed();
+        data.CopyTo(new Span<byte>((void*)buffer, data.Length));
         return result;
     }
 
-    public static unsafe JSValue CreateExternalArrayBuffer<T>(Memory<T> memory, object? external = null) where T : struct
+    public static unsafe JSValue CreateExternalArrayBuffer<T>(
+        Memory<T> memory, object? external = null) where T : struct
     {
         var pinnedMemory = new PinnedMemory<T>(memory, external);
         return napi_create_external_arraybuffer(
             Env,
-            pinnedMemory.Pointer,
+            (nint)pinnedMemory.Pointer,
             (nuint)pinnedMemory.Length,
-            new napi_finalize(&FinalizeHintHandle), // We pass object to finalize as a hint parameter
+            // We pass object to finalize as a hint parameter
+            new napi_finalize(&FinalizeHintHandle),
             (nint)GCHandle.Alloc(pinnedMemory),
             out napi_value result)
             .ThrowIfFailed(result);
     }
 
     public static JSValue CreateDataView(int length, JSValue arrayBuffer, int byteOffset)
-        => napi_create_dataview(Env, (nuint)length, (napi_value)arrayBuffer, (nuint)byteOffset, out napi_value result).ThrowIfFailed(result);
+        => napi_create_dataview(
+            Env, (nuint)length, (napi_value)arrayBuffer, (nuint)byteOffset, out napi_value result)
+            .ThrowIfFailed(result);
 
-    public static JSValue CreateTypedArray(JSTypedArrayType type, int length, JSValue arrayBuffer, int byteOffset)
+    public static JSValue CreateTypedArray(
+        JSTypedArrayType type, int length, JSValue arrayBuffer, int byteOffset)
         => napi_create_typedarray(
             Env,
             (napi_typedarray_type)type,
@@ -226,7 +252,8 @@ public readonly struct JSValue : IEquatable<JSValue>
 
     public static JSValue CreatePromise(out JSPromise.Deferred deferred)
     {
-        napi_create_promise(Env, out napi_deferred deferred_, out napi_value promise).ThrowIfFailed();
+        napi_create_promise(Env, out napi_deferred deferred_, out napi_value promise)
+            .ThrowIfFailed();
         deferred = new JSPromise.Deferred(deferred_);
         return promise;
     }
@@ -244,7 +271,9 @@ public readonly struct JSValue : IEquatable<JSValue>
     {
         fixed (ulong* wordPtr = words)
         {
-            return napi_create_bigint_words(Env, signBit, (nuint)words.Length, wordPtr, out napi_value result).ThrowIfFailed(result);
+            return napi_create_bigint_words(
+                Env, signBit, (nuint)words.Length, wordPtr, out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Security;
 
 namespace Microsoft.JavaScript.NodeApi;
@@ -11,35 +12,199 @@ public static partial class JSNativeApi
 {
     // Node-API Interop definitions and functions.
     [SuppressUnmanagedCodeSecurity]
-    public static unsafe partial class Interop
+    public unsafe partial class Interop
     {
+        private readonly nint _libraryHandle;
+        private readonly nint[] _functions = new nint[(int)FunctionId.FunctionCount];
+
         private static bool s_initialized;
 
-        public static void Initialize()
+        public static Interop? Current { get; set; }
+
+        public Interop(nint libraryHandle) => _libraryHandle = libraryHandle;
+
+        public static void Initialize(nint libraryHandle)
         {
             if (s_initialized) return;
             s_initialized = true;
+
+            Current = new Interop(libraryHandle);
 
             // Node APIs are all imported from the main `node` executable. Overriding the import
             // resolution is more efficient and avoids issues with library search paths and
             // differences in the name of the executable.
             NativeLibrary.SetDllImportResolver(
-              typeof(JSNativeApi).Assembly,
-              (libraryName, _, _) =>
-              {
-                  return libraryName switch
-                  {
-                      nameof(DotNetHost.HostFxr) => DotNetHost.HostFxr.Handle,
-                      nameof(NodeApi) => NativeLibrary.GetMainProgramHandle(),
-                      _ => default,
-                  };
-              });
+                typeof(JSNativeApi).Assembly,
+                (libraryName, _, _) => libraryName switch
+                {
+                    nameof(DotNetHost.HostFxr) => DotNetHost.HostFxr.Handle,
+                    _ => default,
+                });
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate napi_value napi_register_module_v1(napi_env env, napi_value exports);
 
         public static readonly nuint NAPI_AUTO_LENGTH = nuint.MaxValue;
+
+        public enum FunctionId
+        {
+            // js_native_api.h APIs
+            napi_get_last_error_info,
+            napi_get_undefined,
+            napi_get_null,
+            napi_get_global,
+            napi_get_boolean,
+            napi_create_object,
+            napi_create_array,
+            napi_create_array_with_length,
+            napi_create_double,
+            napi_create_int32,
+            napi_create_uint32,
+            napi_create_int64,
+            napi_create_string_latin1,
+            napi_create_string_utf8,
+            napi_create_string_utf16,
+            napi_create_symbol,
+            node_api_symbol_for,
+            napi_create_function,
+            napi_create_error,
+            napi_create_type_error,
+            napi_create_range_error,
+            node_api_create_syntax_error,
+            napi_typeof,
+            napi_get_value_double,
+            napi_get_value_int32,
+            napi_get_value_uint32,
+            napi_get_value_int64,
+            napi_get_value_bool,
+            napi_get_value_string_latin1,
+            napi_get_value_string_utf8,
+            napi_get_value_string_utf16,
+            napi_coerce_to_bool,
+            napi_coerce_to_number,
+            napi_coerce_to_object,
+            napi_coerce_to_string,
+            napi_get_prototype,
+            napi_get_property_names,
+            napi_set_property,
+            napi_has_property,
+            napi_get_property,
+            napi_delete_property,
+            napi_has_own_property,
+            napi_set_named_property,
+            napi_has_named_property,
+            napi_get_named_property,
+            napi_set_element,
+            napi_has_element,
+            napi_get_element,
+            napi_delete_element,
+            napi_define_properties,
+            napi_is_array,
+            napi_get_array_length,
+            napi_strict_equals,
+            napi_call_function,
+            napi_new_instance,
+            napi_instanceof,
+            napi_get_cb_info,
+            napi_get_new_target,
+            napi_define_class,
+            napi_wrap,
+            napi_unwrap,
+            napi_remove_wrap,
+            napi_create_external,
+            napi_get_value_external,
+            napi_create_reference,
+            napi_delete_reference,
+            napi_reference_ref,
+            napi_reference_unref,
+            napi_get_reference_value,
+            napi_open_handle_scope,
+            napi_close_handle_scope,
+            napi_open_escapable_handle_scope,
+            napi_close_escapable_handle_scope,
+            napi_escape_handle,
+            napi_throw,
+            napi_throw_error,
+            napi_throw_type_error,
+            napi_throw_range_error,
+            node_api_throw_syntax_error,
+            napi_is_error,
+            napi_is_exception_pending,
+            napi_get_and_clear_last_exception,
+            napi_is_arraybuffer,
+            napi_create_arraybuffer,
+            napi_create_external_arraybuffer,
+            napi_get_arraybuffer_info,
+            napi_is_typedarray,
+            napi_create_typedarray,
+            napi_get_typedarray_info,
+            napi_create_dataview,
+            napi_is_dataview,
+            napi_get_dataview_info,
+            napi_get_version,
+            napi_create_promise,
+            napi_resolve_deferred,
+            napi_reject_deferred,
+            napi_is_promise,
+            napi_run_script,
+            napi_adjust_external_memory,
+            napi_create_date,
+            napi_is_date,
+            napi_get_date_value,
+            napi_add_finalizer,
+            napi_create_bigint_int64,
+            napi_create_bigint_uint64,
+            napi_create_bigint_words,
+            napi_get_value_bigint_int64,
+            napi_get_value_bigint_uint64,
+            napi_get_value_bigint_words,
+            napi_get_all_property_names,
+            napi_set_instance_data,
+            napi_get_instance_data,
+            napi_detach_arraybuffer,
+            napi_is_detached_arraybuffer,
+            napi_type_tag_object,
+            napi_check_object_type_tag,
+            napi_object_freeze,
+            napi_object_seal,
+
+            // node_api.h APIs
+            napi_module_register,
+            napi_fatal_error,
+            napi_async_init,
+            napi_async_destroy,
+            napi_make_callback,
+            napi_create_buffer,
+            napi_create_external_buffer,
+            napi_create_buffer_copy,
+            napi_is_buffer,
+            napi_get_buffer_info,
+            napi_create_async_work,
+            napi_delete_async_work,
+            napi_queue_async_work,
+            napi_cancel_async_work,
+            napi_get_node_version,
+            napi_get_uv_event_loop,
+            napi_fatal_exception,
+            napi_add_env_cleanup_hook,
+            napi_remove_env_cleanup_hook,
+            napi_open_callback_scope,
+            napi_close_callback_scope,
+            napi_create_threadsafe_function,
+            napi_get_threadsafe_function_context,
+            napi_call_threadsafe_function,
+            napi_acquire_threadsafe_function,
+            napi_release_threadsafe_function,
+            napi_unref_threadsafe_function,
+            napi_ref_threadsafe_function,
+            napi_add_async_cleanup_hook,
+            napi_remove_async_cleanup_hook,
+            node_api_get_module_file_name,
+
+            // A special value to get function count. Must the last one.
+            FunctionCount,
+        }
 
         //===========================================================================
         // Specialized pointer types
@@ -143,16 +308,17 @@ public static partial class JSNativeApi
         {
             public delegate* unmanaged[Cdecl]<napi_env, napi_callback_info, napi_value> Handle;
 
-            public napi_callback(delegate* unmanaged[Cdecl]<napi_env, napi_callback_info, napi_value> handle) =>
-              Handle = handle;
+            public napi_callback(delegate* unmanaged[Cdecl]<
+                    napi_env, napi_callback_info, napi_value> handle)
+                => Handle = handle;
         }
 
         public unsafe struct napi_finalize
         {
             public delegate* unmanaged[Cdecl]<napi_env, nint, nint, void> Handle;
 
-            public napi_finalize(delegate* unmanaged[Cdecl]<napi_env, nint, nint, void> handle) =>
-              Handle = handle;
+            public napi_finalize(delegate* unmanaged[Cdecl]<napi_env, nint, nint, void> handle)
+                => Handle = handle;
         }
 
         public unsafe struct napi_property_descriptor
@@ -220,451 +386,1398 @@ public static partial class JSNativeApi
             public static readonly c_bool False = new(false);
         }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_last_error_info(napi_env env, out napi_extended_error_info* result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_undefined(napi_env env, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_null(napi_env env, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_global(napi_env env, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_boolean(napi_env env, c_bool value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_object(napi_env env, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_array(napi_env env, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_array_with_length(napi_env env, nuint length, out napi_value result);
-
-        // napi_status napi_create_double(napi_env env, double value, napi_value *result)
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_double(napi_env env, double value, out napi_value result);
-
-        // napi_status napi_create_int32(napi_env env, int32_t value, napi_value *result)
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_int32(napi_env env, int value, out napi_value result);
-
-        // napi_status napi_create_uint32(napi_env env, uint32_t value, napi_value *result)
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_uint32(napi_env env, uint value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_int64(napi_env env, long value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_string_latin1(napi_env env, byte* str, nuint length, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_string_utf8(napi_env env, byte* str, nuint length, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_string_utf16(napi_env env, char* str, nuint length, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_symbol(napi_env env, napi_value description, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status node_api_symbol_for(napi_env env, byte* utf8name, nuint length, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_function(napi_env env, byte* utf8name, nuint length,
-          napi_callback cb, nint data, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_error(napi_env env, napi_value code, napi_value msg, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_type_error(napi_env env, napi_value code, napi_value msg, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_range_error(napi_env env, napi_value code, napi_value msg, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status node_api_create_syntax_error(napi_env env, napi_value code, napi_value msg, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_typeof(napi_env env, napi_value value, out napi_valuetype result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_double(napi_env env, napi_value value, out double result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_int32(napi_env env, napi_value value, out int result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_uint32(napi_env env, napi_value value, out uint result);
-
-        // napi_status napi_get_value_int64(napi_env env, napi_value value, int64_t *result)
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_int64(napi_env env, napi_value value, out long result);
-
-        // napi_status napi_get_value_bool(napi_env env, napi_value value, bool *result)
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_bool(napi_env env, napi_value value, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_string_latin1(napi_env env, napi_value value,
-           byte* buf, nuint bufsize, out nuint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_string_utf8(napi_env env, napi_value value,
-           byte* buf, nuint bufsize, out nuint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_string_utf16(napi_env env, napi_value value,
-           char* buf, nuint bufsize, out nuint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_coerce_to_bool(napi_env env, napi_value value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_coerce_to_number(napi_env env, napi_value value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_coerce_to_object(napi_env env, napi_value value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_coerce_to_string(napi_env env, napi_value value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_prototype(napi_env env, napi_value @object, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_property_names(napi_env env, napi_value @object, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_set_property(napi_env env, napi_value @object, napi_value key, napi_value value);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_has_property(napi_env env, napi_value @object, napi_value key, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_property(napi_env env, napi_value @object, napi_value key, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_delete_property(napi_env env, napi_value @object, napi_value key, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_has_own_property(napi_env env, napi_value @object, napi_value key, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_set_named_property(
-          napi_env env,
-          napi_value @object,
-          byte* utf8name,
-          napi_value value);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_has_named_property(
-          napi_env env,
-          napi_value @object,
-          byte* utf8name,
-          out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_named_property(
-          napi_env env,
-          napi_value @object,
-          byte* utf8name,
-          out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_set_element(napi_env env, napi_value @object, uint index, napi_value value);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_has_element(napi_env env, napi_value @object, uint index, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_element(napi_env env, napi_value @object, uint index, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_delete_element(napi_env env, napi_value @object, uint index, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_define_properties(napi_env env, napi_value @object,
-           nuint property_count, napi_property_descriptor* properties);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_array(napi_env env, napi_value value, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_array_length(napi_env env, napi_value value, out uint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_strict_equals(napi_env env, napi_value lhs, napi_value rhs, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_call_function(napi_env env, napi_value recv, napi_value func,
-           nuint argc, napi_value* argv, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_new_instance(napi_env env, napi_value constructor,
-           nuint argc, napi_value* argv, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_instanceof(napi_env env, napi_value @object, napi_value constructor, out c_bool result);
-
-        // napi_status napi_get_cb_info(
-        //     napi_env env,              // [in] NAPI environment handle
-        //     napi_callback_info cbinfo, // [in] Opaque callback-info handle
-        //     size_t* argc,              // [in-out] Specifies the size of the provided argv array
-        //                                // and receives the actual count of args.
-        //     napi_value* argv,          // [out] Array of values
-        //     napi_value* this_arg,      // [out] Receives the JS 'this' arg for the call
-        //     void** data)               // [out] Receives the data pointer for the callback.
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
-          nuint* argc, napi_value* argv, napi_value* this_arg, nint* data);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_new_target(napi_env env, napi_callback_info cbinfo, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_define_class(
-           napi_env env,
-           byte* utf8name,
-           nuint length,
-           napi_callback constructor,
-           nint data,
-           nuint property_count,
-           napi_property_descriptor* properties,
-           out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_wrap(
-          napi_env env,
-          napi_value js_object,
-          nint native_object,
-          napi_finalize finalize_cb,
-          nint finalize_hint,
-          napi_ref* result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_unwrap(napi_env env, napi_value js_object, out nint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_remove_wrap(napi_env env, napi_value js_object, out nint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_external(
-          napi_env env,
-          nint data,
-          napi_finalize finalize_cb,
-          nint finalize_hint,
-          out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_external(napi_env env, napi_value value, out nint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_reference(napi_env env, napi_value value,
-           uint initial_refcount, out napi_ref result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_delete_reference(napi_env env, napi_ref @ref);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_reference_ref(napi_env env, napi_ref @ref, nint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_reference_unref(napi_env env, napi_ref @ref, nint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_reference_value(napi_env env, napi_ref @ref, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_open_handle_scope(napi_env env, out napi_handle_scope result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_close_handle_scope(napi_env env, napi_handle_scope scope);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_open_escapable_handle_scope(napi_env env, out napi_escapable_handle_scope result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_close_escapable_handle_scope(napi_env env, napi_escapable_handle_scope scope);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_escape_handle(napi_env env, napi_escapable_handle_scope scope,
-           napi_value escapee, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_throw(napi_env env, napi_value error);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_throw_error(napi_env env,
-           [MarshalAs(UnmanagedType.LPUTF8Str)] string? code, [MarshalAs(UnmanagedType.LPUTF8Str)] string msg);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_throw_type_error(napi_env env,
-           [MarshalAs(UnmanagedType.LPUTF8Str)] string? code, [MarshalAs(UnmanagedType.LPUTF8Str)] string msg);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_throw_range_error(napi_env env,
-           [MarshalAs(UnmanagedType.LPUTF8Str)] string? code, [MarshalAs(UnmanagedType.LPUTF8Str)] string msg);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status node_api_throw_syntax_error(napi_env env,
-            [MarshalAs(UnmanagedType.LPUTF8Str)] string? code, [MarshalAs(UnmanagedType.LPUTF8Str)] string msg);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_error(napi_env env, napi_value value, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_exception_pending(napi_env env, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_and_clear_last_exception(napi_env env, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_arraybuffer(napi_env env, napi_value value, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_arraybuffer(napi_env env, nuint byte_length,
-           out void* data, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_external_arraybuffer(napi_env env,
-           void* external_data, nuint byte_length, napi_finalize finalize_cb,
-           nint finalize_hint, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_arraybuffer_info(napi_env env, napi_value arraybuffer,
-           out void* data, out nuint byte_length);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_typedarray(napi_env env, napi_value value, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_typedarray(
-          napi_env env,
-          napi_typedarray_type type,
-          nuint length,
-          napi_value arraybuffer,
-          nuint byte_offset,
-          out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_typedarray_info(
-          napi_env env,
-          napi_value typedarray,
-          out napi_typedarray_type type,
-          out nuint length,
-          out void* data,
-          out napi_value arraybuffer,
-          out nuint byte_offset);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_dataview(napi_env env, nuint length,
-           napi_value arraybuffer, nuint byte_offset, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_dataview(napi_env env, napi_value value, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_dataview_info(napi_env env, napi_value dataview,
-           out nuint bytelength, out void* data, out napi_value arraybuffer, out nuint byte_offset);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_version(napi_env env, out uint result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_promise(napi_env env, out napi_deferred deferred, out napi_value promise);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_resolve_deferred(napi_env env, napi_deferred deferred, napi_value resolution);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_reject_deferred(napi_env env, napi_deferred deferred, napi_value rejection);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_promise(napi_env env, napi_value value, out c_bool is_promise);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_run_script(napi_env env, napi_value script, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_adjust_external_memory(napi_env env, long change_in_bytes, out long adjusted_value);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_date(napi_env env, double time, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_date(napi_env env, napi_value value, out c_bool is_date);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_date_value(napi_env env, napi_value value, out double result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_add_finalizer(napi_env env, napi_value js_object,
-           nint native_object, napi_finalize finalize_cb, nint finalize_hint, napi_ref* result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_bigint_int64(napi_env env, long value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_bigint_uint64(napi_env env, ulong value, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_create_bigint_words(napi_env env, int sign_bit,
-           nuint word_count, ulong* words, out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_bigint_int64(napi_env env, napi_value value,
-           out long result, out c_bool lossless);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_bigint_uint64(napi_env env, napi_value value,
-           out ulong result, out c_bool lossless);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_value_bigint_words(napi_env env, napi_value value,
-           out int sign_bit, out nuint word_count, ulong* words);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_all_property_names(
-          napi_env env,
-          napi_value @object,
-          napi_key_collection_mode key_mode,
-          napi_key_filter key_filter,
-          napi_key_conversion key_conversion,
-          out napi_value result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_set_instance_data(
-          napi_env env,
-          nint data,
-          napi_finalize finalize_cb,
-          nint finalize_hint);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_get_instance_data(napi_env env, out nint data);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_is_detached_arraybuffer(napi_env env, napi_value value, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_type_tag_object(napi_env env, napi_value value, in napi_type_tag type_tag);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_check_object_type_tag(napi_env env, napi_value value,
-           in napi_type_tag type_tag, out c_bool result);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_object_freeze(napi_env env, napi_value @object);
-
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static partial napi_status napi_object_seal(napi_env env, napi_value @object);
+        internal static napi_status napi_get_last_error_info(napi_env env, out nint result)
+            => CallInterop(Current, FunctionId.napi_get_last_error_info, env, out result);
+
+        internal static napi_status napi_get_undefined(napi_env env, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_get_undefined, env, out result);
+
+        internal static napi_status napi_get_null(napi_env env, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_get_null, env, out result);
+
+        internal static napi_status napi_get_global(napi_env env, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_get_global, env, out result);
+
+        internal static napi_status napi_get_boolean(
+            napi_env env, c_bool value, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_get_boolean);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, c_bool, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_create_object(napi_env env, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_create_object, env, out result);
+
+        internal static napi_status napi_create_array(napi_env env, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_create_array, env, out result);
+
+        internal static napi_status napi_create_array_with_length(
+            napi_env env, nuint length, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_create_array_with_length, env, (nint)length, out result);
+
+        internal static napi_status napi_create_double(
+            napi_env env, double value, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_double);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, double, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_create_int32(
+            napi_env env, int value, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_int32);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, int, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_create_uint32(
+            napi_env env, uint value, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_uint32);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, uint, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_create_int64(
+            napi_env env, long value, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_int64);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, long, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_create_string_latin1(
+            napi_env env, byte* str, nuint length, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_string_latin1,
+                env,
+                (nint)str,
+                (nint)length,
+                out result);
+
+        internal static napi_status napi_create_string_utf8(
+            napi_env env, byte* str, nuint length, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_string_utf8,
+                env,
+                (nint)str,
+                (nint)length,
+                out result);
+
+        internal static napi_status napi_create_string_utf16(
+            napi_env env, char* str, nuint length, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_string_utf16,
+                env,
+                (nint)str,
+                (nint)length,
+                out result);
+
+        internal static napi_status napi_create_symbol(
+            napi_env env, napi_value description, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_create_symbol, env, description.Handle, out result);
+
+        internal static napi_status node_api_symbol_for(
+            napi_env env, byte* utf8name, nuint length, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.node_api_symbol_for,
+                env,
+                (nint)utf8name,
+                (nint)length,
+                out result);
+
+        internal static napi_status napi_create_function(
+            napi_env env,
+            byte* utf8name,
+            nuint length,
+            napi_callback cb,
+            nint data,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_function,
+                env,
+                (nint)utf8name,
+                (nint)length,
+                (nint)cb.Handle,
+                data,
+                out result);
+
+        internal static napi_status napi_create_error(
+            napi_env env, napi_value code, napi_value msg, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_error);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, napi_value, napi_value, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, code, msg, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_create_type_error(
+            napi_env env, napi_value code, napi_value msg, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_type_error,
+                env,
+                code.Handle,
+                msg.Handle,
+                out result);
+
+        internal static napi_status napi_create_range_error(
+            napi_env env, napi_value code, napi_value msg, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_range_error,
+                env,
+                code.Handle,
+                msg.Handle,
+                out result);
+
+        internal static napi_status node_api_create_syntax_error(
+            napi_env env, napi_value code, napi_value msg, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.node_api_create_syntax_error,
+                env,
+                code.Handle,
+                msg.Handle,
+                out result);
+
+        internal static napi_status napi_typeof(
+            napi_env env, napi_value value, out napi_valuetype result)
+            => CallInterop(Current, FunctionId.napi_typeof, env, value.Handle, out result);
+
+        internal static napi_status napi_get_value_double(
+            napi_env env, napi_value value, out double result)
+            => CallInterop(
+                Current, FunctionId.napi_get_value_double, env, value.Handle, out result);
+
+        internal static napi_status napi_get_value_int32(
+            napi_env env, napi_value value, out int result)
+            => CallInterop(
+                Current, FunctionId.napi_get_value_int32, env, value.Handle, out result);
+
+        internal static napi_status napi_get_value_uint32(
+            napi_env env, napi_value value, out uint result)
+            => CallInterop(
+                Current, FunctionId.napi_get_value_uint32, env, value.Handle, out result);
+
+        internal static napi_status napi_get_value_int64(
+            napi_env env, napi_value value, out long result)
+            => CallInterop(
+                Current, FunctionId.napi_get_value_int64, env, value.Handle, out result);
+
+        internal static napi_status napi_get_value_bool(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(
+                Current, FunctionId.napi_get_value_bool, env, value.Handle, out result);
+
+        internal static napi_status napi_get_value_string_latin1(
+            napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_value_string_latin1,
+                env,
+                value.Handle,
+                buf,
+                (nint)bufsize,
+                out result);
+
+        internal static napi_status napi_get_value_string_utf8(
+            napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_value_string_utf8,
+                env,
+                value.Handle,
+                buf,
+                (nint)bufsize,
+                out result);
+
+        internal static napi_status napi_get_value_string_utf16(
+            napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_value_string_utf16,
+                env,
+                value.Handle,
+                buf,
+                (nint)bufsize,
+                out result);
+
+        internal static napi_status napi_coerce_to_bool(
+            napi_env env, napi_value value, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_coerce_to_bool, env, value.Handle, out result);
+
+        internal static napi_status napi_coerce_to_number(
+            napi_env env, napi_value value, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_coerce_to_number, env, value.Handle, out result);
+
+        internal static napi_status napi_coerce_to_object(
+            napi_env env, napi_value value, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_coerce_to_object, env, value.Handle, out result);
+
+        internal static napi_status napi_coerce_to_string(
+            napi_env env, napi_value value, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_coerce_to_string, env, value.Handle, out result);
+
+        internal static napi_status napi_get_prototype(
+            napi_env env, napi_value js_object, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_get_prototype, env, js_object.Handle, out result);
+
+        internal static napi_status napi_get_property_names(
+            napi_env env, napi_value js_object, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_get_property_names, env, js_object.Handle, out result);
+
+        internal static napi_status napi_set_property(
+            napi_env env, napi_value js_object, napi_value key, napi_value value)
+            => CallInterop(
+                Current,
+                FunctionId.napi_set_property,
+                env,
+                js_object.Handle,
+                key.Handle,
+                value.Handle);
+
+        internal static napi_status napi_has_property(
+            napi_env env, napi_value js_object, napi_value key, out c_bool result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_has_property,
+                env,
+                js_object.Handle,
+                key.Handle,
+                out result);
+
+        internal static napi_status napi_get_property(
+            napi_env env, napi_value js_object, napi_value key, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_property,
+                env,
+                js_object.Handle,
+                key.Handle,
+                out result);
+
+        internal static napi_status napi_delete_property(
+            napi_env env, napi_value js_object, napi_value key, out c_bool result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_delete_property,
+                env,
+                js_object.Handle,
+                key.Handle,
+                out result);
+
+        internal static napi_status napi_has_own_property(
+            napi_env env, napi_value js_object, napi_value key, out c_bool result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_has_own_property,
+                env,
+                js_object.Handle,
+                key.Handle,
+                out result);
+
+        internal static napi_status napi_set_named_property(
+            napi_env env, napi_value js_object, nint utf8name, napi_value value)
+            => CallInterop(
+                Current,
+                FunctionId.napi_set_named_property,
+                env,
+                js_object.Handle,
+                utf8name,
+                value.Handle);
+
+        internal static napi_status napi_has_named_property(
+            napi_env env, napi_value js_object, nint utf8name, out c_bool result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_has_named_property,
+                env,
+                js_object.Handle,
+                utf8name,
+                out result);
+
+        internal static napi_status napi_get_named_property(
+            napi_env env, napi_value js_object, nint utf8name, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_named_property,
+                env,
+                js_object.Handle,
+                utf8name,
+                out result);
+
+        internal static napi_status napi_set_element(
+            napi_env env, napi_value js_object, uint index, napi_value value)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_set_element);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, napi_value, uint, napi_value, napi_status>)funcHandle;
+            return funcDelegate(env, js_object, index, value);
+        }
+
+        internal static napi_status napi_has_element(
+            napi_env env, napi_value js_object, uint index, out c_bool result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_has_element,
+                env,
+                js_object.Handle,
+                index,
+                out result);
+
+        internal static napi_status napi_get_element(
+            napi_env env, napi_value js_object, uint index, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_element,
+                env,
+                js_object.Handle,
+                index,
+                out result);
+
+        internal static napi_status napi_delete_element(
+            napi_env env, napi_value js_object, uint index, out c_bool result)
+            => CallInterop(
+                Current, FunctionId.napi_delete_element, env, js_object.Handle, index, out result);
+
+        internal static napi_status napi_define_properties(
+            napi_env env, napi_value js_object, nuint property_count, nint properties)
+            => CallInterop(
+                Current,
+                FunctionId.napi_define_properties,
+                env,
+                js_object.Handle,
+                (nint)property_count,
+                properties);
+
+        internal static napi_status napi_is_array(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(Current, FunctionId.napi_is_array, env, value.Handle, out result);
+
+        internal static napi_status napi_get_array_length(
+            napi_env env, napi_value value, out uint result)
+            => CallInterop(
+                Current, FunctionId.napi_get_array_length, env, value.Handle, out result);
+
+        internal static napi_status napi_strict_equals(
+            napi_env env, napi_value lhs, napi_value rhs, out c_bool result)
+            => CallInterop(
+                Current, FunctionId.napi_strict_equals, env, lhs.Handle, rhs.Handle, out result);
+
+        internal static napi_status napi_call_function(
+            napi_env env,
+            napi_value recv,
+            napi_value func,
+            nuint argc,
+            nint argv,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_call_function,
+                env,
+                recv.Handle,
+                func.Handle,
+                (nint)argc,
+                argv,
+                out result);
+
+        internal static napi_status napi_new_instance(
+            napi_env env,
+            napi_value constructor,
+            nuint argc,
+            nint argv,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_new_instance,
+                env,
+                constructor.Handle,
+                (nint)argc,
+                argv,
+                out result);
+
+        internal static napi_status napi_instanceof(
+            napi_env env, napi_value js_object, napi_value constructor, out c_bool result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_instanceof,
+                env,
+                js_object.Handle,
+                constructor.Handle,
+                out result);
+
+        internal static napi_status napi_get_cb_info(
+            napi_env env,              // [in] NAPI environment handle
+            napi_callback_info cbinfo, // [in] Opaque callback-info handle
+            nuint* argc,               // [in-out] Specifies the size of the provided argv array
+                                       // and receives the actual count of args.
+            napi_value* argv,          // [out] Array of values
+            napi_value* this_arg,      // [out] Receives the JS 'this' arg for the call
+            nint* data)                // [out] Receives the data pointer for the callback.
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_cb_info,
+                env,
+                cbinfo.Handle,
+                (nint)argc,
+                (nint)argv,
+                (nint)this_arg,
+                (nint)data);
+
+        internal static napi_status napi_get_new_target(
+            napi_env env, napi_callback_info cbinfo, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_get_new_target, env, cbinfo.Handle, out result);
+
+        internal static napi_status napi_define_class(
+            napi_env env,
+            nint utf8name,
+            nuint length,
+            napi_callback constructor,
+            nint data,
+            nuint property_count,
+            nint properties,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_define_class,
+                env,
+                utf8name,
+                (nint)length,
+                (nint)constructor.Handle,
+                data,
+                (nint)property_count,
+                properties,
+                out result);
+
+        internal static napi_status napi_wrap(
+            napi_env env,
+            napi_value js_object,
+            nint native_object,
+            napi_finalize finalize_cb,
+            nint finalize_hint,
+            napi_ref* result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_wrap,
+                env,
+                js_object.Handle,
+                native_object,
+                (nint)finalize_cb.Handle,
+                finalize_hint,
+                (nint)result);
+
+        internal static napi_status napi_unwrap(
+            napi_env env, napi_value js_object, out nint result)
+            => CallInterop(Current, FunctionId.napi_unwrap, env, js_object.Handle, out result);
+
+        internal static napi_status napi_remove_wrap(
+            napi_env env, napi_value js_object, out nint result)
+            => CallInterop(
+                Current, FunctionId.napi_remove_wrap, env, js_object.Handle, out result);
+
+        internal static napi_status napi_create_external(
+            napi_env env,
+            nint data,
+            napi_finalize finalize_cb,
+            nint finalize_hint,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_external,
+                env,
+                data,
+                (nint)finalize_cb.Handle,
+                finalize_hint,
+                out result);
+
+        internal static napi_status napi_get_value_external(
+            napi_env env, napi_value value, out nint result)
+            => CallInterop(
+                Current, FunctionId.napi_get_value_external, env, value.Handle, out result);
+
+        internal static napi_status napi_create_reference(
+            napi_env env, napi_value value, uint initial_refcount, out napi_ref result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_reference);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, napi_value, uint, nint, napi_status>)funcHandle;
+            fixed (napi_ref* result_native = &result)
+            {
+                return funcDelegate(env, value, initial_refcount, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_delete_reference(napi_env env, napi_ref @ref)
+            => CallInterop(Current, FunctionId.napi_delete_reference, env, @ref.Handle);
+
+        internal static napi_status napi_reference_ref(napi_env env, napi_ref @ref, nint result)
+            => CallInterop(Current, FunctionId.napi_reference_ref, env, @ref.Handle, result);
+
+        internal static napi_status napi_reference_unref(napi_env env, napi_ref @ref, nint result)
+            => CallInterop(Current, FunctionId.napi_reference_unref, env, @ref.Handle, result);
+
+        internal static napi_status napi_get_reference_value(
+            napi_env env, napi_ref @ref, out napi_value result)
+            => CallInterop(
+                Current, FunctionId.napi_get_reference_value, env, @ref.Handle, out result);
+
+        internal static napi_status napi_open_handle_scope(
+            napi_env env, out napi_handle_scope result)
+            => CallInterop(Current, FunctionId.napi_open_handle_scope, env, out result);
+
+        internal static napi_status napi_close_handle_scope(napi_env env, napi_handle_scope scope)
+            => CallInterop(Current, FunctionId.napi_close_handle_scope, env, scope.Handle);
+
+        internal static napi_status napi_open_escapable_handle_scope(
+            napi_env env, out napi_escapable_handle_scope result)
+            => CallInterop(Current, FunctionId.napi_open_escapable_handle_scope, env, out result);
+
+        internal static napi_status napi_close_escapable_handle_scope(
+            napi_env env, napi_escapable_handle_scope scope)
+            => CallInterop(
+                Current, FunctionId.napi_close_escapable_handle_scope, env, scope.Handle);
+
+        internal static napi_status napi_escape_handle(napi_env env,
+            napi_escapable_handle_scope scope, napi_value escapee, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_escape_handle,
+                env,
+                scope.Handle,
+                escapee.Handle,
+                out result);
+
+        internal static napi_status napi_throw(napi_env env, napi_value error)
+            => CallInterop(Current, FunctionId.napi_throw, env, error.Handle);
+
+        internal static napi_status napi_throw_error(napi_env env, string? code, string msg)
+            => CallInterop(Current, FunctionId.napi_throw_error, env, code, msg);
+
+        internal static napi_status napi_throw_type_error(napi_env env, string? code, string msg)
+            => CallInterop(Current, FunctionId.napi_throw_type_error, env, code, msg);
+
+        internal static napi_status napi_throw_range_error(napi_env env, string? code, string msg)
+            => CallInterop(Current, FunctionId.napi_throw_range_error, env, code, msg);
+
+        internal static napi_status node_api_throw_syntax_error(
+            napi_env env, string? code, string msg)
+            => CallInterop(Current, FunctionId.node_api_throw_syntax_error, env, code, msg);
+
+        internal static napi_status napi_is_error(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(Current, FunctionId.napi_is_error, env, value.Handle, out result);
+
+        internal static napi_status napi_is_exception_pending(napi_env env, out c_bool result)
+            => CallInterop(Current, FunctionId.napi_is_exception_pending, env, out result);
+
+        internal static napi_status napi_get_and_clear_last_exception(
+            napi_env env, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_get_and_clear_last_exception, env, out result);
+
+        internal static napi_status napi_is_arraybuffer(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(Current, FunctionId.napi_is_arraybuffer, env, value.Handle, out result);
+
+        internal static napi_status napi_create_arraybuffer(
+            napi_env env, nuint byte_length, out nint data, out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_arraybuffer,
+                env,
+                (nint)byte_length,
+                out data,
+                out result);
+
+        internal static napi_status napi_create_external_arraybuffer(
+            napi_env env,
+            nint external_data,
+            nuint byte_length,
+            napi_finalize finalize_cb,
+            nint finalize_hint,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_external_arraybuffer,
+                env,
+                external_data,
+                (nint)byte_length,
+                (nint)finalize_cb.Handle,
+                finalize_hint,
+                out result);
+
+        internal static napi_status napi_get_arraybuffer_info(
+            napi_env env, napi_value arraybuffer, out nint data, out nuint byte_length)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_arraybuffer_info,
+                env,
+                arraybuffer.Handle,
+                out data,
+                out byte_length);
+
+        internal static napi_status napi_is_typedarray(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(Current, FunctionId.napi_is_typedarray, env, value.Handle, out result);
+
+        internal static napi_status napi_create_typedarray(
+            napi_env env,
+            napi_typedarray_type type,
+            nuint length,
+            napi_value arraybuffer,
+            nuint byte_offset,
+            out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_typedarray);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env,
+                napi_typedarray_type,
+                nuint,
+                napi_value,
+                nuint,
+                nint,
+                napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(
+                    env,
+                    type,
+                    length,
+                    arraybuffer,
+                    byte_offset,
+                    (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_get_typedarray_info(
+                napi_env env,
+                napi_value typedarray,
+                out napi_typedarray_type type,
+                out nuint length,
+                out nint data,
+                out napi_value arraybuffer,
+                out nuint byte_offset)
+                => CallInterop(
+                    Current,
+                    FunctionId.napi_get_typedarray_info,
+                    env,
+                    typedarray.Handle,
+                    out type,
+                    out length,
+                    out data,
+                    out arraybuffer,
+                    out byte_offset);
+
+        internal static napi_status napi_create_dataview(
+            napi_env env,
+            nuint length,
+            napi_value arraybuffer,
+            nuint byte_offset,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_dataview,
+                env,
+                (nint)length,
+                arraybuffer.Handle,
+                (nint)byte_offset,
+                out result);
+
+        internal static napi_status napi_is_dataview(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(Current, FunctionId.napi_is_dataview, env, value.Handle, out result);
+
+        internal static napi_status napi_get_dataview_info(
+            napi_env env,
+            napi_value dataview,
+            out nuint bytelength,
+            out nint data,
+            out napi_value arraybuffer,
+            out nuint byte_offset)
+            => CallInterop(
+                Current, FunctionId.napi_get_dataview_info,
+                env,
+                dataview.Handle,
+                out bytelength,
+                out data,
+                out arraybuffer,
+                out byte_offset);
+
+        internal static napi_status napi_get_version(napi_env env, out uint result)
+            => CallInterop(Current, FunctionId.napi_get_version, env, out result);
+
+        internal static napi_status napi_create_promise(
+            napi_env env, out napi_deferred deferred, out napi_value promise)
+            => CallInterop(
+                Current, FunctionId.napi_create_promise, env, out deferred, out promise);
+
+        internal static napi_status napi_resolve_deferred(
+            napi_env env, napi_deferred deferred, napi_value resolution)
+            => CallInterop(
+                Current,
+                FunctionId.napi_resolve_deferred,
+                env,
+                deferred.Handle,
+                resolution.Handle);
+
+        internal static napi_status napi_reject_deferred(
+            napi_env env, napi_deferred deferred, napi_value rejection)
+            => CallInterop(
+                Current, FunctionId.napi_reject_deferred, env, deferred.Handle, rejection.Handle);
+
+        internal static napi_status napi_is_promise(
+            napi_env env, napi_value value, out c_bool is_promise)
+            => CallInterop(Current, FunctionId.napi_is_promise, env, value.Handle, out is_promise);
+
+        internal static napi_status napi_run_script(
+            napi_env env, napi_value script, out napi_value result)
+            => CallInterop(Current, FunctionId.napi_run_script, env, script.Handle, out result);
+
+        internal static napi_status napi_adjust_external_memory(
+            napi_env env, long change_in_bytes, out long adjusted_value)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_adjust_external_memory);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, long, nint, napi_status>)funcHandle;
+            fixed (long* adjusted_value_native = &adjusted_value)
+            {
+                return funcDelegate(env, change_in_bytes, (nint)adjusted_value_native);
+            }
+        }
+
+        internal static napi_status napi_create_date(
+            napi_env env, double time, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_date);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, double, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, time, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_is_date(
+            napi_env env, napi_value value, out c_bool is_date)
+            => CallInterop(Current, FunctionId.napi_is_date, env, value.Handle, out is_date);
+
+        internal static napi_status napi_get_date_value(
+            napi_env env, napi_value value, out double result)
+            => CallInterop(Current, FunctionId.napi_get_date_value, env, value.Handle, out result);
+
+        internal static napi_status napi_add_finalizer(
+            napi_env env,
+            napi_value js_object,
+            nint native_object,
+            napi_finalize finalize_cb,
+            nint finalize_hint,
+            napi_ref* result)
+            => CallInterop(
+                Current, FunctionId.napi_add_finalizer,
+                env,
+                js_object.Handle,
+                native_object,
+                (nint)finalize_cb.Handle,
+                finalize_hint,
+                (nint)result);
+
+        internal static napi_status napi_create_bigint_int64(
+            napi_env env, long value, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_int64);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, long, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+
+        internal static napi_status napi_create_bigint_uint64(
+            napi_env env, ulong value, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_uint64);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, ulong, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_create_bigint_words(
+            napi_env env, int sign_bit, nuint word_count, ulong* words, out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_uint64);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, int, nuint, nint, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, sign_bit, word_count, (nint)words, (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_get_value_bigint_int64(
+            napi_env env, napi_value value, out long result, out c_bool lossless)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_value_bigint_int64,
+                env,
+                value.Handle,
+                out result,
+                out lossless);
+
+        internal static napi_status napi_get_value_bigint_uint64(
+            napi_env env, napi_value value, out ulong result, out c_bool lossless)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_value_bigint_uint64,
+                env,
+                value.Handle,
+                out result,
+                out lossless);
+
+        internal static napi_status napi_get_value_bigint_words(
+            napi_env env, napi_value value, out int sign_bit, out nuint word_count, ulong* words)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_value_bigint_words,
+                env,
+                value.Handle,
+                out sign_bit,
+                out word_count,
+                (nint)words);
+
+        internal static napi_status napi_get_all_property_names(
+            napi_env env,
+            napi_value js_object,
+            napi_key_collection_mode key_mode,
+            napi_key_filter key_filter,
+            napi_key_conversion key_conversion,
+            out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_uint64);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env,
+                napi_value,
+                napi_key_collection_mode,
+                napi_key_filter,
+                napi_key_conversion,
+                nint,
+                napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(
+                    env,
+                    js_object,
+                    key_mode,
+                    key_filter,
+                    key_conversion,
+                    (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_set_instance_data(
+            napi_env env, nint data, napi_finalize finalize_cb, nint finalize_hint)
+        {
+            nint funcHandle = Current!.GetExport(
+                FunctionId.napi_set_instance_data, nameof(napi_set_instance_data));
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, napi_finalize, nint, napi_status>)funcHandle;
+            return funcDelegate(env, data, finalize_cb, finalize_hint);
+        }
+
+        internal static napi_status napi_get_instance_data(napi_env env, out nint data)
+            => CallInterop(Current, FunctionId.napi_get_instance_data, env, out data);
+
+        internal static napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer)
+            => CallInterop(Current, FunctionId.napi_detach_arraybuffer, env, arraybuffer.Handle);
+
+        internal static napi_status napi_is_detached_arraybuffer(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(
+                Current, FunctionId.napi_is_detached_arraybuffer, env, value.Handle, out result);
+
+        internal static napi_status napi_type_tag_object(
+            napi_env env, napi_value value, in napi_type_tag type_tag)
+        {
+            fixed (napi_type_tag* type_tag_native = &type_tag)
+            {
+                return CallInterop(
+                    Current,
+                    FunctionId.napi_type_tag_object,
+                    env,
+                    value.Handle,
+                    (nint)type_tag_native);
+            }
+        }
+
+        internal static napi_status napi_check_object_type_tag(
+            napi_env env, napi_value value, in napi_type_tag type_tag, out c_bool result)
+        {
+            fixed (napi_type_tag* type_tag_native = &type_tag)
+            fixed (c_bool* result_native = &result)
+            {
+                return CallInterop(
+                    Current,
+                    FunctionId.napi_check_object_type_tag,
+                    env,
+                    value.Handle,
+                    (nint)type_tag_native,
+                    (nint)result_native);
+            }
+        }
+
+        internal static napi_status napi_object_freeze(napi_env env, napi_value js_object)
+            => CallInterop(Current, FunctionId.napi_object_freeze, env, js_object.Handle);
+
+        internal static napi_status napi_object_seal(napi_env env, napi_value js_object)
+            => CallInterop(Current, FunctionId.napi_object_seal, env, js_object.Handle);
+
+        private nint GetExport(FunctionId functionId, [CallerMemberName] string functionName = "")
+        {
+            nint methodPtr = _functions[(int)functionId];
+            if (methodPtr == nint.Zero)
+            {
+                methodPtr = NativeLibrary.GetExport(_libraryHandle, functionName);
+                _functions[(int)functionId] = methodPtr;
+            }
+
+            return methodPtr;
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(env, (nint)result_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult1, TResult2>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            out TResult1 result1,
+            out TResult2 result2,
+            [CallerMemberName] string functionName = "")
+            where TResult1 : unmanaged
+            where TResult2 : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, napi_status>)funcHandle;
+            fixed (TResult1* result1_native = &result1)
+            fixed (TResult2* result2_native = &result2)
+            {
+                return funcDelegate(env, (nint)result1_native, (nint)result2_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(env, value, (nint)result_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult1, TResult2>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value,
+            out TResult1 result1,
+            out TResult2 result2,
+            [CallerMemberName] string functionName = "")
+            where TResult1 : unmanaged
+            where TResult2 : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult1* result1_native = &result1)
+            fixed (TResult2* result2_native = &result2)
+            {
+                return funcDelegate(env, value, (nint)result1_native, (nint)result2_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult1, TResult2>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value,
+            out TResult1 result1,
+            out TResult2 result2,
+            nint result3,
+            [CallerMemberName] string functionName = "")
+            where TResult1 : unmanaged
+            where TResult2 : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult1* result1_native = &result1)
+            fixed (TResult2* result2_native = &result2)
+            {
+                return funcDelegate(
+                    env, value, (nint)result1_native, (nint)result2_native, result3);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult1, TResult2, TResult3, TResult4>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value,
+            out TResult1 result1,
+            out TResult2 result2,
+            out TResult3 result3,
+            out TResult4 result4,
+            [CallerMemberName] string functionName = "")
+            where TResult1 : unmanaged
+            where TResult2 : unmanaged
+            where TResult3 : unmanaged
+            where TResult4 : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult1* result1_native = &result1)
+            fixed (TResult2* result2_native = &result2)
+            fixed (TResult3* result3_native = &result3)
+            fixed (TResult4* result4_native = &result4)
+            {
+                return funcDelegate(
+                    env,
+                    value,
+                    (nint)result1_native,
+                    (nint)result2_native,
+                    (nint)result3_native,
+                    (nint)result4_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<
+            TResult1, TResult2, TResult3, TResult4, TResult5>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value,
+            out TResult1 result1,
+            out TResult2 result2,
+            out TResult3 result3,
+            out TResult4 result4,
+            out TResult5 result5,
+            [CallerMemberName] string functionName = "")
+            where TResult1 : unmanaged
+            where TResult2 : unmanaged
+            where TResult3 : unmanaged
+            where TResult4 : unmanaged
+            where TResult5 : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env,
+                nint,
+                nint,
+                nint,
+                nint,
+                nint,
+                nint,
+                napi_status>)funcHandle;
+            fixed (TResult1* result1_native = &result1)
+            fixed (TResult2* result2_native = &result2)
+            fixed (TResult3* result3_native = &result3)
+            fixed (TResult4* result4_native = &result4)
+            fixed (TResult5* result5_native = &result5)
+            {
+                return funcDelegate(
+                    env,
+                    value,
+                    (nint)result1_native,
+                    (nint)result2_native,
+                    (nint)result3_native,
+                    (nint)result4_native,
+                    (nint)result5_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(env, value1, value2, (nint)result_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            uint value2,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, uint, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(env, value1, value2, (nint)result_native);
+            }
+        }
+        private static unsafe napi_status CallInterop(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, napi_status>)funcHandle;
+            return funcDelegate(env, value1, value2);
+        }
+
+        private static unsafe napi_status CallInterop(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            nint value3,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, napi_status>)funcHandle;
+            return funcDelegate(env, value1, value2, value3);
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            nint value3,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(env, value1, value2, value3, (nint)result_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            nint value3,
+            nint value4,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(env, value1, value2, value3, value4, (nint)result_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            nint value3,
+            nint value4,
+            nint value5,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
+            return funcDelegate(env, value1, value2, value3, value4, value5);
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            nint value3,
+            nint value4,
+            nint value5,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(
+                    env, value1, value2, value3, value4, value5, (nint)result_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop<TResult>(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value1,
+            nint value2,
+            nint value3,
+            nint value4,
+            nint value5,
+            nint value6,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(
+                    env, value1, value2, value3, value4, value5, value6, (nint)result_native);
+            }
+        }
+
+        private static unsafe napi_status CallInterop(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            nint value,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<napi_env, nint, napi_status>)funcHandle;
+            return funcDelegate(env, value);
+        }
+
+        private static napi_status CallInterop(
+            Interop? interop,
+            FunctionId functionId,
+            napi_env env,
+            string? value1,
+            string? value2,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = interop!.GetExport(functionId, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, napi_status>)funcHandle;
+
+            Utf8StringMarshaller.ManagedToUnmanagedIn value1_marshaller = new();
+            Utf8StringMarshaller.ManagedToUnmanagedIn value2_marshaller = new();
+            try
+            {
+                int bufferSize = Utf8StringMarshaller.ManagedToUnmanagedIn.BufferSize;
+
+                byte* value1_stackptr = stackalloc byte[bufferSize];
+                value1_marshaller.FromManaged(value1, new Span<byte>(value1_stackptr, bufferSize));
+                byte* value1_native = value1_marshaller.ToUnmanaged();
+
+                byte* value2_stackptr = stackalloc byte[bufferSize];
+                value2_marshaller.FromManaged(value2, new Span<byte>(value2_stackptr, bufferSize));
+                byte* value2_native = value2_marshaller.ToUnmanaged();
+
+                return funcDelegate(env, (nint)value1_native, (nint)value2_native);
+            }
+            finally
+            {
+                value1_marshaller.Free();
+                value2_marshaller.Free();
+            }
+        }
     }
 }

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -14,9 +14,8 @@ public static partial class JSNativeApi
     [SuppressUnmanagedCodeSecurity]
     public unsafe static partial class Interop
     {
-        private static nint _libraryHandle;
-        private static readonly nint[] _functions = new nint[(int)FunctionId.FunctionCount];
-
+        private static nint s_libraryHandle;
+        private static FunctionFields s_fields = new();
         private static bool s_initialized;
 
         public static void Initialize(nint libraryHandle)
@@ -24,7 +23,7 @@ public static partial class JSNativeApi
             if (s_initialized) return;
             s_initialized = true;
 
-            _libraryHandle = libraryHandle;
+            s_libraryHandle = libraryHandle;
 
             // Node APIs are all imported from the main `node` executable. Overriding the import
             // resolution is more efficient and avoids issues with library search paths and
@@ -43,163 +42,160 @@ public static partial class JSNativeApi
 
         public static readonly nuint NAPI_AUTO_LENGTH = nuint.MaxValue;
 
-        public enum FunctionId
+        private struct FunctionFields
         {
             // js_native_api.h APIs
-            napi_get_last_error_info,
-            napi_get_undefined,
-            napi_get_null,
-            napi_get_global,
-            napi_get_boolean,
-            napi_create_object,
-            napi_create_array,
-            napi_create_array_with_length,
-            napi_create_double,
-            napi_create_int32,
-            napi_create_uint32,
-            napi_create_int64,
-            napi_create_string_latin1,
-            napi_create_string_utf8,
-            napi_create_string_utf16,
-            napi_create_symbol,
-            node_api_symbol_for,
-            napi_create_function,
-            napi_create_error,
-            napi_create_type_error,
-            napi_create_range_error,
-            node_api_create_syntax_error,
-            napi_typeof,
-            napi_get_value_double,
-            napi_get_value_int32,
-            napi_get_value_uint32,
-            napi_get_value_int64,
-            napi_get_value_bool,
-            napi_get_value_string_latin1,
-            napi_get_value_string_utf8,
-            napi_get_value_string_utf16,
-            napi_coerce_to_bool,
-            napi_coerce_to_number,
-            napi_coerce_to_object,
-            napi_coerce_to_string,
-            napi_get_prototype,
-            napi_get_property_names,
-            napi_set_property,
-            napi_has_property,
-            napi_get_property,
-            napi_delete_property,
-            napi_has_own_property,
-            napi_set_named_property,
-            napi_has_named_property,
-            napi_get_named_property,
-            napi_set_element,
-            napi_has_element,
-            napi_get_element,
-            napi_delete_element,
-            napi_define_properties,
-            napi_is_array,
-            napi_get_array_length,
-            napi_strict_equals,
-            napi_call_function,
-            napi_new_instance,
-            napi_instanceof,
-            napi_get_cb_info,
-            napi_get_new_target,
-            napi_define_class,
-            napi_wrap,
-            napi_unwrap,
-            napi_remove_wrap,
-            napi_create_external,
-            napi_get_value_external,
-            napi_create_reference,
-            napi_delete_reference,
-            napi_reference_ref,
-            napi_reference_unref,
-            napi_get_reference_value,
-            napi_open_handle_scope,
-            napi_close_handle_scope,
-            napi_open_escapable_handle_scope,
-            napi_close_escapable_handle_scope,
-            napi_escape_handle,
-            napi_throw,
-            napi_throw_error,
-            napi_throw_type_error,
-            napi_throw_range_error,
-            node_api_throw_syntax_error,
-            napi_is_error,
-            napi_is_exception_pending,
-            napi_get_and_clear_last_exception,
-            napi_is_arraybuffer,
-            napi_create_arraybuffer,
-            napi_create_external_arraybuffer,
-            napi_get_arraybuffer_info,
-            napi_is_typedarray,
-            napi_create_typedarray,
-            napi_get_typedarray_info,
-            napi_create_dataview,
-            napi_is_dataview,
-            napi_get_dataview_info,
-            napi_get_version,
-            napi_create_promise,
-            napi_resolve_deferred,
-            napi_reject_deferred,
-            napi_is_promise,
-            napi_run_script,
-            napi_adjust_external_memory,
-            napi_create_date,
-            napi_is_date,
-            napi_get_date_value,
-            napi_add_finalizer,
-            napi_create_bigint_int64,
-            napi_create_bigint_uint64,
-            napi_create_bigint_words,
-            napi_get_value_bigint_int64,
-            napi_get_value_bigint_uint64,
-            napi_get_value_bigint_words,
-            napi_get_all_property_names,
-            napi_set_instance_data,
-            napi_get_instance_data,
-            napi_detach_arraybuffer,
-            napi_is_detached_arraybuffer,
-            napi_type_tag_object,
-            napi_check_object_type_tag,
-            napi_object_freeze,
-            napi_object_seal,
+            public nint napi_get_last_error_info;
+            public nint napi_get_undefined;
+            public nint napi_get_null;
+            public nint napi_get_global;
+            public nint napi_get_boolean;
+            public nint napi_create_object;
+            public nint napi_create_array;
+            public nint napi_create_array_with_length;
+            public nint napi_create_double;
+            public nint napi_create_int32;
+            public nint napi_create_uint32;
+            public nint napi_create_int64;
+            public nint napi_create_string_latin1;
+            public nint napi_create_string_utf8;
+            public nint napi_create_string_utf16;
+            public nint napi_create_symbol;
+            public nint node_api_symbol_for;
+            public nint napi_create_function;
+            public nint napi_create_error;
+            public nint napi_create_type_error;
+            public nint napi_create_range_error;
+            public nint node_api_create_syntax_error;
+            public nint napi_typeof;
+            public nint napi_get_value_double;
+            public nint napi_get_value_int32;
+            public nint napi_get_value_uint32;
+            public nint napi_get_value_int64;
+            public nint napi_get_value_bool;
+            public nint napi_get_value_string_latin1;
+            public nint napi_get_value_string_utf8;
+            public nint napi_get_value_string_utf16;
+            public nint napi_coerce_to_bool;
+            public nint napi_coerce_to_number;
+            public nint napi_coerce_to_object;
+            public nint napi_coerce_to_string;
+            public nint napi_get_prototype;
+            public nint napi_get_property_names;
+            public nint napi_set_property;
+            public nint napi_has_property;
+            public nint napi_get_property;
+            public nint napi_delete_property;
+            public nint napi_has_own_property;
+            public nint napi_set_named_property;
+            public nint napi_has_named_property;
+            public nint napi_get_named_property;
+            public nint napi_set_element;
+            public nint napi_has_element;
+            public nint napi_get_element;
+            public nint napi_delete_element;
+            public nint napi_define_properties;
+            public nint napi_is_array;
+            public nint napi_get_array_length;
+            public nint napi_strict_equals;
+            public nint napi_call_function;
+            public nint napi_new_instance;
+            public nint napi_instanceof;
+            public nint napi_get_cb_info;
+            public nint napi_get_new_target;
+            public nint napi_define_class;
+            public nint napi_wrap;
+            public nint napi_unwrap;
+            public nint napi_remove_wrap;
+            public nint napi_create_external;
+            public nint napi_get_value_external;
+            public nint napi_create_reference;
+            public nint napi_delete_reference;
+            public nint napi_reference_ref;
+            public nint napi_reference_unref;
+            public nint napi_get_reference_value;
+            public nint napi_open_handle_scope;
+            public nint napi_close_handle_scope;
+            public nint napi_open_escapable_handle_scope;
+            public nint napi_close_escapable_handle_scope;
+            public nint napi_escape_handle;
+            public nint napi_throw;
+            public nint napi_throw_error;
+            public nint napi_throw_type_error;
+            public nint napi_throw_range_error;
+            public nint node_api_throw_syntax_error;
+            public nint napi_is_error;
+            public nint napi_is_exception_pending;
+            public nint napi_get_and_clear_last_exception;
+            public nint napi_is_arraybuffer;
+            public nint napi_create_arraybuffer;
+            public nint napi_create_external_arraybuffer;
+            public nint napi_get_arraybuffer_info;
+            public nint napi_is_typedarray;
+            public nint napi_create_typedarray;
+            public nint napi_get_typedarray_info;
+            public nint napi_create_dataview;
+            public nint napi_is_dataview;
+            public nint napi_get_dataview_info;
+            public nint napi_get_version;
+            public nint napi_create_promise;
+            public nint napi_resolve_deferred;
+            public nint napi_reject_deferred;
+            public nint napi_is_promise;
+            public nint napi_run_script;
+            public nint napi_adjust_external_memory;
+            public nint napi_create_date;
+            public nint napi_is_date;
+            public nint napi_get_date_value;
+            public nint napi_add_finalizer;
+            public nint napi_create_bigint_int64;
+            public nint napi_create_bigint_uint64;
+            public nint napi_create_bigint_words;
+            public nint napi_get_value_bigint_int64;
+            public nint napi_get_value_bigint_uint64;
+            public nint napi_get_value_bigint_words;
+            public nint napi_get_all_property_names;
+            public nint napi_set_instance_data;
+            public nint napi_get_instance_data;
+            public nint napi_detach_arraybuffer;
+            public nint napi_is_detached_arraybuffer;
+            public nint napi_type_tag_object;
+            public nint napi_check_object_type_tag;
+            public nint napi_object_freeze;
+            public nint napi_object_seal;
 
             // node_api.h APIs
-            napi_module_register,
-            napi_fatal_error,
-            napi_async_init,
-            napi_async_destroy,
-            napi_make_callback,
-            napi_create_buffer,
-            napi_create_external_buffer,
-            napi_create_buffer_copy,
-            napi_is_buffer,
-            napi_get_buffer_info,
-            napi_create_async_work,
-            napi_delete_async_work,
-            napi_queue_async_work,
-            napi_cancel_async_work,
-            napi_get_node_version,
-            napi_get_uv_event_loop,
-            napi_fatal_exception,
-            napi_add_env_cleanup_hook,
-            napi_remove_env_cleanup_hook,
-            napi_open_callback_scope,
-            napi_close_callback_scope,
-            napi_create_threadsafe_function,
-            napi_get_threadsafe_function_context,
-            napi_call_threadsafe_function,
-            napi_acquire_threadsafe_function,
-            napi_release_threadsafe_function,
-            napi_unref_threadsafe_function,
-            napi_ref_threadsafe_function,
-            napi_add_async_cleanup_hook,
-            napi_remove_async_cleanup_hook,
-            node_api_get_module_file_name,
-
-            // A special value to get function count. Must the last one.
-            FunctionCount,
+            public nint napi_module_register;
+            public nint napi_fatal_error;
+            public nint napi_async_init;
+            public nint napi_async_destroy;
+            public nint napi_make_callback;
+            public nint napi_create_buffer;
+            public nint napi_create_external_buffer;
+            public nint napi_create_buffer_copy;
+            public nint napi_is_buffer;
+            public nint napi_get_buffer_info;
+            public nint napi_create_async_work;
+            public nint napi_delete_async_work;
+            public nint napi_queue_async_work;
+            public nint napi_cancel_async_work;
+            public nint napi_get_node_version;
+            public nint napi_get_uv_event_loop;
+            public nint napi_fatal_exception;
+            public nint napi_add_env_cleanup_hook;
+            public nint napi_remove_env_cleanup_hook;
+            public nint napi_open_callback_scope;
+            public nint napi_close_callback_scope;
+            public nint napi_create_threadsafe_function;
+            public nint napi_get_threadsafe_function_context;
+            public nint napi_call_threadsafe_function;
+            public nint napi_acquire_threadsafe_function;
+            public nint napi_release_threadsafe_function;
+            public nint napi_unref_threadsafe_function;
+            public nint napi_ref_threadsafe_function;
+            public nint napi_add_async_cleanup_hook;
+            public nint napi_remove_async_cleanup_hook;
+            public nint node_api_get_module_file_name;
         }
 
         //===========================================================================
@@ -383,21 +379,21 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_get_last_error_info(napi_env env, out nint result)
-            => CallInterop(FunctionId.napi_get_last_error_info, env, out result);
+            => CallInterop(ref s_fields.napi_get_last_error_info, env, out result);
 
         internal static napi_status napi_get_undefined(napi_env env, out napi_value result)
-            => CallInterop(FunctionId.napi_get_undefined, env, out result);
+            => CallInterop(ref s_fields.napi_get_undefined, env, out result);
 
         internal static napi_status napi_get_null(napi_env env, out napi_value result)
-            => CallInterop(FunctionId.napi_get_null, env, out result);
+            => CallInterop(ref s_fields.napi_get_null, env, out result);
 
         internal static napi_status napi_get_global(napi_env env, out napi_value result)
-            => CallInterop(FunctionId.napi_get_global, env, out result);
+            => CallInterop(ref s_fields.napi_get_global, env, out result);
 
         internal static napi_status napi_get_boolean(
             napi_env env, c_bool value, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_get_boolean);
+            nint funcHandle = GetExport(ref s_fields.napi_get_boolean);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, c_bool, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -407,20 +403,20 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_create_object(napi_env env, out napi_value result)
-            => CallInterop(FunctionId.napi_create_object, env, out result);
+            => CallInterop(ref s_fields.napi_create_object, env, out result);
 
         internal static napi_status napi_create_array(napi_env env, out napi_value result)
-            => CallInterop(FunctionId.napi_create_array, env, out result);
+            => CallInterop(ref s_fields.napi_create_array, env, out result);
 
         internal static napi_status napi_create_array_with_length(
             napi_env env, nuint length, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_array_with_length, env, (nint)length, out result);
+                ref s_fields.napi_create_array_with_length, env, (nint)length, out result);
 
         internal static napi_status napi_create_double(
             napi_env env, double value, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_double);
+            nint funcHandle = GetExport(ref s_fields.napi_create_double);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, double, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -432,7 +428,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_int32(
             napi_env env, int value, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_int32);
+            nint funcHandle = GetExport(ref s_fields.napi_create_int32);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, int, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -444,7 +440,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_uint32(
             napi_env env, uint value, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_uint32);
+            nint funcHandle = GetExport(ref s_fields.napi_create_uint32);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, uint, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -456,7 +452,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_int64(
             napi_env env, long value, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_int64);
+            nint funcHandle = GetExport(ref s_fields.napi_create_int64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, long, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -468,7 +464,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_string_latin1(
             napi_env env, byte* str, nuint length, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_string_latin1,
+                ref s_fields.napi_create_string_latin1,
                 env,
                 (nint)str,
                 (nint)length,
@@ -477,7 +473,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_string_utf8(
             napi_env env, byte* str, nuint length, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_string_utf8,
+                ref s_fields.napi_create_string_utf8,
                 env,
                 (nint)str,
                 (nint)length,
@@ -486,7 +482,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_string_utf16(
             napi_env env, char* str, nuint length, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_string_utf16,
+                ref s_fields.napi_create_string_utf16,
                 env,
                 (nint)str,
                 (nint)length,
@@ -495,12 +491,12 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_symbol(
             napi_env env, napi_value description, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_symbol, env, description.Handle, out result);
+                ref s_fields.napi_create_symbol, env, description.Handle, out result);
 
         internal static napi_status node_api_symbol_for(
             napi_env env, byte* utf8name, nuint length, out napi_value result)
             => CallInterop(
-                FunctionId.node_api_symbol_for,
+                ref s_fields.node_api_symbol_for,
                 env,
                 (nint)utf8name,
                 (nint)length,
@@ -514,7 +510,7 @@ public static partial class JSNativeApi
             nint data,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_function,
+                ref s_fields.napi_create_function,
                 env,
                 (nint)utf8name,
                 (nint)length,
@@ -525,7 +521,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_error);
+            nint funcHandle = GetExport(ref s_fields.napi_create_error);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_value, napi_value, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -537,7 +533,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_type_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_type_error,
+                ref s_fields.napi_create_type_error,
                 env,
                 code.Handle,
                 msg.Handle,
@@ -546,7 +542,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_range_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_range_error,
+                ref s_fields.napi_create_range_error,
                 env,
                 code.Handle,
                 msg.Handle,
@@ -555,7 +551,7 @@ public static partial class JSNativeApi
         internal static napi_status node_api_create_syntax_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
             => CallInterop(
-                FunctionId.node_api_create_syntax_error,
+                ref s_fields.node_api_create_syntax_error,
                 env,
                 code.Handle,
                 msg.Handle,
@@ -563,37 +559,37 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_typeof(
             napi_env env, napi_value value, out napi_valuetype result)
-            => CallInterop(FunctionId.napi_typeof, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_typeof, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_double(
             napi_env env, napi_value value, out double result)
             => CallInterop(
-                FunctionId.napi_get_value_double, env, value.Handle, out result);
+                ref s_fields.napi_get_value_double, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_int32(
             napi_env env, napi_value value, out int result)
             => CallInterop(
-                FunctionId.napi_get_value_int32, env, value.Handle, out result);
+                ref s_fields.napi_get_value_int32, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_uint32(
             napi_env env, napi_value value, out uint result)
             => CallInterop(
-                FunctionId.napi_get_value_uint32, env, value.Handle, out result);
+                ref s_fields.napi_get_value_uint32, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_int64(
             napi_env env, napi_value value, out long result)
             => CallInterop(
-                FunctionId.napi_get_value_int64, env, value.Handle, out result);
+                ref s_fields.napi_get_value_int64, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_bool(
             napi_env env, napi_value value, out c_bool result)
             => CallInterop(
-                FunctionId.napi_get_value_bool, env, value.Handle, out result);
+                ref s_fields.napi_get_value_bool, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_string_latin1(
             napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
             => CallInterop(
-                FunctionId.napi_get_value_string_latin1,
+                ref s_fields.napi_get_value_string_latin1,
                 env,
                 value.Handle,
                 buf,
@@ -603,7 +599,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_string_utf8(
             napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
             => CallInterop(
-                FunctionId.napi_get_value_string_utf8,
+                ref s_fields.napi_get_value_string_utf8,
                 env,
                 value.Handle,
                 buf,
@@ -613,7 +609,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_string_utf16(
             napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
             => CallInterop(
-                FunctionId.napi_get_value_string_utf16,
+                ref s_fields.napi_get_value_string_utf16,
                 env,
                 value.Handle,
                 buf,
@@ -622,37 +618,37 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_coerce_to_bool(
             napi_env env, napi_value value, out napi_value result)
-            => CallInterop(FunctionId.napi_coerce_to_bool, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_coerce_to_bool, env, value.Handle, out result);
 
         internal static napi_status napi_coerce_to_number(
             napi_env env, napi_value value, out napi_value result)
             => CallInterop(
-                FunctionId.napi_coerce_to_number, env, value.Handle, out result);
+                ref s_fields.napi_coerce_to_number, env, value.Handle, out result);
 
         internal static napi_status napi_coerce_to_object(
             napi_env env, napi_value value, out napi_value result)
             => CallInterop(
-                FunctionId.napi_coerce_to_object, env, value.Handle, out result);
+                ref s_fields.napi_coerce_to_object, env, value.Handle, out result);
 
         internal static napi_status napi_coerce_to_string(
             napi_env env, napi_value value, out napi_value result)
             => CallInterop(
-                FunctionId.napi_coerce_to_string, env, value.Handle, out result);
+                ref s_fields.napi_coerce_to_string, env, value.Handle, out result);
 
         internal static napi_status napi_get_prototype(
             napi_env env, napi_value js_object, out napi_value result)
             => CallInterop(
-                FunctionId.napi_get_prototype, env, js_object.Handle, out result);
+                ref s_fields.napi_get_prototype, env, js_object.Handle, out result);
 
         internal static napi_status napi_get_property_names(
             napi_env env, napi_value js_object, out napi_value result)
             => CallInterop(
-                FunctionId.napi_get_property_names, env, js_object.Handle, out result);
+                ref s_fields.napi_get_property_names, env, js_object.Handle, out result);
 
         internal static napi_status napi_set_property(
             napi_env env, napi_value js_object, napi_value key, napi_value value)
             => CallInterop(
-                FunctionId.napi_set_property,
+                ref s_fields.napi_set_property,
                 env,
                 js_object.Handle,
                 key.Handle,
@@ -661,7 +657,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_property(
             napi_env env, napi_value js_object, napi_value key, out c_bool result)
             => CallInterop(
-                FunctionId.napi_has_property,
+                ref s_fields.napi_has_property,
                 env,
                 js_object.Handle,
                 key.Handle,
@@ -670,7 +666,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_property(
             napi_env env, napi_value js_object, napi_value key, out napi_value result)
             => CallInterop(
-                FunctionId.napi_get_property,
+                ref s_fields.napi_get_property,
                 env,
                 js_object.Handle,
                 key.Handle,
@@ -679,7 +675,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_delete_property(
             napi_env env, napi_value js_object, napi_value key, out c_bool result)
             => CallInterop(
-                FunctionId.napi_delete_property,
+                ref s_fields.napi_delete_property,
                 env,
                 js_object.Handle,
                 key.Handle,
@@ -688,7 +684,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_own_property(
             napi_env env, napi_value js_object, napi_value key, out c_bool result)
             => CallInterop(
-                FunctionId.napi_has_own_property,
+                ref s_fields.napi_has_own_property,
                 env,
                 js_object.Handle,
                 key.Handle,
@@ -697,7 +693,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_set_named_property(
             napi_env env, napi_value js_object, nint utf8name, napi_value value)
             => CallInterop(
-                FunctionId.napi_set_named_property,
+                ref s_fields.napi_set_named_property,
                 env,
                 js_object.Handle,
                 utf8name,
@@ -706,7 +702,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_named_property(
             napi_env env, napi_value js_object, nint utf8name, out c_bool result)
             => CallInterop(
-                FunctionId.napi_has_named_property,
+                ref s_fields.napi_has_named_property,
                 env,
                 js_object.Handle,
                 utf8name,
@@ -715,7 +711,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_named_property(
             napi_env env, napi_value js_object, nint utf8name, out napi_value result)
             => CallInterop(
-                FunctionId.napi_get_named_property,
+                ref s_fields.napi_get_named_property,
                 env,
                 js_object.Handle,
                 utf8name,
@@ -724,7 +720,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_set_element(
             napi_env env, napi_value js_object, uint index, napi_value value)
         {
-            nint funcHandle = GetExport(FunctionId.napi_set_element);
+            nint funcHandle = GetExport(ref s_fields.napi_set_element);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_value, uint, napi_value, napi_status>)funcHandle;
             return funcDelegate(env, js_object, index, value);
@@ -733,7 +729,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_element(
             napi_env env, napi_value js_object, uint index, out c_bool result)
             => CallInterop(
-                FunctionId.napi_has_element,
+                ref s_fields.napi_has_element,
                 env,
                 js_object.Handle,
                 index,
@@ -742,7 +738,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_element(
             napi_env env, napi_value js_object, uint index, out napi_value result)
             => CallInterop(
-                FunctionId.napi_get_element,
+                ref s_fields.napi_get_element,
                 env,
                 js_object.Handle,
                 index,
@@ -751,12 +747,12 @@ public static partial class JSNativeApi
         internal static napi_status napi_delete_element(
             napi_env env, napi_value js_object, uint index, out c_bool result)
             => CallInterop(
-                FunctionId.napi_delete_element, env, js_object.Handle, index, out result);
+                ref s_fields.napi_delete_element, env, js_object.Handle, index, out result);
 
         internal static napi_status napi_define_properties(
             napi_env env, napi_value js_object, nuint property_count, nint properties)
             => CallInterop(
-                FunctionId.napi_define_properties,
+                ref s_fields.napi_define_properties,
                 env,
                 js_object.Handle,
                 (nint)property_count,
@@ -764,17 +760,17 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_array(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(FunctionId.napi_is_array, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_is_array, env, value.Handle, out result);
 
         internal static napi_status napi_get_array_length(
             napi_env env, napi_value value, out uint result)
             => CallInterop(
-                FunctionId.napi_get_array_length, env, value.Handle, out result);
+                ref s_fields.napi_get_array_length, env, value.Handle, out result);
 
         internal static napi_status napi_strict_equals(
             napi_env env, napi_value lhs, napi_value rhs, out c_bool result)
             => CallInterop(
-                FunctionId.napi_strict_equals, env, lhs.Handle, rhs.Handle, out result);
+                ref s_fields.napi_strict_equals, env, lhs.Handle, rhs.Handle, out result);
 
         internal static napi_status napi_call_function(
             napi_env env,
@@ -784,7 +780,7 @@ public static partial class JSNativeApi
             nint argv,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_call_function,
+                ref s_fields.napi_call_function,
                 env,
                 recv.Handle,
                 func.Handle,
@@ -799,7 +795,7 @@ public static partial class JSNativeApi
             nint argv,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_new_instance,
+                ref s_fields.napi_new_instance,
                 env,
                 constructor.Handle,
                 (nint)argc,
@@ -809,7 +805,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_instanceof(
             napi_env env, napi_value js_object, napi_value constructor, out c_bool result)
             => CallInterop(
-                FunctionId.napi_instanceof,
+                ref s_fields.napi_instanceof,
                 env,
                 js_object.Handle,
                 constructor.Handle,
@@ -824,7 +820,7 @@ public static partial class JSNativeApi
             napi_value* this_arg,      // [out] Receives the JS 'this' arg for the call
             nint* data)                // [out] Receives the data pointer for the callback.
             => CallInterop(
-                FunctionId.napi_get_cb_info,
+                ref s_fields.napi_get_cb_info,
                 env,
                 cbinfo.Handle,
                 (nint)argc,
@@ -835,7 +831,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_new_target(
             napi_env env, napi_callback_info cbinfo, out napi_value result)
             => CallInterop(
-                FunctionId.napi_get_new_target, env, cbinfo.Handle, out result);
+                ref s_fields.napi_get_new_target, env, cbinfo.Handle, out result);
 
         internal static napi_status napi_define_class(
             napi_env env,
@@ -847,7 +843,7 @@ public static partial class JSNativeApi
             nint properties,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_define_class,
+                ref s_fields.napi_define_class,
                 env,
                 utf8name,
                 (nint)length,
@@ -865,7 +861,7 @@ public static partial class JSNativeApi
             nint finalize_hint,
             napi_ref* result)
             => CallInterop(
-                FunctionId.napi_wrap,
+                ref s_fields.napi_wrap,
                 env,
                 js_object.Handle,
                 native_object,
@@ -875,12 +871,12 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_unwrap(
             napi_env env, napi_value js_object, out nint result)
-            => CallInterop(FunctionId.napi_unwrap, env, js_object.Handle, out result);
+            => CallInterop(ref s_fields.napi_unwrap, env, js_object.Handle, out result);
 
         internal static napi_status napi_remove_wrap(
             napi_env env, napi_value js_object, out nint result)
             => CallInterop(
-                FunctionId.napi_remove_wrap, env, js_object.Handle, out result);
+                ref s_fields.napi_remove_wrap, env, js_object.Handle, out result);
 
         internal static napi_status napi_create_external(
             napi_env env,
@@ -889,7 +885,7 @@ public static partial class JSNativeApi
             nint finalize_hint,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_external,
+                ref s_fields.napi_create_external,
                 env,
                 data,
                 (nint)finalize_cb.Handle,
@@ -899,12 +895,12 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_external(
             napi_env env, napi_value value, out nint result)
             => CallInterop(
-                FunctionId.napi_get_value_external, env, value.Handle, out result);
+                ref s_fields.napi_get_value_external, env, value.Handle, out result);
 
         internal static napi_status napi_create_reference(
             napi_env env, napi_value value, uint initial_refcount, out napi_ref result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_reference);
+            nint funcHandle = GetExport(ref s_fields.napi_create_reference);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_value, uint, nint, napi_status>)funcHandle;
             fixed (napi_ref* result_native = &result)
@@ -914,79 +910,79 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_delete_reference(napi_env env, napi_ref @ref)
-            => CallInterop(FunctionId.napi_delete_reference, env, @ref.Handle);
+            => CallInterop(ref s_fields.napi_delete_reference, env, @ref.Handle);
 
         internal static napi_status napi_reference_ref(napi_env env, napi_ref @ref, nint result)
-            => CallInterop(FunctionId.napi_reference_ref, env, @ref.Handle, result);
+            => CallInterop(ref s_fields.napi_reference_ref, env, @ref.Handle, result);
 
         internal static napi_status napi_reference_unref(napi_env env, napi_ref @ref, nint result)
-            => CallInterop(FunctionId.napi_reference_unref, env, @ref.Handle, result);
+            => CallInterop(ref s_fields.napi_reference_unref, env, @ref.Handle, result);
 
         internal static napi_status napi_get_reference_value(
             napi_env env, napi_ref @ref, out napi_value result)
             => CallInterop(
-                FunctionId.napi_get_reference_value, env, @ref.Handle, out result);
+                ref s_fields.napi_get_reference_value, env, @ref.Handle, out result);
 
         internal static napi_status napi_open_handle_scope(
             napi_env env, out napi_handle_scope result)
-            => CallInterop(FunctionId.napi_open_handle_scope, env, out result);
+            => CallInterop(ref s_fields.napi_open_handle_scope, env, out result);
 
         internal static napi_status napi_close_handle_scope(napi_env env, napi_handle_scope scope)
-            => CallInterop(FunctionId.napi_close_handle_scope, env, scope.Handle);
+            => CallInterop(ref s_fields.napi_close_handle_scope, env, scope.Handle);
 
         internal static napi_status napi_open_escapable_handle_scope(
             napi_env env, out napi_escapable_handle_scope result)
-            => CallInterop(FunctionId.napi_open_escapable_handle_scope, env, out result);
+            => CallInterop(ref s_fields.napi_open_escapable_handle_scope, env, out result);
 
         internal static napi_status napi_close_escapable_handle_scope(
             napi_env env, napi_escapable_handle_scope scope)
             => CallInterop(
-                FunctionId.napi_close_escapable_handle_scope, env, scope.Handle);
+                ref s_fields.napi_close_escapable_handle_scope, env, scope.Handle);
 
         internal static napi_status napi_escape_handle(napi_env env,
             napi_escapable_handle_scope scope, napi_value escapee, out napi_value result)
             => CallInterop(
-                FunctionId.napi_escape_handle,
+                ref s_fields.napi_escape_handle,
                 env,
                 scope.Handle,
                 escapee.Handle,
                 out result);
 
         internal static napi_status napi_throw(napi_env env, napi_value error)
-            => CallInterop(FunctionId.napi_throw, env, error.Handle);
+            => CallInterop(ref s_fields.napi_throw, env, error.Handle);
 
         internal static napi_status napi_throw_error(napi_env env, string? code, string msg)
-            => CallInterop(FunctionId.napi_throw_error, env, code, msg);
+            => CallInterop(ref s_fields.napi_throw_error, env, code, msg);
 
         internal static napi_status napi_throw_type_error(napi_env env, string? code, string msg)
-            => CallInterop(FunctionId.napi_throw_type_error, env, code, msg);
+            => CallInterop(ref s_fields.napi_throw_type_error, env, code, msg);
 
         internal static napi_status napi_throw_range_error(napi_env env, string? code, string msg)
-            => CallInterop(FunctionId.napi_throw_range_error, env, code, msg);
+            => CallInterop(ref s_fields.napi_throw_range_error, env, code, msg);
 
         internal static napi_status node_api_throw_syntax_error(
             napi_env env, string? code, string msg)
-            => CallInterop(FunctionId.node_api_throw_syntax_error, env, code, msg);
+            => CallInterop(ref s_fields.node_api_throw_syntax_error, env, code, msg);
 
         internal static napi_status napi_is_error(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(FunctionId.napi_is_error, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_is_error, env, value.Handle, out result);
 
         internal static napi_status napi_is_exception_pending(napi_env env, out c_bool result)
-            => CallInterop(FunctionId.napi_is_exception_pending, env, out result);
+            => CallInterop(ref s_fields.napi_is_exception_pending, env, out result);
 
         internal static napi_status napi_get_and_clear_last_exception(
             napi_env env, out napi_value result)
-            => CallInterop(FunctionId.napi_get_and_clear_last_exception, env, out result);
+            => CallInterop(ref s_fields.napi_get_and_clear_last_exception, env, out result);
 
         internal static napi_status napi_is_arraybuffer(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(FunctionId.napi_is_arraybuffer, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_is_arraybuffer, env, value.Handle, out result);
 
         internal static napi_status napi_create_arraybuffer(
             napi_env env, nuint byte_length, out nint data, out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_arraybuffer,
+                ref s_fields.napi_create_arraybuffer,
                 env,
                 (nint)byte_length,
                 out data,
@@ -1000,7 +996,7 @@ public static partial class JSNativeApi
             nint finalize_hint,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_external_arraybuffer,
+                ref s_fields.napi_create_external_arraybuffer,
                 env,
                 external_data,
                 (nint)byte_length,
@@ -1011,7 +1007,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_arraybuffer_info(
             napi_env env, napi_value arraybuffer, out nint data, out nuint byte_length)
             => CallInterop(
-                FunctionId.napi_get_arraybuffer_info,
+                ref s_fields.napi_get_arraybuffer_info,
                 env,
                 arraybuffer.Handle,
                 out data,
@@ -1019,7 +1015,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_typedarray(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(FunctionId.napi_is_typedarray, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_is_typedarray, env, value.Handle, out result);
 
         internal static napi_status napi_create_typedarray(
             napi_env env,
@@ -1029,7 +1025,7 @@ public static partial class JSNativeApi
             nuint byte_offset,
             out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_typedarray);
+            nint funcHandle = GetExport(ref s_fields.napi_create_typedarray);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 napi_typedarray_type,
@@ -1059,7 +1055,7 @@ public static partial class JSNativeApi
                 out napi_value arraybuffer,
                 out nuint byte_offset)
                 => CallInterop(
-                        FunctionId.napi_get_typedarray_info,
+                        ref s_fields.napi_get_typedarray_info,
                     env,
                     typedarray.Handle,
                     out type,
@@ -1075,7 +1071,7 @@ public static partial class JSNativeApi
             nuint byte_offset,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_dataview,
+                ref s_fields.napi_create_dataview,
                 env,
                 (nint)length,
                 arraybuffer.Handle,
@@ -1084,7 +1080,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_dataview(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(FunctionId.napi_is_dataview, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_is_dataview, env, value.Handle, out result);
 
         internal static napi_status napi_get_dataview_info(
             napi_env env,
@@ -1094,7 +1090,7 @@ public static partial class JSNativeApi
             out napi_value arraybuffer,
             out nuint byte_offset)
             => CallInterop(
-                FunctionId.napi_get_dataview_info,
+                ref s_fields.napi_get_dataview_info,
                 env,
                 dataview.Handle,
                 out bytelength,
@@ -1103,17 +1099,17 @@ public static partial class JSNativeApi
                 out byte_offset);
 
         internal static napi_status napi_get_version(napi_env env, out uint result)
-            => CallInterop(FunctionId.napi_get_version, env, out result);
+            => CallInterop(ref s_fields.napi_get_version, env, out result);
 
         internal static napi_status napi_create_promise(
             napi_env env, out napi_deferred deferred, out napi_value promise)
             => CallInterop(
-                FunctionId.napi_create_promise, env, out deferred, out promise);
+                ref s_fields.napi_create_promise, env, out deferred, out promise);
 
         internal static napi_status napi_resolve_deferred(
             napi_env env, napi_deferred deferred, napi_value resolution)
             => CallInterop(
-                FunctionId.napi_resolve_deferred,
+                ref s_fields.napi_resolve_deferred,
                 env,
                 deferred.Handle,
                 resolution.Handle);
@@ -1121,20 +1117,20 @@ public static partial class JSNativeApi
         internal static napi_status napi_reject_deferred(
             napi_env env, napi_deferred deferred, napi_value rejection)
             => CallInterop(
-                FunctionId.napi_reject_deferred, env, deferred.Handle, rejection.Handle);
+                ref s_fields.napi_reject_deferred, env, deferred.Handle, rejection.Handle);
 
         internal static napi_status napi_is_promise(
             napi_env env, napi_value value, out c_bool is_promise)
-            => CallInterop(FunctionId.napi_is_promise, env, value.Handle, out is_promise);
+            => CallInterop(ref s_fields.napi_is_promise, env, value.Handle, out is_promise);
 
         internal static napi_status napi_run_script(
             napi_env env, napi_value script, out napi_value result)
-            => CallInterop(FunctionId.napi_run_script, env, script.Handle, out result);
+            => CallInterop(ref s_fields.napi_run_script, env, script.Handle, out result);
 
         internal static napi_status napi_adjust_external_memory(
             napi_env env, long change_in_bytes, out long adjusted_value)
         {
-            nint funcHandle = GetExport(FunctionId.napi_adjust_external_memory);
+            nint funcHandle = GetExport(ref s_fields.napi_adjust_external_memory);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, long, nint, napi_status>)funcHandle;
             fixed (long* adjusted_value_native = &adjusted_value)
@@ -1146,7 +1142,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_date(
             napi_env env, double time, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_date);
+            nint funcHandle = GetExport(ref s_fields.napi_create_date);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, double, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1157,11 +1153,11 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_date(
             napi_env env, napi_value value, out c_bool is_date)
-            => CallInterop(FunctionId.napi_is_date, env, value.Handle, out is_date);
+            => CallInterop(ref s_fields.napi_is_date, env, value.Handle, out is_date);
 
         internal static napi_status napi_get_date_value(
             napi_env env, napi_value value, out double result)
-            => CallInterop(FunctionId.napi_get_date_value, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_get_date_value, env, value.Handle, out result);
 
         internal static napi_status napi_add_finalizer(
             napi_env env,
@@ -1171,7 +1167,7 @@ public static partial class JSNativeApi
             nint finalize_hint,
             napi_ref* result)
             => CallInterop(
-                FunctionId.napi_add_finalizer,
+                ref s_fields.napi_add_finalizer,
                 env,
                 js_object.Handle,
                 native_object,
@@ -1182,7 +1178,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_bigint_int64(
             napi_env env, long value, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_bigint_int64);
+            nint funcHandle = GetExport(ref s_fields.napi_create_bigint_int64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, long, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1195,7 +1191,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_bigint_uint64(
             napi_env env, ulong value, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_bigint_uint64);
+            nint funcHandle = GetExport(ref s_fields.napi_create_bigint_uint64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, ulong, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1207,7 +1203,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_bigint_words(
             napi_env env, int sign_bit, nuint word_count, ulong* words, out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_bigint_uint64);
+            nint funcHandle = GetExport(ref s_fields.napi_create_bigint_words);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, int, nuint, nint, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1219,7 +1215,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_bigint_int64(
             napi_env env, napi_value value, out long result, out c_bool lossless)
             => CallInterop(
-                FunctionId.napi_get_value_bigint_int64,
+                ref s_fields.napi_get_value_bigint_int64,
                 env,
                 value.Handle,
                 out result,
@@ -1228,7 +1224,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_bigint_uint64(
             napi_env env, napi_value value, out ulong result, out c_bool lossless)
             => CallInterop(
-                FunctionId.napi_get_value_bigint_uint64,
+                ref s_fields.napi_get_value_bigint_uint64,
                 env,
                 value.Handle,
                 out result,
@@ -1237,7 +1233,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_bigint_words(
             napi_env env, napi_value value, out int sign_bit, out nuint word_count, ulong* words)
             => CallInterop(
-                FunctionId.napi_get_value_bigint_words,
+                ref s_fields.napi_get_value_bigint_words,
                 env,
                 value.Handle,
                 out sign_bit,
@@ -1252,7 +1248,7 @@ public static partial class JSNativeApi
             napi_key_conversion key_conversion,
             out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_bigint_uint64);
+            nint funcHandle = GetExport(ref s_fields.napi_get_all_property_names);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 napi_value,
@@ -1277,22 +1273,22 @@ public static partial class JSNativeApi
             napi_env env, nint data, napi_finalize finalize_cb, nint finalize_hint)
         {
             nint funcHandle = GetExport(
-                FunctionId.napi_set_instance_data, nameof(napi_set_instance_data));
+                ref s_fields.napi_set_instance_data, nameof(napi_set_instance_data));
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, napi_finalize, nint, napi_status>)funcHandle;
             return funcDelegate(env, data, finalize_cb, finalize_hint);
         }
 
         internal static napi_status napi_get_instance_data(napi_env env, out nint data)
-            => CallInterop(FunctionId.napi_get_instance_data, env, out data);
+            => CallInterop(ref s_fields.napi_get_instance_data, env, out data);
 
         internal static napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer)
-            => CallInterop(FunctionId.napi_detach_arraybuffer, env, arraybuffer.Handle);
+            => CallInterop(ref s_fields.napi_detach_arraybuffer, env, arraybuffer.Handle);
 
         internal static napi_status napi_is_detached_arraybuffer(
             napi_env env, napi_value value, out c_bool result)
             => CallInterop(
-                FunctionId.napi_is_detached_arraybuffer, env, value.Handle, out result);
+                ref s_fields.napi_is_detached_arraybuffer, env, value.Handle, out result);
 
         internal static napi_status napi_type_tag_object(
             napi_env env, napi_value value, in napi_type_tag type_tag)
@@ -1300,7 +1296,7 @@ public static partial class JSNativeApi
             fixed (napi_type_tag* type_tag_native = &type_tag)
             {
                 return CallInterop(
-                        FunctionId.napi_type_tag_object,
+                    ref s_fields.napi_type_tag_object,
                     env,
                     value.Handle,
                     (nint)type_tag_native);
@@ -1314,7 +1310,7 @@ public static partial class JSNativeApi
             fixed (c_bool* result_native = &result)
             {
                 return CallInterop(
-                        FunctionId.napi_check_object_type_tag,
+                    ref s_fields.napi_check_object_type_tag,
                     env,
                     value.Handle,
                     (nint)type_tag_native,
@@ -1323,31 +1319,31 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_object_freeze(napi_env env, napi_value js_object)
-            => CallInterop(FunctionId.napi_object_freeze, env, js_object.Handle);
+            => CallInterop(ref s_fields.napi_object_freeze, env, js_object.Handle);
 
         internal static napi_status napi_object_seal(napi_env env, napi_value js_object)
-            => CallInterop(FunctionId.napi_object_seal, env, js_object.Handle);
+            => CallInterop(ref s_fields.napi_object_seal, env, js_object.Handle);
 
-        private static nint GetExport(FunctionId functionId, [CallerMemberName] string functionName = "")
+        private static nint GetExport(ref nint field, [CallerMemberName] string functionName = "")
         {
-            nint methodPtr = _functions[(int)functionId];
+            nint methodPtr = field;
             if (methodPtr == nint.Zero)
             {
-                methodPtr = NativeLibrary.GetExport(_libraryHandle, functionName);
-                _functions[(int)functionId] = methodPtr;
+                methodPtr = NativeLibrary.GetExport(s_libraryHandle, functionName);
+                field = methodPtr;
             }
 
             return methodPtr;
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             out TResult result,
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1357,7 +1353,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             out TResult1 result1,
             out TResult2 result2,
@@ -1365,7 +1361,7 @@ public static partial class JSNativeApi
             where TResult1 : unmanaged
             where TResult2 : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1376,14 +1372,14 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value,
             out TResult result,
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1393,7 +1389,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value,
             out TResult1 result1,
@@ -1402,7 +1398,7 @@ public static partial class JSNativeApi
             where TResult1 : unmanaged
             where TResult2 : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1413,7 +1409,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value,
             out TResult1 result1,
@@ -1423,7 +1419,7 @@ public static partial class JSNativeApi
             where TResult1 : unmanaged
             where TResult2 : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1435,7 +1431,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2, TResult3, TResult4>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value,
             out TResult1 result1,
@@ -1448,7 +1444,7 @@ public static partial class JSNativeApi
             where TResult3 : unmanaged
             where TResult4 : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1468,7 +1464,7 @@ public static partial class JSNativeApi
 
         private static unsafe napi_status CallInterop<
             TResult1, TResult2, TResult3, TResult4, TResult5>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value,
             out TResult1 result1,
@@ -1483,7 +1479,7 @@ public static partial class JSNativeApi
             where TResult4 : unmanaged
             where TResult5 : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 nint,
@@ -1511,7 +1507,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
@@ -1519,7 +1515,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1529,7 +1525,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             uint value2,
@@ -1537,7 +1533,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, uint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1546,34 +1542,34 @@ public static partial class JSNativeApi
             }
         }
         private static unsafe napi_status CallInterop(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
             return funcDelegate(env, value1, value2);
         }
 
         private static unsafe napi_status CallInterop(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
             nint value3,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, napi_status>)funcHandle;
             return funcDelegate(env, value1, value2, value3);
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
@@ -1582,7 +1578,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1592,7 +1588,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
@@ -1602,7 +1598,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1612,7 +1608,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
@@ -1621,14 +1617,14 @@ public static partial class JSNativeApi
             nint value5,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             return funcDelegate(env, value1, value2, value3, value4, value5);
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
@@ -1639,7 +1635,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1650,7 +1646,7 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value1,
             nint value2,
@@ -1662,7 +1658,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1673,24 +1669,24 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             nint value,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<napi_env, nint, napi_status>)funcHandle;
             return funcDelegate(env, value);
         }
 
         private static napi_status CallInterop(
-            FunctionId functionId,
+            ref nint field,
             napi_env env,
             string? value1,
             string? value2,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = GetExport(functionId, functionName);
+            nint funcHandle = GetExport(ref field, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
 

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -296,7 +296,7 @@ public static partial class JSNativeApi
             napi_would_deadlock,
         }
 
-        public unsafe struct napi_callback
+        public struct napi_callback
         {
             public delegate* unmanaged[Cdecl]<napi_env, napi_callback_info, napi_value> Handle;
 
@@ -305,7 +305,7 @@ public static partial class JSNativeApi
                 => Handle = handle;
         }
 
-        public unsafe struct napi_finalize
+        public struct napi_finalize
         {
             public delegate* unmanaged[Cdecl]<napi_env, nint, nint, void> Handle;
 
@@ -313,7 +313,7 @@ public static partial class JSNativeApi
                 => Handle = handle;
         }
 
-        public unsafe struct napi_property_descriptor
+        public struct napi_property_descriptor
         {
             // One of utf8name or name should be NULL.
             public nint utf8name;
@@ -842,16 +842,22 @@ public static partial class JSNativeApi
             nuint property_count,
             nint properties,
             out napi_value result)
-            => CallInterop(
-                ref s_fields.napi_define_class,
-                env,
-                utf8name,
-                (nint)length,
-                (nint)constructor.Handle,
-                data,
-                (nint)property_count,
-                properties,
-                out result);
+        {
+            nint funcHandle = GetExport(ref s_fields.napi_define_class);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, nint, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(
+                    env,
+                    utf8name,
+                    (nint)length,
+                    (nint)constructor.Handle,
+                    data,
+                    (nint)property_count,
+                    properties, (nint)result_native);
+            }
+        }
 
         internal static napi_status napi_wrap(
             napi_env env,
@@ -1272,8 +1278,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_set_instance_data(
             napi_env env, nint data, napi_finalize finalize_cb, nint finalize_hint)
         {
-            nint funcHandle = GetExport(
-                ref s_fields.napi_set_instance_data, nameof(napi_set_instance_data));
+            nint funcHandle = GetExport(ref s_fields.napi_set_instance_data);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, napi_finalize, nint, napi_status>)funcHandle;
             return funcDelegate(env, data, finalize_cb, finalize_hint);
@@ -1336,7 +1341,7 @@ public static partial class JSNativeApi
             return methodPtr;
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
+        private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,
             out TResult result,
@@ -1352,7 +1357,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult1, TResult2>(
+        private static napi_status CallInterop<TResult1, TResult2>(
             ref nint field,
             napi_env env,
             out TResult1 result1,
@@ -1371,7 +1376,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
+        private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,
             nint value,
@@ -1388,7 +1393,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult1, TResult2>(
+        private static napi_status CallInterop<TResult1, TResult2>(
             ref nint field,
             napi_env env,
             nint value,
@@ -1408,7 +1413,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult1, TResult2>(
+        private static napi_status CallInterop<TResult1, TResult2>(
             ref nint field,
             napi_env env,
             nint value,
@@ -1430,7 +1435,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult1, TResult2, TResult3, TResult4>(
+        private static napi_status CallInterop<TResult1, TResult2, TResult3, TResult4>(
             ref nint field,
             napi_env env,
             nint value,
@@ -1462,7 +1467,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<
+        private static napi_status CallInterop<
             TResult1, TResult2, TResult3, TResult4, TResult5>(
             ref nint field,
             napi_env env,
@@ -1506,7 +1511,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
+        private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1524,7 +1529,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
+        private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1541,7 +1546,7 @@ public static partial class JSNativeApi
                 return funcDelegate(env, value1, value2, (nint)result_native);
             }
         }
-        private static unsafe napi_status CallInterop(
+        private static napi_status CallInterop(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1554,7 +1559,7 @@ public static partial class JSNativeApi
             return funcDelegate(env, value1, value2);
         }
 
-        private static unsafe napi_status CallInterop(
+        private static napi_status CallInterop(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1568,7 +1573,7 @@ public static partial class JSNativeApi
             return funcDelegate(env, value1, value2, value3);
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
+        private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1587,7 +1592,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
+        private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1607,7 +1612,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop(
+        private static napi_status CallInterop(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1623,7 +1628,7 @@ public static partial class JSNativeApi
             return funcDelegate(env, value1, value2, value3, value4, value5);
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
+        private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,
             nint value1,
@@ -1645,30 +1650,7 @@ public static partial class JSNativeApi
             }
         }
 
-        private static unsafe napi_status CallInterop<TResult>(
-            ref nint field,
-            napi_env env,
-            nint value1,
-            nint value2,
-            nint value3,
-            nint value4,
-            nint value5,
-            nint value6,
-            out TResult result,
-            [CallerMemberName] string functionName = "")
-            where TResult : unmanaged
-        {
-            nint funcHandle = GetExport(ref field, functionName);
-            var funcDelegate = (delegate* unmanaged[Cdecl]<
-                napi_env, nint, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
-            fixed (TResult* result_native = &result)
-            {
-                return funcDelegate(
-                    env, value1, value2, value3, value4, value5, value6, (nint)result_native);
-            }
-        }
-
-        private static unsafe napi_status CallInterop(
+        private static napi_status CallInterop(
             ref nint field,
             napi_env env,
             nint value,

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -12,7 +12,7 @@ public static partial class JSNativeApi
 {
     // Node-API Interop definitions and functions.
     [SuppressUnmanagedCodeSecurity]
-    public unsafe static partial class Interop
+    public static unsafe partial class Interop
     {
         private static nint s_libraryHandle;
         private static FunctionFields s_fields = new();

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -12,23 +12,19 @@ public static partial class JSNativeApi
 {
     // Node-API Interop definitions and functions.
     [SuppressUnmanagedCodeSecurity]
-    public unsafe partial class Interop
+    public unsafe static partial class Interop
     {
-        private readonly nint _libraryHandle;
-        private readonly nint[] _functions = new nint[(int)FunctionId.FunctionCount];
+        private static nint _libraryHandle;
+        private static readonly nint[] _functions = new nint[(int)FunctionId.FunctionCount];
 
         private static bool s_initialized;
-
-        public static Interop? Current { get; set; }
-
-        public Interop(nint libraryHandle) => _libraryHandle = libraryHandle;
 
         public static void Initialize(nint libraryHandle)
         {
             if (s_initialized) return;
             s_initialized = true;
 
-            Current = new Interop(libraryHandle);
+            _libraryHandle = libraryHandle;
 
             // Node APIs are all imported from the main `node` executable. Overriding the import
             // resolution is more efficient and avoids issues with library search paths and
@@ -387,21 +383,21 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_get_last_error_info(napi_env env, out nint result)
-            => CallInterop(Current, FunctionId.napi_get_last_error_info, env, out result);
+            => CallInterop(FunctionId.napi_get_last_error_info, env, out result);
 
         internal static napi_status napi_get_undefined(napi_env env, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_get_undefined, env, out result);
+            => CallInterop(FunctionId.napi_get_undefined, env, out result);
 
         internal static napi_status napi_get_null(napi_env env, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_get_null, env, out result);
+            => CallInterop(FunctionId.napi_get_null, env, out result);
 
         internal static napi_status napi_get_global(napi_env env, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_get_global, env, out result);
+            => CallInterop(FunctionId.napi_get_global, env, out result);
 
         internal static napi_status napi_get_boolean(
             napi_env env, c_bool value, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_get_boolean);
+            nint funcHandle = GetExport(FunctionId.napi_get_boolean);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, c_bool, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -411,20 +407,20 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_create_object(napi_env env, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_create_object, env, out result);
+            => CallInterop(FunctionId.napi_create_object, env, out result);
 
         internal static napi_status napi_create_array(napi_env env, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_create_array, env, out result);
+            => CallInterop(FunctionId.napi_create_array, env, out result);
 
         internal static napi_status napi_create_array_with_length(
             napi_env env, nuint length, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_create_array_with_length, env, (nint)length, out result);
+                FunctionId.napi_create_array_with_length, env, (nint)length, out result);
 
         internal static napi_status napi_create_double(
             napi_env env, double value, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_double);
+            nint funcHandle = GetExport(FunctionId.napi_create_double);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, double, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -436,7 +432,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_int32(
             napi_env env, int value, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_int32);
+            nint funcHandle = GetExport(FunctionId.napi_create_int32);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, int, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -448,7 +444,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_uint32(
             napi_env env, uint value, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_uint32);
+            nint funcHandle = GetExport(FunctionId.napi_create_uint32);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, uint, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -460,7 +456,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_int64(
             napi_env env, long value, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_int64);
+            nint funcHandle = GetExport(FunctionId.napi_create_int64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, long, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -472,7 +468,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_string_latin1(
             napi_env env, byte* str, nuint length, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_string_latin1,
                 env,
                 (nint)str,
@@ -482,7 +477,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_string_utf8(
             napi_env env, byte* str, nuint length, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_string_utf8,
                 env,
                 (nint)str,
@@ -492,7 +486,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_string_utf16(
             napi_env env, char* str, nuint length, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_string_utf16,
                 env,
                 (nint)str,
@@ -502,12 +495,11 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_symbol(
             napi_env env, napi_value description, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_create_symbol, env, description.Handle, out result);
+                FunctionId.napi_create_symbol, env, description.Handle, out result);
 
         internal static napi_status node_api_symbol_for(
             napi_env env, byte* utf8name, nuint length, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.node_api_symbol_for,
                 env,
                 (nint)utf8name,
@@ -522,7 +514,6 @@ public static partial class JSNativeApi
             nint data,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_function,
                 env,
                 (nint)utf8name,
@@ -534,7 +525,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_error);
+            nint funcHandle = GetExport(FunctionId.napi_create_error);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_value, napi_value, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -546,7 +537,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_type_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_type_error,
                 env,
                 code.Handle,
@@ -556,7 +546,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_range_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_range_error,
                 env,
                 code.Handle,
@@ -566,7 +555,6 @@ public static partial class JSNativeApi
         internal static napi_status node_api_create_syntax_error(
             napi_env env, napi_value code, napi_value msg, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.node_api_create_syntax_error,
                 env,
                 code.Handle,
@@ -575,37 +563,36 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_typeof(
             napi_env env, napi_value value, out napi_valuetype result)
-            => CallInterop(Current, FunctionId.napi_typeof, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_typeof, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_double(
             napi_env env, napi_value value, out double result)
             => CallInterop(
-                Current, FunctionId.napi_get_value_double, env, value.Handle, out result);
+                FunctionId.napi_get_value_double, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_int32(
             napi_env env, napi_value value, out int result)
             => CallInterop(
-                Current, FunctionId.napi_get_value_int32, env, value.Handle, out result);
+                FunctionId.napi_get_value_int32, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_uint32(
             napi_env env, napi_value value, out uint result)
             => CallInterop(
-                Current, FunctionId.napi_get_value_uint32, env, value.Handle, out result);
+                FunctionId.napi_get_value_uint32, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_int64(
             napi_env env, napi_value value, out long result)
             => CallInterop(
-                Current, FunctionId.napi_get_value_int64, env, value.Handle, out result);
+                FunctionId.napi_get_value_int64, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_bool(
             napi_env env, napi_value value, out c_bool result)
             => CallInterop(
-                Current, FunctionId.napi_get_value_bool, env, value.Handle, out result);
+                FunctionId.napi_get_value_bool, env, value.Handle, out result);
 
         internal static napi_status napi_get_value_string_latin1(
             napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_value_string_latin1,
                 env,
                 value.Handle,
@@ -616,7 +603,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_string_utf8(
             napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_value_string_utf8,
                 env,
                 value.Handle,
@@ -627,7 +613,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_string_utf16(
             napi_env env, napi_value value, nint buf, nuint bufsize, out nuint result)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_value_string_utf16,
                 env,
                 value.Handle,
@@ -637,37 +622,36 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_coerce_to_bool(
             napi_env env, napi_value value, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_coerce_to_bool, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_coerce_to_bool, env, value.Handle, out result);
 
         internal static napi_status napi_coerce_to_number(
             napi_env env, napi_value value, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_coerce_to_number, env, value.Handle, out result);
+                FunctionId.napi_coerce_to_number, env, value.Handle, out result);
 
         internal static napi_status napi_coerce_to_object(
             napi_env env, napi_value value, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_coerce_to_object, env, value.Handle, out result);
+                FunctionId.napi_coerce_to_object, env, value.Handle, out result);
 
         internal static napi_status napi_coerce_to_string(
             napi_env env, napi_value value, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_coerce_to_string, env, value.Handle, out result);
+                FunctionId.napi_coerce_to_string, env, value.Handle, out result);
 
         internal static napi_status napi_get_prototype(
             napi_env env, napi_value js_object, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_get_prototype, env, js_object.Handle, out result);
+                FunctionId.napi_get_prototype, env, js_object.Handle, out result);
 
         internal static napi_status napi_get_property_names(
             napi_env env, napi_value js_object, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_get_property_names, env, js_object.Handle, out result);
+                FunctionId.napi_get_property_names, env, js_object.Handle, out result);
 
         internal static napi_status napi_set_property(
             napi_env env, napi_value js_object, napi_value key, napi_value value)
             => CallInterop(
-                Current,
                 FunctionId.napi_set_property,
                 env,
                 js_object.Handle,
@@ -677,7 +661,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_property(
             napi_env env, napi_value js_object, napi_value key, out c_bool result)
             => CallInterop(
-                Current,
                 FunctionId.napi_has_property,
                 env,
                 js_object.Handle,
@@ -687,7 +670,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_property(
             napi_env env, napi_value js_object, napi_value key, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_property,
                 env,
                 js_object.Handle,
@@ -697,7 +679,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_delete_property(
             napi_env env, napi_value js_object, napi_value key, out c_bool result)
             => CallInterop(
-                Current,
                 FunctionId.napi_delete_property,
                 env,
                 js_object.Handle,
@@ -707,7 +688,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_own_property(
             napi_env env, napi_value js_object, napi_value key, out c_bool result)
             => CallInterop(
-                Current,
                 FunctionId.napi_has_own_property,
                 env,
                 js_object.Handle,
@@ -717,7 +697,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_set_named_property(
             napi_env env, napi_value js_object, nint utf8name, napi_value value)
             => CallInterop(
-                Current,
                 FunctionId.napi_set_named_property,
                 env,
                 js_object.Handle,
@@ -727,7 +706,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_named_property(
             napi_env env, napi_value js_object, nint utf8name, out c_bool result)
             => CallInterop(
-                Current,
                 FunctionId.napi_has_named_property,
                 env,
                 js_object.Handle,
@@ -737,7 +715,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_named_property(
             napi_env env, napi_value js_object, nint utf8name, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_named_property,
                 env,
                 js_object.Handle,
@@ -747,7 +724,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_set_element(
             napi_env env, napi_value js_object, uint index, napi_value value)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_set_element);
+            nint funcHandle = GetExport(FunctionId.napi_set_element);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_value, uint, napi_value, napi_status>)funcHandle;
             return funcDelegate(env, js_object, index, value);
@@ -756,7 +733,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_has_element(
             napi_env env, napi_value js_object, uint index, out c_bool result)
             => CallInterop(
-                Current,
                 FunctionId.napi_has_element,
                 env,
                 js_object.Handle,
@@ -766,7 +742,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_element(
             napi_env env, napi_value js_object, uint index, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_element,
                 env,
                 js_object.Handle,
@@ -776,12 +751,11 @@ public static partial class JSNativeApi
         internal static napi_status napi_delete_element(
             napi_env env, napi_value js_object, uint index, out c_bool result)
             => CallInterop(
-                Current, FunctionId.napi_delete_element, env, js_object.Handle, index, out result);
+                FunctionId.napi_delete_element, env, js_object.Handle, index, out result);
 
         internal static napi_status napi_define_properties(
             napi_env env, napi_value js_object, nuint property_count, nint properties)
             => CallInterop(
-                Current,
                 FunctionId.napi_define_properties,
                 env,
                 js_object.Handle,
@@ -790,17 +764,17 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_array(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(Current, FunctionId.napi_is_array, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_is_array, env, value.Handle, out result);
 
         internal static napi_status napi_get_array_length(
             napi_env env, napi_value value, out uint result)
             => CallInterop(
-                Current, FunctionId.napi_get_array_length, env, value.Handle, out result);
+                FunctionId.napi_get_array_length, env, value.Handle, out result);
 
         internal static napi_status napi_strict_equals(
             napi_env env, napi_value lhs, napi_value rhs, out c_bool result)
             => CallInterop(
-                Current, FunctionId.napi_strict_equals, env, lhs.Handle, rhs.Handle, out result);
+                FunctionId.napi_strict_equals, env, lhs.Handle, rhs.Handle, out result);
 
         internal static napi_status napi_call_function(
             napi_env env,
@@ -810,7 +784,6 @@ public static partial class JSNativeApi
             nint argv,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_call_function,
                 env,
                 recv.Handle,
@@ -826,7 +799,6 @@ public static partial class JSNativeApi
             nint argv,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_new_instance,
                 env,
                 constructor.Handle,
@@ -837,7 +809,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_instanceof(
             napi_env env, napi_value js_object, napi_value constructor, out c_bool result)
             => CallInterop(
-                Current,
                 FunctionId.napi_instanceof,
                 env,
                 js_object.Handle,
@@ -853,7 +824,6 @@ public static partial class JSNativeApi
             napi_value* this_arg,      // [out] Receives the JS 'this' arg for the call
             nint* data)                // [out] Receives the data pointer for the callback.
             => CallInterop(
-                Current,
                 FunctionId.napi_get_cb_info,
                 env,
                 cbinfo.Handle,
@@ -865,7 +835,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_new_target(
             napi_env env, napi_callback_info cbinfo, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_get_new_target, env, cbinfo.Handle, out result);
+                FunctionId.napi_get_new_target, env, cbinfo.Handle, out result);
 
         internal static napi_status napi_define_class(
             napi_env env,
@@ -877,7 +847,6 @@ public static partial class JSNativeApi
             nint properties,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_define_class,
                 env,
                 utf8name,
@@ -896,7 +865,6 @@ public static partial class JSNativeApi
             nint finalize_hint,
             napi_ref* result)
             => CallInterop(
-                Current,
                 FunctionId.napi_wrap,
                 env,
                 js_object.Handle,
@@ -907,12 +875,12 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_unwrap(
             napi_env env, napi_value js_object, out nint result)
-            => CallInterop(Current, FunctionId.napi_unwrap, env, js_object.Handle, out result);
+            => CallInterop(FunctionId.napi_unwrap, env, js_object.Handle, out result);
 
         internal static napi_status napi_remove_wrap(
             napi_env env, napi_value js_object, out nint result)
             => CallInterop(
-                Current, FunctionId.napi_remove_wrap, env, js_object.Handle, out result);
+                FunctionId.napi_remove_wrap, env, js_object.Handle, out result);
 
         internal static napi_status napi_create_external(
             napi_env env,
@@ -921,7 +889,6 @@ public static partial class JSNativeApi
             nint finalize_hint,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_external,
                 env,
                 data,
@@ -932,12 +899,12 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_external(
             napi_env env, napi_value value, out nint result)
             => CallInterop(
-                Current, FunctionId.napi_get_value_external, env, value.Handle, out result);
+                FunctionId.napi_get_value_external, env, value.Handle, out result);
 
         internal static napi_status napi_create_reference(
             napi_env env, napi_value value, uint initial_refcount, out napi_ref result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_reference);
+            nint funcHandle = GetExport(FunctionId.napi_create_reference);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_value, uint, nint, napi_status>)funcHandle;
             fixed (napi_ref* result_native = &result)
@@ -947,39 +914,38 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_delete_reference(napi_env env, napi_ref @ref)
-            => CallInterop(Current, FunctionId.napi_delete_reference, env, @ref.Handle);
+            => CallInterop(FunctionId.napi_delete_reference, env, @ref.Handle);
 
         internal static napi_status napi_reference_ref(napi_env env, napi_ref @ref, nint result)
-            => CallInterop(Current, FunctionId.napi_reference_ref, env, @ref.Handle, result);
+            => CallInterop(FunctionId.napi_reference_ref, env, @ref.Handle, result);
 
         internal static napi_status napi_reference_unref(napi_env env, napi_ref @ref, nint result)
-            => CallInterop(Current, FunctionId.napi_reference_unref, env, @ref.Handle, result);
+            => CallInterop(FunctionId.napi_reference_unref, env, @ref.Handle, result);
 
         internal static napi_status napi_get_reference_value(
             napi_env env, napi_ref @ref, out napi_value result)
             => CallInterop(
-                Current, FunctionId.napi_get_reference_value, env, @ref.Handle, out result);
+                FunctionId.napi_get_reference_value, env, @ref.Handle, out result);
 
         internal static napi_status napi_open_handle_scope(
             napi_env env, out napi_handle_scope result)
-            => CallInterop(Current, FunctionId.napi_open_handle_scope, env, out result);
+            => CallInterop(FunctionId.napi_open_handle_scope, env, out result);
 
         internal static napi_status napi_close_handle_scope(napi_env env, napi_handle_scope scope)
-            => CallInterop(Current, FunctionId.napi_close_handle_scope, env, scope.Handle);
+            => CallInterop(FunctionId.napi_close_handle_scope, env, scope.Handle);
 
         internal static napi_status napi_open_escapable_handle_scope(
             napi_env env, out napi_escapable_handle_scope result)
-            => CallInterop(Current, FunctionId.napi_open_escapable_handle_scope, env, out result);
+            => CallInterop(FunctionId.napi_open_escapable_handle_scope, env, out result);
 
         internal static napi_status napi_close_escapable_handle_scope(
             napi_env env, napi_escapable_handle_scope scope)
             => CallInterop(
-                Current, FunctionId.napi_close_escapable_handle_scope, env, scope.Handle);
+                FunctionId.napi_close_escapable_handle_scope, env, scope.Handle);
 
         internal static napi_status napi_escape_handle(napi_env env,
             napi_escapable_handle_scope scope, napi_value escapee, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_escape_handle,
                 env,
                 scope.Handle,
@@ -987,40 +953,39 @@ public static partial class JSNativeApi
                 out result);
 
         internal static napi_status napi_throw(napi_env env, napi_value error)
-            => CallInterop(Current, FunctionId.napi_throw, env, error.Handle);
+            => CallInterop(FunctionId.napi_throw, env, error.Handle);
 
         internal static napi_status napi_throw_error(napi_env env, string? code, string msg)
-            => CallInterop(Current, FunctionId.napi_throw_error, env, code, msg);
+            => CallInterop(FunctionId.napi_throw_error, env, code, msg);
 
         internal static napi_status napi_throw_type_error(napi_env env, string? code, string msg)
-            => CallInterop(Current, FunctionId.napi_throw_type_error, env, code, msg);
+            => CallInterop(FunctionId.napi_throw_type_error, env, code, msg);
 
         internal static napi_status napi_throw_range_error(napi_env env, string? code, string msg)
-            => CallInterop(Current, FunctionId.napi_throw_range_error, env, code, msg);
+            => CallInterop(FunctionId.napi_throw_range_error, env, code, msg);
 
         internal static napi_status node_api_throw_syntax_error(
             napi_env env, string? code, string msg)
-            => CallInterop(Current, FunctionId.node_api_throw_syntax_error, env, code, msg);
+            => CallInterop(FunctionId.node_api_throw_syntax_error, env, code, msg);
 
         internal static napi_status napi_is_error(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(Current, FunctionId.napi_is_error, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_is_error, env, value.Handle, out result);
 
         internal static napi_status napi_is_exception_pending(napi_env env, out c_bool result)
-            => CallInterop(Current, FunctionId.napi_is_exception_pending, env, out result);
+            => CallInterop(FunctionId.napi_is_exception_pending, env, out result);
 
         internal static napi_status napi_get_and_clear_last_exception(
             napi_env env, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_get_and_clear_last_exception, env, out result);
+            => CallInterop(FunctionId.napi_get_and_clear_last_exception, env, out result);
 
         internal static napi_status napi_is_arraybuffer(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(Current, FunctionId.napi_is_arraybuffer, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_is_arraybuffer, env, value.Handle, out result);
 
         internal static napi_status napi_create_arraybuffer(
             napi_env env, nuint byte_length, out nint data, out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_arraybuffer,
                 env,
                 (nint)byte_length,
@@ -1035,7 +1000,6 @@ public static partial class JSNativeApi
             nint finalize_hint,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_external_arraybuffer,
                 env,
                 external_data,
@@ -1047,7 +1011,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_arraybuffer_info(
             napi_env env, napi_value arraybuffer, out nint data, out nuint byte_length)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_arraybuffer_info,
                 env,
                 arraybuffer.Handle,
@@ -1056,7 +1019,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_typedarray(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(Current, FunctionId.napi_is_typedarray, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_is_typedarray, env, value.Handle, out result);
 
         internal static napi_status napi_create_typedarray(
             napi_env env,
@@ -1066,7 +1029,7 @@ public static partial class JSNativeApi
             nuint byte_offset,
             out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_typedarray);
+            nint funcHandle = GetExport(FunctionId.napi_create_typedarray);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 napi_typedarray_type,
@@ -1096,8 +1059,7 @@ public static partial class JSNativeApi
                 out napi_value arraybuffer,
                 out nuint byte_offset)
                 => CallInterop(
-                    Current,
-                    FunctionId.napi_get_typedarray_info,
+                        FunctionId.napi_get_typedarray_info,
                     env,
                     typedarray.Handle,
                     out type,
@@ -1113,7 +1075,6 @@ public static partial class JSNativeApi
             nuint byte_offset,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_dataview,
                 env,
                 (nint)length,
@@ -1123,7 +1084,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_dataview(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(Current, FunctionId.napi_is_dataview, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_is_dataview, env, value.Handle, out result);
 
         internal static napi_status napi_get_dataview_info(
             napi_env env,
@@ -1133,7 +1094,7 @@ public static partial class JSNativeApi
             out napi_value arraybuffer,
             out nuint byte_offset)
             => CallInterop(
-                Current, FunctionId.napi_get_dataview_info,
+                FunctionId.napi_get_dataview_info,
                 env,
                 dataview.Handle,
                 out bytelength,
@@ -1142,17 +1103,16 @@ public static partial class JSNativeApi
                 out byte_offset);
 
         internal static napi_status napi_get_version(napi_env env, out uint result)
-            => CallInterop(Current, FunctionId.napi_get_version, env, out result);
+            => CallInterop(FunctionId.napi_get_version, env, out result);
 
         internal static napi_status napi_create_promise(
             napi_env env, out napi_deferred deferred, out napi_value promise)
             => CallInterop(
-                Current, FunctionId.napi_create_promise, env, out deferred, out promise);
+                FunctionId.napi_create_promise, env, out deferred, out promise);
 
         internal static napi_status napi_resolve_deferred(
             napi_env env, napi_deferred deferred, napi_value resolution)
             => CallInterop(
-                Current,
                 FunctionId.napi_resolve_deferred,
                 env,
                 deferred.Handle,
@@ -1161,20 +1121,20 @@ public static partial class JSNativeApi
         internal static napi_status napi_reject_deferred(
             napi_env env, napi_deferred deferred, napi_value rejection)
             => CallInterop(
-                Current, FunctionId.napi_reject_deferred, env, deferred.Handle, rejection.Handle);
+                FunctionId.napi_reject_deferred, env, deferred.Handle, rejection.Handle);
 
         internal static napi_status napi_is_promise(
             napi_env env, napi_value value, out c_bool is_promise)
-            => CallInterop(Current, FunctionId.napi_is_promise, env, value.Handle, out is_promise);
+            => CallInterop(FunctionId.napi_is_promise, env, value.Handle, out is_promise);
 
         internal static napi_status napi_run_script(
             napi_env env, napi_value script, out napi_value result)
-            => CallInterop(Current, FunctionId.napi_run_script, env, script.Handle, out result);
+            => CallInterop(FunctionId.napi_run_script, env, script.Handle, out result);
 
         internal static napi_status napi_adjust_external_memory(
             napi_env env, long change_in_bytes, out long adjusted_value)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_adjust_external_memory);
+            nint funcHandle = GetExport(FunctionId.napi_adjust_external_memory);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, long, nint, napi_status>)funcHandle;
             fixed (long* adjusted_value_native = &adjusted_value)
@@ -1186,7 +1146,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_date(
             napi_env env, double time, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_date);
+            nint funcHandle = GetExport(FunctionId.napi_create_date);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, double, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1197,11 +1157,11 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_date(
             napi_env env, napi_value value, out c_bool is_date)
-            => CallInterop(Current, FunctionId.napi_is_date, env, value.Handle, out is_date);
+            => CallInterop(FunctionId.napi_is_date, env, value.Handle, out is_date);
 
         internal static napi_status napi_get_date_value(
             napi_env env, napi_value value, out double result)
-            => CallInterop(Current, FunctionId.napi_get_date_value, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_get_date_value, env, value.Handle, out result);
 
         internal static napi_status napi_add_finalizer(
             napi_env env,
@@ -1211,7 +1171,7 @@ public static partial class JSNativeApi
             nint finalize_hint,
             napi_ref* result)
             => CallInterop(
-                Current, FunctionId.napi_add_finalizer,
+                FunctionId.napi_add_finalizer,
                 env,
                 js_object.Handle,
                 native_object,
@@ -1222,7 +1182,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_bigint_int64(
             napi_env env, long value, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_int64);
+            nint funcHandle = GetExport(FunctionId.napi_create_bigint_int64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, long, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1235,7 +1195,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_bigint_uint64(
             napi_env env, ulong value, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_uint64);
+            nint funcHandle = GetExport(FunctionId.napi_create_bigint_uint64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, ulong, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1247,7 +1207,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_bigint_words(
             napi_env env, int sign_bit, nuint word_count, ulong* words, out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_uint64);
+            nint funcHandle = GetExport(FunctionId.napi_create_bigint_uint64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, int, nuint, nint, nint, napi_status>)funcHandle;
             fixed (napi_value* result_native = &result)
@@ -1259,7 +1219,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_bigint_int64(
             napi_env env, napi_value value, out long result, out c_bool lossless)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_value_bigint_int64,
                 env,
                 value.Handle,
@@ -1269,7 +1228,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_bigint_uint64(
             napi_env env, napi_value value, out ulong result, out c_bool lossless)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_value_bigint_uint64,
                 env,
                 value.Handle,
@@ -1279,7 +1237,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_value_bigint_words(
             napi_env env, napi_value value, out int sign_bit, out nuint word_count, ulong* words)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_value_bigint_words,
                 env,
                 value.Handle,
@@ -1295,7 +1252,7 @@ public static partial class JSNativeApi
             napi_key_conversion key_conversion,
             out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_bigint_uint64);
+            nint funcHandle = GetExport(FunctionId.napi_create_bigint_uint64);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 napi_value,
@@ -1319,7 +1276,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_set_instance_data(
             napi_env env, nint data, napi_finalize finalize_cb, nint finalize_hint)
         {
-            nint funcHandle = Current!.GetExport(
+            nint funcHandle = GetExport(
                 FunctionId.napi_set_instance_data, nameof(napi_set_instance_data));
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, napi_finalize, nint, napi_status>)funcHandle;
@@ -1327,15 +1284,15 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_get_instance_data(napi_env env, out nint data)
-            => CallInterop(Current, FunctionId.napi_get_instance_data, env, out data);
+            => CallInterop(FunctionId.napi_get_instance_data, env, out data);
 
         internal static napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer)
-            => CallInterop(Current, FunctionId.napi_detach_arraybuffer, env, arraybuffer.Handle);
+            => CallInterop(FunctionId.napi_detach_arraybuffer, env, arraybuffer.Handle);
 
         internal static napi_status napi_is_detached_arraybuffer(
             napi_env env, napi_value value, out c_bool result)
             => CallInterop(
-                Current, FunctionId.napi_is_detached_arraybuffer, env, value.Handle, out result);
+                FunctionId.napi_is_detached_arraybuffer, env, value.Handle, out result);
 
         internal static napi_status napi_type_tag_object(
             napi_env env, napi_value value, in napi_type_tag type_tag)
@@ -1343,8 +1300,7 @@ public static partial class JSNativeApi
             fixed (napi_type_tag* type_tag_native = &type_tag)
             {
                 return CallInterop(
-                    Current,
-                    FunctionId.napi_type_tag_object,
+                        FunctionId.napi_type_tag_object,
                     env,
                     value.Handle,
                     (nint)type_tag_native);
@@ -1358,8 +1314,7 @@ public static partial class JSNativeApi
             fixed (c_bool* result_native = &result)
             {
                 return CallInterop(
-                    Current,
-                    FunctionId.napi_check_object_type_tag,
+                        FunctionId.napi_check_object_type_tag,
                     env,
                     value.Handle,
                     (nint)type_tag_native,
@@ -1368,12 +1323,12 @@ public static partial class JSNativeApi
         }
 
         internal static napi_status napi_object_freeze(napi_env env, napi_value js_object)
-            => CallInterop(Current, FunctionId.napi_object_freeze, env, js_object.Handle);
+            => CallInterop(FunctionId.napi_object_freeze, env, js_object.Handle);
 
         internal static napi_status napi_object_seal(napi_env env, napi_value js_object)
-            => CallInterop(Current, FunctionId.napi_object_seal, env, js_object.Handle);
+            => CallInterop(FunctionId.napi_object_seal, env, js_object.Handle);
 
-        private nint GetExport(FunctionId functionId, [CallerMemberName] string functionName = "")
+        private static nint GetExport(FunctionId functionId, [CallerMemberName] string functionName = "")
         {
             nint methodPtr = _functions[(int)functionId];
             if (methodPtr == nint.Zero)
@@ -1386,14 +1341,13 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             out TResult result,
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1403,7 +1357,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             out TResult1 result1,
@@ -1412,7 +1365,7 @@ public static partial class JSNativeApi
             where TResult1 : unmanaged
             where TResult2 : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1423,7 +1376,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value,
@@ -1431,7 +1383,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1441,7 +1393,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value,
@@ -1451,7 +1402,7 @@ public static partial class JSNativeApi
             where TResult1 : unmanaged
             where TResult2 : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1462,7 +1413,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value,
@@ -1473,7 +1423,7 @@ public static partial class JSNativeApi
             where TResult1 : unmanaged
             where TResult2 : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1485,7 +1435,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult1, TResult2, TResult3, TResult4>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value,
@@ -1499,7 +1448,7 @@ public static partial class JSNativeApi
             where TResult3 : unmanaged
             where TResult4 : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult1* result1_native = &result1)
@@ -1519,7 +1468,6 @@ public static partial class JSNativeApi
 
         private static unsafe napi_status CallInterop<
             TResult1, TResult2, TResult3, TResult4, TResult5>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value,
@@ -1535,7 +1483,7 @@ public static partial class JSNativeApi
             where TResult4 : unmanaged
             where TResult5 : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 nint,
@@ -1563,7 +1511,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1572,7 +1519,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1582,7 +1529,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1591,7 +1537,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, uint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1600,21 +1546,19 @@ public static partial class JSNativeApi
             }
         }
         private static unsafe napi_status CallInterop(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
             nint value2,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
             return funcDelegate(env, value1, value2);
         }
 
         private static unsafe napi_status CallInterop(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1622,14 +1566,13 @@ public static partial class JSNativeApi
             nint value3,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, napi_status>)funcHandle;
             return funcDelegate(env, value1, value2, value3);
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1639,7 +1582,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1649,7 +1592,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1660,7 +1602,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1670,7 +1612,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1680,14 +1621,13 @@ public static partial class JSNativeApi
             nint value5,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             return funcDelegate(env, value1, value2, value3, value4, value5);
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1699,7 +1639,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1710,7 +1650,6 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop<TResult>(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value1,
@@ -1723,7 +1662,7 @@ public static partial class JSNativeApi
             [CallerMemberName] string functionName = "")
             where TResult : unmanaged
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, nint, nint, nint, nint, nint, napi_status>)funcHandle;
             fixed (TResult* result_native = &result)
@@ -1734,26 +1673,24 @@ public static partial class JSNativeApi
         }
 
         private static unsafe napi_status CallInterop(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             nint value,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<napi_env, nint, napi_status>)funcHandle;
             return funcDelegate(env, value);
         }
 
         private static napi_status CallInterop(
-            Interop? interop,
             FunctionId functionId,
             napi_env env,
             string? value1,
             string? value2,
             [CallerMemberName] string functionName = "")
         {
-            nint funcHandle = interop!.GetExport(functionId, functionName);
+            nint funcHandle = GetExport(functionId, functionName);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, nint, nint, napi_status>)funcHandle;
 

--- a/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
+++ b/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
@@ -15,7 +15,7 @@ public static partial class JSNativeApi
         public record struct napi_async_context(nint Handle);
         public record struct napi_async_work(nint Handle);
 
-        public unsafe struct napi_cleanup_hook
+        public struct napi_cleanup_hook
         {
             public delegate* unmanaged[Cdecl]<nint /*arg*/, void> Handle;
             public napi_cleanup_hook(delegate* unmanaged[Cdecl]<nint /*arg*/, void> handle)
@@ -36,7 +36,7 @@ public static partial class JSNativeApi
             napi_tsfn_blocking
         }
 
-        public unsafe struct napi_async_execute_callback
+        public struct napi_async_execute_callback
         {
             public delegate* unmanaged[Cdecl]<napi_env /*env*/, void* /*data*/, void> Handle;
             public napi_async_execute_callback(
@@ -44,7 +44,7 @@ public static partial class JSNativeApi
                 => Handle = handle;
         }
 
-        public unsafe struct napi_async_complete_callback
+        public struct napi_async_complete_callback
         {
             public delegate* unmanaged[Cdecl]<
                 napi_env /*env*/, napi_status /*status*/, void* /*data*/, void> Handle;
@@ -54,7 +54,7 @@ public static partial class JSNativeApi
                 => Handle = handle;
         }
 
-        public unsafe struct napi_threadsafe_function_call_js
+        public struct napi_threadsafe_function_call_js
         {
             public delegate* unmanaged[Cdecl]<
                 napi_env /*env*/,
@@ -72,7 +72,7 @@ public static partial class JSNativeApi
                 => Handle = handle;
         }
 
-        public unsafe struct napi_node_version
+        public struct napi_node_version
         {
             public uint major;
             public uint minor;
@@ -82,7 +82,7 @@ public static partial class JSNativeApi
 
         public record struct napi_async_cleanup_hook_handle(nint Handle);
 
-        public unsafe struct napi_async_cleanup_hook
+        public struct napi_async_cleanup_hook
         {
             public delegate* unmanaged[Cdecl]<
                 napi_async_cleanup_hook_handle /*handle*/, void* /*data*/, void> Handle;
@@ -92,7 +92,7 @@ public static partial class JSNativeApi
                 => Handle = handle;
         }
 
-        public unsafe struct napi_addon_register_func
+        public struct napi_addon_register_func
         {
             public delegate* unmanaged[Cdecl]<
                 napi_env /*env*/, napi_value /*exports*/, napi_value> Handle;
@@ -392,9 +392,7 @@ public static partial class JSNativeApi
             napi_threadsafe_function func,
             napi_threadsafe_function_release_mode mode)
         {
-            nint funcHandle = GetExport(
-                ref s_fields.napi_release_threadsafe_function,
-                nameof(napi_release_threadsafe_function));
+            nint funcHandle = GetExport(ref s_fields.napi_release_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function,
                 napi_threadsafe_function_release_mode,
@@ -430,9 +428,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_remove_async_cleanup_hook(
             napi_async_cleanup_hook_handle remove_handle)
         {
-            nint funcHandle = GetExport(
-                ref s_fields.napi_remove_async_cleanup_hook,
-                nameof(napi_remove_async_cleanup_hook));
+            nint funcHandle = GetExport(ref s_fields.napi_remove_async_cleanup_hook);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_async_cleanup_hook_handle,
                 napi_status>)funcHandle;
@@ -441,9 +437,7 @@ public static partial class JSNativeApi
 
         internal static napi_status node_api_get_module_file_name(napi_env env, byte** result)
         {
-            nint funcHandle = GetExport(
-                ref s_fields.node_api_get_module_file_name,
-                nameof(node_api_get_module_file_name));
+            nint funcHandle = GetExport(ref s_fields.node_api_get_module_file_name);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, byte**, napi_status>)funcHandle;
             return funcDelegate(env, result);

--- a/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
+++ b/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
@@ -120,7 +120,7 @@ public static partial class JSNativeApi
 
         internal static void napi_module_register(napi_module* mod)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_module_register);
+            nint funcHandle = GetExport(FunctionId.napi_module_register);
             var funcDelegate = (delegate* unmanaged[Cdecl]<napi_module*, void>)funcHandle;
             funcDelegate(mod);
         }
@@ -128,7 +128,7 @@ public static partial class JSNativeApi
         [DoesNotReturn]
         internal static void napi_fatal_error(string location, string message)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_fatal_error);
+            nint funcHandle = GetExport(FunctionId.napi_fatal_error);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 byte*, nuint, byte*, nuint, void>)funcHandle;
 
@@ -163,7 +163,6 @@ public static partial class JSNativeApi
             napi_value async_resource_name,
             out napi_async_context result)
             => CallInterop(
-                Current,
                 FunctionId.napi_async_init,
                 env,
                 async_resource.Handle,
@@ -172,7 +171,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_async_destroy(
             napi_env env, napi_async_context async_context)
-            => CallInterop(Current, FunctionId.napi_async_destroy, env, async_context.Handle);
+            => CallInterop(FunctionId.napi_async_destroy, env, async_context.Handle);
 
         internal static napi_status napi_make_callback(
             napi_env env,
@@ -183,7 +182,6 @@ public static partial class JSNativeApi
             nint argv,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_make_callback,
                 env,
                 async_context.Handle,
@@ -196,7 +194,6 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_buffer(
             napi_env env, nuint length, nint* data, napi_value* result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_buffer,
                 env,
                 (nint)length,
@@ -211,7 +208,6 @@ public static partial class JSNativeApi
             nint finalize_hint,
             out napi_value result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_external_buffer,
                 env,
                 (nint)length,
@@ -227,7 +223,7 @@ public static partial class JSNativeApi
             out nint result_data,
             out napi_value result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_buffer_copy);
+            nint funcHandle = GetExport(FunctionId.napi_create_buffer_copy);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                  napi_env, nuint, nint, nint*, napi_value*, napi_status>)funcHandle;
             fixed (nint* result_data_native = &result_data)
@@ -239,12 +235,11 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_buffer(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(Current, FunctionId.napi_is_buffer, env, value.Handle, out result);
+            => CallInterop(FunctionId.napi_is_buffer, env, value.Handle, out result);
 
         internal static napi_status napi_get_buffer_info(
             napi_env env, napi_value value, nint* data, nuint* length)
             => CallInterop(
-                Current,
                 FunctionId.napi_get_buffer_info,
                 env,
                 value.Handle,
@@ -260,7 +255,6 @@ public static partial class JSNativeApi
             nint data,
             out napi_async_work result)
             => CallInterop(
-                Current,
                 FunctionId.napi_create_async_work,
                 env,
                 async_resource.Handle,
@@ -271,32 +265,32 @@ public static partial class JSNativeApi
                 out result);
 
         internal static napi_status napi_delete_async_work(napi_env env, napi_async_work work)
-            => CallInterop(Current, FunctionId.napi_delete_async_work, env, work.Handle);
+            => CallInterop(FunctionId.napi_delete_async_work, env, work.Handle);
 
         internal static napi_status napi_queue_async_work(napi_env env, napi_async_work work)
-            => CallInterop(Current, FunctionId.napi_queue_async_work, env, work.Handle);
+            => CallInterop(FunctionId.napi_queue_async_work, env, work.Handle);
 
         internal static napi_status napi_cancel_async_work(napi_env env, napi_async_work work)
-            => CallInterop(Current, FunctionId.napi_cancel_async_work, env, work.Handle);
+            => CallInterop(FunctionId.napi_cancel_async_work, env, work.Handle);
 
         internal static napi_status napi_get_node_version(napi_env env, out nint version)
-            => CallInterop(Current, FunctionId.napi_get_node_version, env, out version);
+            => CallInterop(FunctionId.napi_get_node_version, env, out version);
 
         internal static napi_status napi_get_uv_event_loop(napi_env env, out uv_loop_t loop)
-            => CallInterop(Current, FunctionId.napi_get_uv_event_loop, env, out loop);
+            => CallInterop(FunctionId.napi_get_uv_event_loop, env, out loop);
 
         internal static napi_status napi_fatal_exception(napi_env env, napi_value err)
-            => CallInterop(Current, FunctionId.napi_fatal_exception, env, err.Handle);
+            => CallInterop(FunctionId.napi_fatal_exception, env, err.Handle);
 
         internal static napi_status napi_add_env_cleanup_hook(
             napi_env env, napi_cleanup_hook fun, nint arg)
             => CallInterop(
-                Current, FunctionId.napi_add_env_cleanup_hook, env, (nint)fun.Handle, arg);
+                FunctionId.napi_add_env_cleanup_hook, env, (nint)fun.Handle, arg);
 
         internal static napi_status napi_remove_env_cleanup_hook(
             napi_env env, napi_cleanup_hook fun, nint arg)
             => CallInterop(
-                Current, FunctionId.napi_remove_env_cleanup_hook, env, (nint)fun.Handle, arg);
+                FunctionId.napi_remove_env_cleanup_hook, env, (nint)fun.Handle, arg);
 
         internal static napi_status napi_open_callback_scope(
             napi_env env,
@@ -304,7 +298,6 @@ public static partial class JSNativeApi
             napi_async_context context,
             out napi_callback_scope result)
             => CallInterop(
-                Current,
                 FunctionId.napi_open_callback_scope,
                 env,
                 resource_object.Handle,
@@ -313,7 +306,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_close_callback_scope(
             napi_env env, napi_callback_scope scope)
-            => CallInterop(Current, FunctionId.napi_close_callback_scope, env, scope.Handle);
+            => CallInterop(FunctionId.napi_close_callback_scope, env, scope.Handle);
 
         internal static napi_status napi_create_threadsafe_function(
             napi_env env,
@@ -328,7 +321,7 @@ public static partial class JSNativeApi
             napi_threadsafe_function_call_js call_js_cb,
             out napi_threadsafe_function result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_create_threadsafe_function);
+            nint funcHandle = GetExport(FunctionId.napi_create_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 napi_value,
@@ -361,7 +354,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_threadsafe_function_context(
             napi_threadsafe_function func, out nint result)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_get_threadsafe_function_context);
+            nint funcHandle = GetExport(FunctionId.napi_get_threadsafe_function_context);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function,
                 nint*,
@@ -377,7 +370,7 @@ public static partial class JSNativeApi
             nint data,
             napi_threadsafe_function_call_mode is_blocking)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_call_threadsafe_function);
+            nint funcHandle = GetExport(FunctionId.napi_call_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function,
                 nint,
@@ -388,7 +381,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_acquire_threadsafe_function(napi_threadsafe_function func)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_acquire_threadsafe_function);
+            nint funcHandle = GetExport(FunctionId.napi_acquire_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function, napi_status>)funcHandle;
             return funcDelegate(func);
@@ -398,7 +391,7 @@ public static partial class JSNativeApi
             napi_threadsafe_function func,
             napi_threadsafe_function_release_mode mode)
         {
-            nint funcHandle = Current!.GetExport(
+            nint funcHandle = GetExport(
                 FunctionId.napi_release_threadsafe_function,
                 nameof(napi_release_threadsafe_function));
             var funcDelegate = (delegate* unmanaged[Cdecl]<
@@ -411,7 +404,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_unref_threadsafe_function(
             napi_env env, napi_threadsafe_function func)
         {
-            nint funcHandle = Current!.GetExport(FunctionId.napi_unref_threadsafe_function);
+            nint funcHandle = GetExport(FunctionId.napi_unref_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_threadsafe_function, napi_status>)funcHandle;
             return funcDelegate(env, func);
@@ -419,7 +412,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_ref_threadsafe_function(
             napi_env env, napi_threadsafe_function func)
-            => CallInterop(Current, FunctionId.napi_ref_threadsafe_function, env, func.Handle);
+            => CallInterop(FunctionId.napi_ref_threadsafe_function, env, func.Handle);
 
         internal static napi_status napi_add_async_cleanup_hook(
             napi_env env,
@@ -427,7 +420,6 @@ public static partial class JSNativeApi
             nint arg,
             out napi_async_cleanup_hook_handle remove_handle)
             => CallInterop(
-                Current,
                 FunctionId.napi_add_async_cleanup_hook,
                 env,
                 (nint)hook.Handle,
@@ -437,7 +429,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_remove_async_cleanup_hook(
             napi_async_cleanup_hook_handle remove_handle)
         {
-            nint funcHandle = Current!.GetExport(
+            nint funcHandle = GetExport(
                 FunctionId.napi_remove_async_cleanup_hook,
                 nameof(napi_remove_async_cleanup_hook));
             var funcDelegate = (delegate* unmanaged[Cdecl]<
@@ -448,7 +440,7 @@ public static partial class JSNativeApi
 
         internal static napi_status node_api_get_module_file_name(napi_env env, byte** result)
         {
-            nint funcHandle = Current!.GetExport(
+            nint funcHandle = GetExport(
                 FunctionId.node_api_get_module_file_name,
                 nameof(node_api_get_module_file_name));
             var funcDelegate = (delegate* unmanaged[Cdecl]<

--- a/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
+++ b/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
@@ -1,18 +1,15 @@
 // Definitions from Node.JS node_api.h and node_api_types.h
 
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Security;
-using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Microsoft.JavaScript.NodeApi;
 
 public static partial class JSNativeApi
 {
     // Node-API Interop definitions and functions.
-    [SuppressUnmanagedCodeSecurity]
-    public static unsafe partial class NodeApiInterop
+    public unsafe partial class Interop
     {
         public record struct napi_callback_scope(nint Handle);
         public record struct napi_async_context(nint Handle);
@@ -49,17 +46,29 @@ public static partial class JSNativeApi
 
         public unsafe struct napi_async_complete_callback
         {
-            public delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_status /*status*/, void* /*data*/, void> Handle;
+            public delegate* unmanaged[Cdecl]<
+                napi_env /*env*/, napi_status /*status*/, void* /*data*/, void> Handle;
             public napi_async_complete_callback(
-                delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_status /*status*/, void* /*data*/, void> handle)
+                delegate* unmanaged[Cdecl]<
+                    napi_env /*env*/, napi_status /*status*/, void* /*data*/, void> handle)
                 => Handle = handle;
         }
 
         public unsafe struct napi_threadsafe_function_call_js
         {
-            public delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*js_callback*/, nint /*context*/, nint /*data*/, void> Handle;
+            public delegate* unmanaged[Cdecl]<
+                napi_env /*env*/,
+                napi_value /*js_callback*/,
+                nint /*context*/,
+                nint /*data*/,
+                void> Handle;
             public napi_threadsafe_function_call_js(
-                delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*js_callback*/, nint /*context*/, nint /*data*/, void> handle)
+                delegate* unmanaged[Cdecl]<
+                    napi_env /*env*/,
+                    napi_value /*js_callback*/,
+                    nint /*context*/,
+                    nint /*data*/,
+                    void> handle)
                 => Handle = handle;
         }
 
@@ -75,17 +84,21 @@ public static partial class JSNativeApi
 
         public unsafe struct napi_async_cleanup_hook
         {
-            public delegate* unmanaged[Cdecl]<napi_async_cleanup_hook_handle /*handle*/, void* /*data*/, void> Handle;
+            public delegate* unmanaged[Cdecl]<
+                napi_async_cleanup_hook_handle /*handle*/, void* /*data*/, void> Handle;
             public napi_async_cleanup_hook(
-                delegate* unmanaged[Cdecl]<napi_async_cleanup_hook_handle /*handle*/, void* /*data*/, void> handle)
+                delegate* unmanaged[Cdecl]<
+                    napi_async_cleanup_hook_handle /*handle*/, void* /*data*/, void> handle)
                 => Handle = handle;
         }
 
         public unsafe struct napi_addon_register_func
         {
-            public delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*exports*/, napi_value> Handle;
+            public delegate* unmanaged[Cdecl]<
+                napi_env /*env*/, napi_value /*exports*/, napi_value> Handle;
             public napi_addon_register_func(
-                delegate* unmanaged[Cdecl]<napi_env /*env*/, napi_value /*exports*/, napi_value> handle)
+                delegate* unmanaged[Cdecl]<
+                    napi_env /*env*/, napi_value /*exports*/, napi_value> handle)
                 => Handle = handle;
         }
 
@@ -105,109 +118,204 @@ public static partial class JSNativeApi
 
         public record struct uv_loop_t(nint Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial void napi_module_register(napi_module* mod);
+        internal static void napi_module_register(napi_module* mod)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_module_register);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<napi_module*, void>)funcHandle;
+            funcDelegate(mod);
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
         [DoesNotReturn]
-        internal static unsafe partial void napi_fatal_error(
-            [MarshalAs(UnmanagedType.LPUTF8Str)] string location,
-            nuint location_len,
-            [MarshalAs(UnmanagedType.LPUTF8Str)] string message,
-            nuint message_len);
+        internal static void napi_fatal_error(string location, string message)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_fatal_error);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                byte*, nuint, byte*, nuint, void>)funcHandle;
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_async_init(
+            Utf8StringMarshaller.ManagedToUnmanagedIn location_marshaller = new();
+            Utf8StringMarshaller.ManagedToUnmanagedIn message_marshaller = new();
+            try
+            {
+                int bufferSize = Utf8StringMarshaller.ManagedToUnmanagedIn.BufferSize;
+
+                byte* location_stackptr = stackalloc byte[bufferSize];
+                location_marshaller.FromManaged(
+                    location, new Span<byte>(location_stackptr, bufferSize));
+                byte* location_native = location_marshaller.ToUnmanaged();
+
+                byte* message_stackptr = stackalloc byte[bufferSize];
+                message_marshaller.FromManaged(
+                    message, new Span<byte>(message_stackptr, bufferSize));
+                byte* message_native = message_marshaller.ToUnmanaged();
+
+                funcDelegate(location_native, NAPI_AUTO_LENGTH, message_native, NAPI_AUTO_LENGTH);
+            }
+            finally
+            {
+                location_marshaller.Free();
+                message_marshaller.Free();
+            }
+        }
+
+        internal static napi_status napi_async_init(
             napi_env env,
             napi_value async_resource,
             napi_value async_resource_name,
-            napi_async_context* result);
+            out napi_async_context result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_async_init,
+                env,
+                async_resource.Handle,
+                async_resource_name.Handle,
+                out result);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_async_destroy(napi_env env, napi_async_context async_context);
+        internal static napi_status napi_async_destroy(
+            napi_env env, napi_async_context async_context)
+            => CallInterop(Current, FunctionId.napi_async_destroy, env, async_context.Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_make_callback(
+        internal static napi_status napi_make_callback(
             napi_env env,
             napi_async_context async_context,
             napi_value recv,
             napi_value func,
             nuint argc,
-            napi_value* argv,
-            napi_value* result);
+            nint argv,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_make_callback,
+                env,
+                async_context.Handle,
+                recv.Handle,
+                func.Handle,
+                (nint)argc,
+                argv,
+                out result);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_create_buffer(napi_env env, nuint length, void** data, napi_value* result);
+        internal static napi_status napi_create_buffer(
+            napi_env env, nuint length, nint* data, napi_value* result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_buffer,
+                env,
+                (nint)length,
+                (nint)data,
+                (nint)result);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_create_external_buffer(
+        internal static napi_status napi_create_external_buffer(
             napi_env env,
             nuint length,
-            void* data,
+            nint data,
             napi_finalize finalize_cb,
-            void* finalize_hint,
-            napi_value* result);
+            nint finalize_hint,
+            out napi_value result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_external_buffer,
+                env,
+                (nint)length,
+                data,
+                (nint)finalize_cb.Handle,
+                finalize_hint,
+                out result);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_create_buffer_copy(
+        internal static napi_status napi_create_buffer_copy(
             napi_env env,
             nuint length,
-            void* data,
-            void** result_data,
-            napi_value* result);
+            nint data,
+            out nint result_data,
+            out napi_value result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_buffer_copy);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                 napi_env, nuint, nint, nint*, napi_value*, napi_status>)funcHandle;
+            fixed (nint* result_data_native = &result_data)
+            fixed (napi_value* result_native = &result)
+            {
+                return funcDelegate(env, length, data, result_data_native, result_native);
+            }
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_is_buffer(napi_env env, napi_value value, c_bool* result);
+        internal static napi_status napi_is_buffer(
+            napi_env env, napi_value value, out c_bool result)
+            => CallInterop(Current, FunctionId.napi_is_buffer, env, value.Handle, out result);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_get_buffer_info(napi_env env, napi_value value, void** data, nuint* length);
+        internal static napi_status napi_get_buffer_info(
+            napi_env env, napi_value value, nint* data, nuint* length)
+            => CallInterop(
+                Current,
+                FunctionId.napi_get_buffer_info,
+                env,
+                value.Handle,
+                (nint)data,
+                (nint)length);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_create_async_work(
+        internal static napi_status napi_create_async_work(
             napi_env env,
             napi_value async_resource,
             napi_value async_resource_name,
             napi_async_execute_callback execute,
             napi_async_complete_callback complete,
-            void* data,
-            napi_async_work* result);
+            nint data,
+            out napi_async_work result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_create_async_work,
+                env,
+                async_resource.Handle,
+                async_resource_name.Handle,
+                (nint)execute.Handle,
+                (nint)complete.Handle,
+                data,
+                out result);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_delete_async_work(napi_env env, napi_async_work work);
+        internal static napi_status napi_delete_async_work(napi_env env, napi_async_work work)
+            => CallInterop(Current, FunctionId.napi_delete_async_work, env, work.Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_queue_async_work(napi_env env, napi_async_work work);
+        internal static napi_status napi_queue_async_work(napi_env env, napi_async_work work)
+            => CallInterop(Current, FunctionId.napi_queue_async_work, env, work.Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_cancel_async_work(napi_env env, napi_async_work work);
+        internal static napi_status napi_cancel_async_work(napi_env env, napi_async_work work)
+            => CallInterop(Current, FunctionId.napi_cancel_async_work, env, work.Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_get_node_version(napi_env env, napi_node_version** version);
+        internal static napi_status napi_get_node_version(napi_env env, out nint version)
+            => CallInterop(Current, FunctionId.napi_get_node_version, env, out version);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_get_uv_event_loop(napi_env env, uv_loop_t* loop);
+        internal static napi_status napi_get_uv_event_loop(napi_env env, out uv_loop_t loop)
+            => CallInterop(Current, FunctionId.napi_get_uv_event_loop, env, out loop);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_fatal_exception(napi_env env, napi_value err);
+        internal static napi_status napi_fatal_exception(napi_env env, napi_value err)
+            => CallInterop(Current, FunctionId.napi_fatal_exception, env, err.Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_add_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, nint arg);
+        internal static napi_status napi_add_env_cleanup_hook(
+            napi_env env, napi_cleanup_hook fun, nint arg)
+            => CallInterop(
+                Current, FunctionId.napi_add_env_cleanup_hook, env, (nint)fun.Handle, arg);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_remove_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, nint arg);
+        internal static napi_status napi_remove_env_cleanup_hook(
+            napi_env env, napi_cleanup_hook fun, nint arg)
+            => CallInterop(
+                Current, FunctionId.napi_remove_env_cleanup_hook, env, (nint)fun.Handle, arg);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_open_callback_scope(
+        internal static napi_status napi_open_callback_scope(
             napi_env env,
             napi_value resource_object,
             napi_async_context context,
-            napi_callback_scope* result);
+            out napi_callback_scope result)
+            => CallInterop(
+                Current,
+                FunctionId.napi_open_callback_scope,
+                env,
+                resource_object.Handle,
+                context.Handle,
+                out result);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_close_callback_scope(napi_env env, napi_callback_scope scope);
+        internal static napi_status napi_close_callback_scope(
+            napi_env env, napi_callback_scope scope)
+            => CallInterop(Current, FunctionId.napi_close_callback_scope, env, scope.Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_create_threadsafe_function(
+        internal static napi_status napi_create_threadsafe_function(
             napi_env env,
             napi_value func,
             napi_value async_resource,
@@ -218,45 +326,134 @@ public static partial class JSNativeApi
             napi_finalize thread_finalize_cb,
             nint context,
             napi_threadsafe_function_call_js call_js_cb,
-            out napi_threadsafe_function result);
+            out napi_threadsafe_function result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_create_threadsafe_function);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env,
+                napi_value,
+                napi_value,
+                napi_value,
+                nuint,
+                nuint,
+                nint,
+                napi_finalize,
+                nint,
+                napi_threadsafe_function_call_js,
+                napi_threadsafe_function*,
+                napi_status>)funcHandle;
+            fixed (napi_threadsafe_function* result_native = &result)
+            {
+                return funcDelegate(env,
+                    func,
+                    async_resource,
+                    async_resource_name,
+                    max_queue_size,
+                    initial_thread_count,
+                    thread_finalize_data,
+                    thread_finalize_cb,
+                    context,
+                    call_js_cb,
+                    result_native);
+            }
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_get_threadsafe_function_context(
-            napi_threadsafe_function func,
-            out nint result);
+        internal static napi_status napi_get_threadsafe_function_context(
+            napi_threadsafe_function func, out nint result)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_get_threadsafe_function_context);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_threadsafe_function,
+                nint*,
+                napi_status>)funcHandle;
+            fixed (nint* result_native = &result)
+            {
+                return funcDelegate(func, result_native);
+            }
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_call_threadsafe_function(
+        internal static napi_status napi_call_threadsafe_function(
             napi_threadsafe_function func,
             nint data,
-            napi_threadsafe_function_call_mode is_blocking);
+            napi_threadsafe_function_call_mode is_blocking)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_call_threadsafe_function);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_threadsafe_function,
+                nint,
+                napi_threadsafe_function_call_mode,
+                napi_status>)funcHandle;
+            return funcDelegate(func, data, is_blocking);
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_acquire_threadsafe_function(napi_threadsafe_function func);
+        internal static napi_status napi_acquire_threadsafe_function(napi_threadsafe_function func)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_acquire_threadsafe_function);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_threadsafe_function, napi_status>)funcHandle;
+            return funcDelegate(func);
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_release_threadsafe_function(
+        internal static napi_status napi_release_threadsafe_function(
             napi_threadsafe_function func,
-            napi_threadsafe_function_release_mode mode);
+            napi_threadsafe_function_release_mode mode)
+        {
+            nint funcHandle = Current!.GetExport(
+                FunctionId.napi_release_threadsafe_function,
+                nameof(napi_release_threadsafe_function));
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_threadsafe_function,
+                napi_threadsafe_function_release_mode,
+                napi_status>)funcHandle;
+            return funcDelegate(func, mode);
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status
-        napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
+        internal static napi_status napi_unref_threadsafe_function(
+            napi_env env, napi_threadsafe_function func)
+        {
+            nint funcHandle = Current!.GetExport(FunctionId.napi_unref_threadsafe_function);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, napi_threadsafe_function, napi_status>)funcHandle;
+            return funcDelegate(env, func);
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
+        internal static napi_status napi_ref_threadsafe_function(
+            napi_env env, napi_threadsafe_function func)
+            => CallInterop(Current, FunctionId.napi_ref_threadsafe_function, env, func.Handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_add_async_cleanup_hook(
+        internal static napi_status napi_add_async_cleanup_hook(
             napi_env env,
             napi_async_cleanup_hook hook,
-            void* arg,
-            napi_async_cleanup_hook_handle* remove_handle);
+            nint arg,
+            out napi_async_cleanup_hook_handle remove_handle)
+            => CallInterop(
+                Current,
+                FunctionId.napi_add_async_cleanup_hook,
+                env,
+                (nint)hook.Handle,
+                arg,
+                out remove_handle);
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status napi_remove_async_cleanup_hook(napi_async_cleanup_hook_handle remove_handle);
+        internal static napi_status napi_remove_async_cleanup_hook(
+            napi_async_cleanup_hook_handle remove_handle)
+        {
+            nint funcHandle = Current!.GetExport(
+                FunctionId.napi_remove_async_cleanup_hook,
+                nameof(napi_remove_async_cleanup_hook));
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_async_cleanup_hook_handle,
+                napi_status>)funcHandle;
+            return funcDelegate(remove_handle);
+        }
 
-        [LibraryImport(nameof(NodeApi)), UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-        internal static unsafe partial napi_status node_api_get_module_file_name(napi_env env, byte** result);
+        internal static napi_status node_api_get_module_file_name(napi_env env, byte** result)
+        {
+            nint funcHandle = Current!.GetExport(
+                FunctionId.node_api_get_module_file_name,
+                nameof(node_api_get_module_file_name));
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                napi_env, byte**, napi_status>)funcHandle;
+            return funcDelegate(env, result);
+        }
     }
 }

--- a/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
+++ b/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
@@ -120,7 +120,7 @@ public static partial class JSNativeApi
 
         internal static void napi_module_register(napi_module* mod)
         {
-            nint funcHandle = GetExport(FunctionId.napi_module_register);
+            nint funcHandle = GetExport(ref s_fields.napi_module_register);
             var funcDelegate = (delegate* unmanaged[Cdecl]<napi_module*, void>)funcHandle;
             funcDelegate(mod);
         }
@@ -128,7 +128,7 @@ public static partial class JSNativeApi
         [DoesNotReturn]
         internal static void napi_fatal_error(string location, string message)
         {
-            nint funcHandle = GetExport(FunctionId.napi_fatal_error);
+            nint funcHandle = GetExport(ref s_fields.napi_fatal_error);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 byte*, nuint, byte*, nuint, void>)funcHandle;
 
@@ -155,6 +155,7 @@ public static partial class JSNativeApi
                 location_marshaller.Free();
                 message_marshaller.Free();
             }
+            throw new InvalidOperationException("This line must be unreachable");
         }
 
         internal static napi_status napi_async_init(
@@ -163,7 +164,7 @@ public static partial class JSNativeApi
             napi_value async_resource_name,
             out napi_async_context result)
             => CallInterop(
-                FunctionId.napi_async_init,
+                ref s_fields.napi_async_init,
                 env,
                 async_resource.Handle,
                 async_resource_name.Handle,
@@ -171,7 +172,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_async_destroy(
             napi_env env, napi_async_context async_context)
-            => CallInterop(FunctionId.napi_async_destroy, env, async_context.Handle);
+            => CallInterop(ref s_fields.napi_async_destroy, env, async_context.Handle);
 
         internal static napi_status napi_make_callback(
             napi_env env,
@@ -182,7 +183,7 @@ public static partial class JSNativeApi
             nint argv,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_make_callback,
+                ref s_fields.napi_make_callback,
                 env,
                 async_context.Handle,
                 recv.Handle,
@@ -194,7 +195,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_create_buffer(
             napi_env env, nuint length, nint* data, napi_value* result)
             => CallInterop(
-                FunctionId.napi_create_buffer,
+                ref s_fields.napi_create_buffer,
                 env,
                 (nint)length,
                 (nint)data,
@@ -208,7 +209,7 @@ public static partial class JSNativeApi
             nint finalize_hint,
             out napi_value result)
             => CallInterop(
-                FunctionId.napi_create_external_buffer,
+                ref s_fields.napi_create_external_buffer,
                 env,
                 (nint)length,
                 data,
@@ -223,7 +224,7 @@ public static partial class JSNativeApi
             out nint result_data,
             out napi_value result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_buffer_copy);
+            nint funcHandle = GetExport(ref s_fields.napi_create_buffer_copy);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                  napi_env, nuint, nint, nint*, napi_value*, napi_status>)funcHandle;
             fixed (nint* result_data_native = &result_data)
@@ -235,12 +236,12 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_is_buffer(
             napi_env env, napi_value value, out c_bool result)
-            => CallInterop(FunctionId.napi_is_buffer, env, value.Handle, out result);
+            => CallInterop(ref s_fields.napi_is_buffer, env, value.Handle, out result);
 
         internal static napi_status napi_get_buffer_info(
             napi_env env, napi_value value, nint* data, nuint* length)
             => CallInterop(
-                FunctionId.napi_get_buffer_info,
+                ref s_fields.napi_get_buffer_info,
                 env,
                 value.Handle,
                 (nint)data,
@@ -255,7 +256,7 @@ public static partial class JSNativeApi
             nint data,
             out napi_async_work result)
             => CallInterop(
-                FunctionId.napi_create_async_work,
+                ref s_fields.napi_create_async_work,
                 env,
                 async_resource.Handle,
                 async_resource_name.Handle,
@@ -265,32 +266,32 @@ public static partial class JSNativeApi
                 out result);
 
         internal static napi_status napi_delete_async_work(napi_env env, napi_async_work work)
-            => CallInterop(FunctionId.napi_delete_async_work, env, work.Handle);
+            => CallInterop(ref s_fields.napi_delete_async_work, env, work.Handle);
 
         internal static napi_status napi_queue_async_work(napi_env env, napi_async_work work)
-            => CallInterop(FunctionId.napi_queue_async_work, env, work.Handle);
+            => CallInterop(ref s_fields.napi_queue_async_work, env, work.Handle);
 
         internal static napi_status napi_cancel_async_work(napi_env env, napi_async_work work)
-            => CallInterop(FunctionId.napi_cancel_async_work, env, work.Handle);
+            => CallInterop(ref s_fields.napi_cancel_async_work, env, work.Handle);
 
         internal static napi_status napi_get_node_version(napi_env env, out nint version)
-            => CallInterop(FunctionId.napi_get_node_version, env, out version);
+            => CallInterop(ref s_fields.napi_get_node_version, env, out version);
 
         internal static napi_status napi_get_uv_event_loop(napi_env env, out uv_loop_t loop)
-            => CallInterop(FunctionId.napi_get_uv_event_loop, env, out loop);
+            => CallInterop(ref s_fields.napi_get_uv_event_loop, env, out loop);
 
         internal static napi_status napi_fatal_exception(napi_env env, napi_value err)
-            => CallInterop(FunctionId.napi_fatal_exception, env, err.Handle);
+            => CallInterop(ref s_fields.napi_fatal_exception, env, err.Handle);
 
         internal static napi_status napi_add_env_cleanup_hook(
             napi_env env, napi_cleanup_hook fun, nint arg)
             => CallInterop(
-                FunctionId.napi_add_env_cleanup_hook, env, (nint)fun.Handle, arg);
+                ref s_fields.napi_add_env_cleanup_hook, env, (nint)fun.Handle, arg);
 
         internal static napi_status napi_remove_env_cleanup_hook(
             napi_env env, napi_cleanup_hook fun, nint arg)
             => CallInterop(
-                FunctionId.napi_remove_env_cleanup_hook, env, (nint)fun.Handle, arg);
+                ref s_fields.napi_remove_env_cleanup_hook, env, (nint)fun.Handle, arg);
 
         internal static napi_status napi_open_callback_scope(
             napi_env env,
@@ -298,7 +299,7 @@ public static partial class JSNativeApi
             napi_async_context context,
             out napi_callback_scope result)
             => CallInterop(
-                FunctionId.napi_open_callback_scope,
+                ref s_fields.napi_open_callback_scope,
                 env,
                 resource_object.Handle,
                 context.Handle,
@@ -306,7 +307,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_close_callback_scope(
             napi_env env, napi_callback_scope scope)
-            => CallInterop(FunctionId.napi_close_callback_scope, env, scope.Handle);
+            => CallInterop(ref s_fields.napi_close_callback_scope, env, scope.Handle);
 
         internal static napi_status napi_create_threadsafe_function(
             napi_env env,
@@ -321,7 +322,7 @@ public static partial class JSNativeApi
             napi_threadsafe_function_call_js call_js_cb,
             out napi_threadsafe_function result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_create_threadsafe_function);
+            nint funcHandle = GetExport(ref s_fields.napi_create_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env,
                 napi_value,
@@ -354,7 +355,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_get_threadsafe_function_context(
             napi_threadsafe_function func, out nint result)
         {
-            nint funcHandle = GetExport(FunctionId.napi_get_threadsafe_function_context);
+            nint funcHandle = GetExport(ref s_fields.napi_get_threadsafe_function_context);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function,
                 nint*,
@@ -370,7 +371,7 @@ public static partial class JSNativeApi
             nint data,
             napi_threadsafe_function_call_mode is_blocking)
         {
-            nint funcHandle = GetExport(FunctionId.napi_call_threadsafe_function);
+            nint funcHandle = GetExport(ref s_fields.napi_call_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function,
                 nint,
@@ -381,7 +382,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_acquire_threadsafe_function(napi_threadsafe_function func)
         {
-            nint funcHandle = GetExport(FunctionId.napi_acquire_threadsafe_function);
+            nint funcHandle = GetExport(ref s_fields.napi_acquire_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function, napi_status>)funcHandle;
             return funcDelegate(func);
@@ -392,7 +393,7 @@ public static partial class JSNativeApi
             napi_threadsafe_function_release_mode mode)
         {
             nint funcHandle = GetExport(
-                FunctionId.napi_release_threadsafe_function,
+                ref s_fields.napi_release_threadsafe_function,
                 nameof(napi_release_threadsafe_function));
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_threadsafe_function,
@@ -404,7 +405,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_unref_threadsafe_function(
             napi_env env, napi_threadsafe_function func)
         {
-            nint funcHandle = GetExport(FunctionId.napi_unref_threadsafe_function);
+            nint funcHandle = GetExport(ref s_fields.napi_unref_threadsafe_function);
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, napi_threadsafe_function, napi_status>)funcHandle;
             return funcDelegate(env, func);
@@ -412,7 +413,7 @@ public static partial class JSNativeApi
 
         internal static napi_status napi_ref_threadsafe_function(
             napi_env env, napi_threadsafe_function func)
-            => CallInterop(FunctionId.napi_ref_threadsafe_function, env, func.Handle);
+            => CallInterop(ref s_fields.napi_ref_threadsafe_function, env, func.Handle);
 
         internal static napi_status napi_add_async_cleanup_hook(
             napi_env env,
@@ -420,7 +421,7 @@ public static partial class JSNativeApi
             nint arg,
             out napi_async_cleanup_hook_handle remove_handle)
             => CallInterop(
-                FunctionId.napi_add_async_cleanup_hook,
+                ref s_fields.napi_add_async_cleanup_hook,
                 env,
                 (nint)hook.Handle,
                 arg,
@@ -430,7 +431,7 @@ public static partial class JSNativeApi
             napi_async_cleanup_hook_handle remove_handle)
         {
             nint funcHandle = GetExport(
-                FunctionId.napi_remove_async_cleanup_hook,
+                ref s_fields.napi_remove_async_cleanup_hook,
                 nameof(napi_remove_async_cleanup_hook));
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_async_cleanup_hook_handle,
@@ -441,7 +442,7 @@ public static partial class JSNativeApi
         internal static napi_status node_api_get_module_file_name(napi_env env, byte** result)
         {
             nint funcHandle = GetExport(
-                FunctionId.node_api_get_module_file_name,
+                ref s_fields.node_api_get_module_file_name,
                 nameof(node_api_get_module_file_name));
             var funcDelegate = (delegate* unmanaged[Cdecl]<
                 napi_env, byte**, napi_status>)funcHandle;

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -85,12 +85,16 @@ public static partial class JSNativeApi
     {
         if (buffer.IsEmpty)
         {
-            return napi_get_value_string_latin1(Env, (napi_value)thisValue, null, 0, out nuint result).ThrowIfFailed((int)result);
+            return napi_get_value_string_latin1(
+                Env, (napi_value)thisValue, nint.Zero, 0, out nuint result)
+                .ThrowIfFailed((int)result);
         }
 
         fixed (byte* ptr = &buffer[0])
         {
-            return napi_get_value_string_latin1(Env, (napi_value)thisValue, ptr, (nuint)buffer.Length, out nuint result).ThrowIfFailed((int)result);
+            return napi_get_value_string_latin1(
+                Env, (napi_value)thisValue, (nint)ptr, (nuint)buffer.Length, out nuint result)
+                .ThrowIfFailed((int)result);
         }
     }
 
@@ -108,12 +112,16 @@ public static partial class JSNativeApi
     {
         if (buffer.IsEmpty)
         {
-            return napi_get_value_string_utf8(Env, (napi_value)thisValue, null, 0, out nuint result).ThrowIfFailed((int)result);
+            return napi_get_value_string_utf8(
+                Env, (napi_value)thisValue, nint.Zero, 0, out nuint result)
+                .ThrowIfFailed((int)result);
         }
 
         fixed (byte* ptr = &buffer[0])
         {
-            return napi_get_value_string_utf8(Env, (napi_value)thisValue, ptr, (nuint)buffer.Length, out nuint result).ThrowIfFailed((int)result);
+            return napi_get_value_string_utf8(
+                Env, (napi_value)thisValue, (nint)ptr, (nuint)buffer.Length, out nuint result)
+                .ThrowIfFailed((int)result);
         }
     }
 
@@ -131,12 +139,16 @@ public static partial class JSNativeApi
     {
         if (buffer.IsEmpty)
         {
-            return napi_get_value_string_utf16(Env, (napi_value)thisValue, null, 0, out nuint result).ThrowIfFailed((int)result);
+            return napi_get_value_string_utf16(
+                Env, (napi_value)thisValue, nint.Zero, 0, out nuint result)
+                .ThrowIfFailed((int)result);
         }
 
         fixed (char* ptr = &buffer[0])
         {
-            return napi_get_value_string_utf16(Env, (napi_value)thisValue, ptr, (nuint)buffer.Length, out nuint result).ThrowIfFailed((int)result);
+            return napi_get_value_string_utf16(
+                Env, (napi_value)thisValue, (nint)ptr, (nuint)buffer.Length, out nuint result)
+                .ThrowIfFailed((int)result);
         }
     }
 
@@ -205,14 +217,14 @@ public static partial class JSNativeApi
     public static unsafe void DefineProperties(this JSValue thisValue, IReadOnlyCollection<JSPropertyDescriptor> descriptors)
     {
         nint[] handles = ToUnmanagedPropertyDescriptors(ReadOnlySpan<byte>.Empty, descriptors, (_, count, descriptorsPtr) =>
-          napi_define_properties(Env, (napi_value)thisValue, count, descriptorsPtr).ThrowIfFailed());
+          napi_define_properties(Env, (napi_value)thisValue, count, (nint)descriptorsPtr).ThrowIfFailed());
         Array.ForEach(handles, handle => thisValue.AddGCHandleFinalizer(handle));
     }
 
     public static unsafe void DefineProperties(this JSValue thisValue, params JSPropertyDescriptor[] descriptors)
     {
         nint[] handles = ToUnmanagedPropertyDescriptors(ReadOnlySpan<byte>.Empty, descriptors, (_, count, descriptorsPtr) =>
-          napi_define_properties(Env, (napi_value)thisValue, count, descriptorsPtr).ThrowIfFailed());
+          napi_define_properties(Env, (napi_value)thisValue, count, (nint)descriptorsPtr).ThrowIfFailed());
         Array.ForEach(handles, handle => thisValue.AddGCHandleFinalizer(handle));
     }
 
@@ -227,33 +239,48 @@ public static partial class JSNativeApi
         => napi_strict_equals(Env, (napi_value)thisValue, (napi_value)other, out c_bool result).ThrowIfFailed((bool)result);
 
     public static unsafe JSValue Call(this JSValue thisValue)
-        => napi_call_function(Env, (napi_value)JSValue.Undefined, (napi_value)thisValue, 0, null, out napi_value result).ThrowIfFailed(result);
+        => napi_call_function(Env, (napi_value)JSValue.Undefined, (napi_value)thisValue, 0, nint.Zero, out napi_value result).ThrowIfFailed(result);
 
     public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg)
-        => napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, 0, null, out napi_value result).ThrowIfFailed(result);
+        => napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, 0, nint.Zero, out napi_value result).ThrowIfFailed(result);
 
     public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg, JSValue arg0)
     {
         napi_value argValue0 = (napi_value)arg0;
-        return napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, 1, &argValue0, out napi_value result).ThrowIfFailed(result);
+        napi_value* argv = &argValue0;
+        return napi_call_function(
+            Env, (napi_value)thisArg, (napi_value)thisValue, 1, (nint)argv, out napi_value result)
+            .ThrowIfFailed(result);
     }
 
-    public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg, JSValue arg0, JSValue arg1)
+    public static unsafe JSValue Call(
+        this JSValue thisValue, JSValue thisArg, JSValue arg0, JSValue arg1)
     {
         napi_value* argv = stackalloc napi_value[2] { (napi_value)arg0, (napi_value)arg1 };
-        return napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, 2, argv, out napi_value result).ThrowIfFailed(result);
+        return napi_call_function(
+            Env, (napi_value)thisArg, (napi_value)thisValue, 2, (nint)argv, out napi_value result)
+            .ThrowIfFailed(result);
     }
 
-    public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg, JSValue arg0, JSValue arg1, JSValue arg2)
+    public static unsafe JSValue Call(
+        this JSValue thisValue, JSValue thisArg, JSValue arg0, JSValue arg1, JSValue arg2)
     {
-        napi_value* argv = stackalloc napi_value[3] { (napi_value)arg0, (napi_value)arg1, (napi_value)arg2 };
-        return napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, 3, argv, out napi_value result).ThrowIfFailed(result);
+        napi_value* argv = stackalloc napi_value[3] {
+            (napi_value)arg0,
+            (napi_value)arg1,
+            (napi_value)arg2
+        };
+        return napi_call_function(
+            Env, (napi_value)thisArg, (napi_value)thisValue, 3, (nint)argv, out napi_value result)
+            .ThrowIfFailed(result);
     }
 
-    public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg, params JSValue[] args)
+    public static unsafe JSValue Call(
+        this JSValue thisValue, JSValue thisArg, params JSValue[] args)
         => Call(thisValue, thisArg, new ReadOnlySpan<JSValue>(args));
 
-    public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg, ReadOnlySpan<JSValue> args)
+    public static unsafe JSValue Call(
+        this JSValue thisValue, JSValue thisArg, ReadOnlySpan<JSValue> args)
     {
         int argc = args.Length;
         napi_value* argv = stackalloc napi_value[argc];
@@ -262,42 +289,69 @@ public static partial class JSNativeApi
             argv[i] = (napi_value)args[i];
         }
 
-        return napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, (nuint)argc, argv, out napi_value result).ThrowIfFailed(result);
+        return napi_call_function(
+            Env,
+            (napi_value)thisArg,
+            (napi_value)thisValue,
+            (nuint)argc,
+            (nint)argv,
+            out napi_value result)
+            .ThrowIfFailed(result);
     }
 
-    public static unsafe JSValue Call(this JSValue thisValue, napi_value thisArg, ReadOnlySpan<napi_value> args)
+    public static unsafe JSValue Call(
+        this JSValue thisValue, napi_value thisArg, ReadOnlySpan<napi_value> args)
     {
         fixed (napi_value* argv = args)
         {
-            return napi_call_function(Env, thisArg, (napi_value)thisValue, (nuint)args.Length, argv, out napi_value result).ThrowIfFailed(result);
+            return napi_call_function(
+                Env,
+                thisArg,
+                (napi_value)thisValue,
+                (nuint)args.Length,
+                (nint)argv,
+                out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 
     public static unsafe JSValue CallAsConstructor(this JSValue thisValue)
-        => napi_new_instance(Env, (napi_value)thisValue, 0, null, out napi_value result).ThrowIfFailed(result);
+        => napi_new_instance(Env, (napi_value)thisValue, 0, nint.Zero, out napi_value result)
+            .ThrowIfFailed(result);
 
     public static unsafe JSValue CallAsConstructor(this JSValue thisValue, JSValue arg0)
     {
         napi_value argValue0 = (napi_value)arg0;
-        return napi_new_instance(Env, (napi_value)thisValue, 1, &argValue0, out napi_value result).ThrowIfFailed(result);
+        napi_value* argv = &argValue0;
+        return napi_new_instance(Env, (napi_value)thisValue, 1, (nint)argv, out napi_value result)
+            .ThrowIfFailed(result);
     }
 
-    public static unsafe JSValue CallAsConstructor(this JSValue thisValue, JSValue arg0, JSValue arg1)
+    public static unsafe JSValue CallAsConstructor(
+        this JSValue thisValue, JSValue arg0, JSValue arg1)
     {
         napi_value* argv = stackalloc napi_value[2] { (napi_value)arg0, (napi_value)arg1 };
-        return napi_new_instance(Env, (napi_value)thisValue, 2, argv, out napi_value result).ThrowIfFailed(result);
+        return napi_new_instance(Env, (napi_value)thisValue, 2, (nint)argv, out napi_value result)
+            .ThrowIfFailed(result);
     }
 
-    public static unsafe JSValue CallAsConstructor(this JSValue thisValue, JSValue arg0, JSValue arg1, JSValue arg2)
+    public static unsafe JSValue CallAsConstructor(
+        this JSValue thisValue, JSValue arg0, JSValue arg1, JSValue arg2)
     {
-        napi_value* argv = stackalloc napi_value[3] { (napi_value)arg0, (napi_value)arg1, (napi_value)arg2 };
-        return napi_new_instance(Env, (napi_value)thisValue, 3, argv, out napi_value result).ThrowIfFailed(result);
+        napi_value* argv = stackalloc napi_value[3] {
+            (napi_value)arg0,
+            (napi_value)arg1,
+            (napi_value)arg2
+        };
+        return napi_new_instance(Env, (napi_value)thisValue, 3, (nint)argv, out napi_value result)
+            .ThrowIfFailed(result);
     }
 
     public static unsafe JSValue CallAsConstructor(this JSValue thisValue, params JSValue[] args)
         => CallAsConstructor(thisValue, new ReadOnlySpan<JSValue>(args));
 
-    public static unsafe JSValue CallAsConstructor(this JSValue thisValue, ReadOnlySpan<JSValue> args)
+    public static unsafe JSValue CallAsConstructor(
+        this JSValue thisValue, ReadOnlySpan<JSValue> args)
     {
         int argc = args.Length;
         napi_value* argv = stackalloc napi_value[argc];
@@ -306,14 +360,19 @@ public static partial class JSNativeApi
             argv[i] = (napi_value)args[i];
         }
 
-        return napi_new_instance(Env, (napi_value)thisValue, (nuint)argc, argv, out napi_value result).ThrowIfFailed(result);
+        return napi_new_instance(
+            Env, (napi_value)thisValue, (nuint)argc, (nint)argv, out napi_value result)
+            .ThrowIfFailed(result);
     }
 
-    public static unsafe JSValue CallAsConstructor(this JSValue thisValue, ReadOnlySpan<napi_value> args)
+    public static unsafe JSValue CallAsConstructor(
+        this JSValue thisValue, ReadOnlySpan<napi_value> args)
     {
         fixed (napi_value* argv = args)
         {
-            return napi_new_instance(Env, (napi_value)thisValue, (nuint)args.Length, argv, out napi_value result).ThrowIfFailed(result);
+            return napi_new_instance(
+                Env, (napi_value)thisValue, (nuint)args.Length, (nint)argv, out napi_value result)
+                .ThrowIfFailed(result);
         }
     }
 
@@ -323,23 +382,29 @@ public static partial class JSNativeApi
     public static JSValue CallMethod(this JSValue thisValue, JSValue methodName, JSValue arg0)
         => thisValue.GetProperty(methodName).Call(thisValue, arg0);
 
-    public static JSValue CallMethod(this JSValue thisValue, JSValue methodName, JSValue arg0, JSValue arg1)
+    public static JSValue CallMethod(
+        this JSValue thisValue, JSValue methodName, JSValue arg0, JSValue arg1)
         => thisValue.GetProperty(methodName).Call(thisValue, arg0, arg1);
 
-    public static JSValue CallMethod(this JSValue thisValue, JSValue methodName, JSValue arg0, JSValue arg1, JSValue arg2)
+    public static JSValue CallMethod(
+        this JSValue thisValue, JSValue methodName, JSValue arg0, JSValue arg1, JSValue arg2)
         => thisValue.GetProperty(methodName).Call(thisValue, arg0, arg1, arg2);
 
-    public static JSValue CallMethod(this JSValue thisValue, JSValue methodName, params JSValue[] args)
+    public static JSValue CallMethod(
+        this JSValue thisValue, JSValue methodName, params JSValue[] args)
         => thisValue.GetProperty(methodName).Call(thisValue, args);
 
-    public static JSValue CallMethod(this JSValue thisValue, JSValue methodName, ReadOnlySpan<JSValue> args)
+    public static JSValue CallMethod(
+        this JSValue thisValue, JSValue methodName, ReadOnlySpan<JSValue> args)
         => thisValue.GetProperty(methodName).Call(thisValue, args);
 
-    public static JSValue CallMethod(this JSValue thisValue, JSValue methodName, ReadOnlySpan<napi_value> args)
+    public static JSValue CallMethod(
+        this JSValue thisValue, JSValue methodName, ReadOnlySpan<napi_value> args)
         => thisValue.GetProperty(methodName).Call((napi_value)thisValue, args);
 
     public static bool InstanceOf(this JSValue thisValue, JSValue constructor)
-        => napi_instanceof(Env, (napi_value)thisValue, (napi_value)constructor, out c_bool result).ThrowIfFailed((bool)result);
+        => napi_instanceof(Env, (napi_value)thisValue, (napi_value)constructor, out c_bool result)
+        .ThrowIfFailed((bool)result);
 
     public static unsafe JSValue DefineClass(
         ReadOnlySpan<byte> utf8Name,
@@ -352,12 +417,12 @@ public static partial class JSNativeApi
         {
             return napi_define_class(
                 Env,
-                namePtr,
+                (nint)namePtr,
                 (nuint)utf8Name.Length,
                 callback,
                 data,
                 count,
-                descriptors,
+                (nint)descriptors,
                 out napi_value result)
                 .ThrowIfFailed(result);
         }
@@ -371,10 +436,12 @@ public static partial class JSNativeApi
         GCHandle descriptorHandle = GCHandle.Alloc(constructorDescriptor);
         JSValue? func = null;
         napi_callback callback = new(
-            JSValueScope.Current?.ScopeType == JSValueScopeType.RootNoContext ?
-            &InvokeJSCallbackNoContext : &InvokeJSCallback);
+            JSValueScope.Current?.ScopeType == JSValueScopeType.RootNoContext
+            ? &InvokeJSCallbackNoContext
+            : &InvokeJSCallback);
 
-        nint[] handles = ToUnmanagedPropertyDescriptors(utf8Name, propertyDescriptors, (name, count, descriptorsPtr) =>
+        nint[] handles = ToUnmanagedPropertyDescriptors(
+            utf8Name, propertyDescriptors, (name, count, descriptorsPtr) =>
         {
             func = DefineClass(name, callback, (nint)descriptorHandle, count, descriptorsPtr);
         });
@@ -388,7 +455,8 @@ public static partial class JSNativeApi
         JSCallbackDescriptor constructorDescriptor,
         params JSPropertyDescriptor[] propertyDescriptors)
     {
-        return DefineClass(Encoding.UTF8.GetBytes(name), constructorDescriptor, propertyDescriptors);
+        return DefineClass(
+            Encoding.UTF8.GetBytes(name), constructorDescriptor, propertyDescriptors);
     }
 
     /// <summary>
@@ -419,7 +487,8 @@ public static partial class JSNativeApi
     /// <param name="value">The object to be wrapped.</param>
     /// <param name="wrapperWeakRef">Returns a weak reference to the JS wrapper.</param>
     /// <returns>The JS wrapper.</returns>
-    public static unsafe JSValue Wrap(this JSValue wrapper, object value, out JSReference wrapperWeakRef)
+    public static unsafe JSValue Wrap(
+        this JSValue wrapper, object value, out JSReference wrapperWeakRef)
     {
         GCHandle valueHandle = GCHandle.Alloc(value);
         napi_ref weakRef;
@@ -522,7 +591,8 @@ public static partial class JSNativeApi
         => new(thisValue, isWeak: true);
 
     public static bool IsError(this JSValue thisValue)
-        => napi_is_error(Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
+        => napi_is_error(
+            Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
 
     public static bool IsExceptionPending()
         => napi_is_exception_pending(Env, out c_bool result).ThrowIfFailed((bool)result);
@@ -531,16 +601,19 @@ public static partial class JSNativeApi
         => napi_get_and_clear_last_exception(Env, out napi_value result).ThrowIfFailed(result);
 
     public static bool IsArrayBuffer(this JSValue thisValue)
-        => napi_is_arraybuffer(Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
+        => napi_is_arraybuffer(
+            Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
 
     public static unsafe Span<byte> GetArrayBufferInfo(this JSValue thisValue)
     {
-        napi_get_arraybuffer_info(Env, (napi_value)thisValue, out void* data, out nuint length).ThrowIfFailed();
-        return new Span<byte>(data, (int)length);
+        napi_get_arraybuffer_info(Env, (napi_value)thisValue, out nint data, out nuint length)
+            .ThrowIfFailed();
+        return new Span<byte>((void*)data, (int)length);
     }
 
     public static bool IsTypedArray(this JSValue thisValue)
-        => napi_is_typedarray(Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
+        => napi_is_typedarray(
+            Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
 
     public static unsafe int GetTypedArrayLength(
         this JSValue thisValue,
@@ -549,13 +622,13 @@ public static partial class JSNativeApi
         napi_get_typedarray_info(
             Env,
             (napi_value)thisValue,
-            out napi_typedarray_type type_,
-            out nuint length_,
-            out void* _,
+            out napi_typedarray_type arrayType,
+            out nuint length,
+            out nint _,
             out napi_value _,
             out nuint _).ThrowIfFailed();
-        type = (JSTypedArrayType)(int)type_;
-        return (int)length_;
+        type = (JSTypedArrayType)(int)arrayType;
+        return (int)length;
     }
 
     public static unsafe Span<T> GetTypedArrayData<T>(
@@ -564,12 +637,12 @@ public static partial class JSNativeApi
         napi_get_typedarray_info(
             Env,
             (napi_value)thisValue,
-            out napi_typedarray_type type_,
-            out nuint length_,
-            out void* data_,
+            out napi_typedarray_type arrayType,
+            out nuint length,
+            out nint data,
             out napi_value _,
             out nuint _).ThrowIfFailed();
-        var type = (JSTypedArrayType)(int)type_;
+        var type = (JSTypedArrayType)(int)arrayType;
         if (!(default(T) switch
         {
             sbyte => type == JSTypedArrayType.Int8,
@@ -589,7 +662,7 @@ public static partial class JSNativeApi
                 $"Incorrect typed-array type {typeof(T)} for {type}Array.");
         }
 
-        return new Span<T>(data_, (int)length_);
+        return new Span<T>((void*)data, (int)length);
     }
 
     public static unsafe void GetTypedArrayBuffer(
@@ -604,7 +677,7 @@ public static partial class JSNativeApi
             (napi_value)thisValue,
             out napi_typedarray_type type_,
             out nuint length_,
-            out void* _,
+            out nint _,
             out napi_value arrayBuffer_,
             out nuint byteOffset_).ThrowIfFailed();
         type = (JSTypedArrayType)(int)type_;
@@ -614,18 +687,23 @@ public static partial class JSNativeApi
     }
 
     public static bool IsDataView(this JSValue thisValue)
-        => napi_is_dataview(Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
+        => napi_is_dataview(Env, (napi_value)thisValue, out c_bool result)
+            .ThrowIfFailed((bool)result);
 
-    public static unsafe void GetDataViewInfo(this JSValue thisValue, out ReadOnlySpan<byte> viewSpan, out JSValue arrayBuffer, out int byteOffset)
+    public static unsafe void GetDataViewInfo(
+        this JSValue thisValue,
+        out ReadOnlySpan<byte> viewSpan,
+        out JSValue arrayBuffer,
+        out int byteOffset)
     {
         napi_get_dataview_info(
           Env,
           (napi_value)thisValue,
           out nuint byteLength,
-          out void* data,
+          out nint data,
           out napi_value arrayBuffer_,
           out nuint byteOffset_).ThrowIfFailed();
-        viewSpan = new ReadOnlySpan<byte>(data, (int)byteLength);
+        viewSpan = new ReadOnlySpan<byte>((void*)data, (int)byteLength);
         arrayBuffer = arrayBuffer_;
         byteOffset = (int)byteOffset_;
     }
@@ -634,41 +712,59 @@ public static partial class JSNativeApi
         => napi_get_version(Env, out uint result).ThrowIfFailed(result);
 
     public static bool IsPromise(this JSValue thisValue)
-        => napi_is_promise(Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
+        => napi_is_promise(Env, (napi_value)thisValue, out c_bool result)
+            .ThrowIfFailed((bool)result);
 
     public static JSValue RunScript(this JSValue thisValue)
-        => napi_run_script(Env, (napi_value)thisValue, out napi_value result).ThrowIfFailed(result);
+        => napi_run_script(Env, (napi_value)thisValue, out napi_value result)
+            .ThrowIfFailed(result);
 
     public static bool IsDate(this JSValue thisValue)
         => napi_is_date(Env, (napi_value)thisValue, out c_bool result).ThrowIfFailed((bool)result);
 
     public static double GetDateValue(this JSValue thisValue)
-        => napi_get_date_value(Env, (napi_value)thisValue, out double result).ThrowIfFailed(result);
+        => napi_get_date_value(Env, (napi_value)thisValue, out double result)
+            .ThrowIfFailed(result);
 
     public static unsafe void AddFinalizer(this JSValue thisValue, Action finalize)
     {
         GCHandle finalizeHandle = GCHandle.Alloc(finalize);
-        napi_add_finalizer(Env, (napi_value)thisValue, (nint)finalizeHandle, new napi_finalize(&CallFinalizeAction), nint.Zero, null).ThrowIfFailed();
+        napi_add_finalizer(
+            Env,
+            (napi_value)thisValue,
+            (nint)finalizeHandle,
+            new napi_finalize(&CallFinalizeAction),
+            nint.Zero,
+            null).ThrowIfFailed();
     }
 
-    public static unsafe void AddFinalizer(this JSValue thisValue, Action finalize, out JSReference finalizerRef)
+    public static unsafe void AddFinalizer(
+        this JSValue thisValue, Action finalize, out JSReference finalizerRef)
     {
         GCHandle finalizeHandle = GCHandle.Alloc(finalize);
         napi_ref reference;
-        napi_add_finalizer(Env, (napi_value)thisValue, (nint)finalizeHandle, new napi_finalize(&CallFinalizeAction), nint.Zero, &reference).ThrowIfFailed();
+        napi_add_finalizer(
+            Env,
+            (napi_value)thisValue,
+            (nint)finalizeHandle,
+            new napi_finalize(&CallFinalizeAction),
+            nint.Zero,
+            &reference).ThrowIfFailed();
         finalizerRef = new JSReference(reference, isWeak: true);
     }
 
     public static long GetValueBigIntInt64(this JSValue thisValue, out bool isLossless)
     {
-        napi_get_value_bigint_int64(Env, (napi_value)thisValue, out long result, out c_bool lossless).ThrowIfFailed();
+        napi_get_value_bigint_int64(
+            Env, (napi_value)thisValue, out long result, out c_bool lossless).ThrowIfFailed();
         isLossless = (bool)lossless;
         return result;
     }
 
     public static ulong GetValueBigIntUInt64(this JSValue thisValue, out bool isLossless)
     {
-        napi_get_value_bigint_uint64(Env, (napi_value)thisValue, out ulong result, out c_bool lossless).ThrowIfFailed();
+        napi_get_value_bigint_uint64(
+            Env, (napi_value)thisValue, out ulong result, out c_bool lossless).ThrowIfFailed();
         isLossless = (bool)lossless;
         return result;
     }


### PR DESCRIPTION
Currently we bind Node-API C functions from the current running module by calling `SetDllImportResolver`.
It works, but it will not allow us using our library outside of Node.JS:
- The Node-API in React Native is going to be exposed from a specific DLL.
- In standalone C# application it may have its own call to `SetDllImportResolver` and thus we cannot do it in library.

In this PR we do not solve the problem completely, but make initial important steps:
- Implement an alternative binding for Node-API C functions by calling `NativeLibrary.GetExport`.
- Remove Node-API DLL resolver from the `SetDllImportResolver`.

I wonder if we can test perf for the new approach against previous. I do not want it causing regressions.

To complete the change, we need to:
- Move `Inperop.Initialize()` call from `JSContext` to code that creates it.
- Implement different binding for `HostFxr` functions and remove the `SetDllImportResolver` call.

In this PR I also did some formatting changes to fit lines into the 100-character limit for the files I was changing.
Sorry, it unnecessary produced more churn than needed.

Spelling of word 'marshler' was changed to 'marshaller' in the code and docs.