### PR TITLE
.NET 6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
       with:
         fetch-depth: 0 # Deep clone is required for versioning on git commit height
 
-    - name: Install libc6-dev # Required by .NET 6
+    - name: Link libdl.so # Required by .NET 6
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install -y libc6-dev
+      run: sudo ln -s /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so
 
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
       with:
         fetch-depth: 0 # Deep clone is required for versioning on git commit height
 
+    - name: Install libc6-dev # Required by .NET 6
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install -y libc6-dev
+
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
-        dotnet-version: [ 7.0.x ]
         node-version: [ 18.x ]
       fail-fast: false  # Don't cancel other jobs when one job fails
 
@@ -31,10 +30,15 @@ jobs:
       with:
         fetch-depth: 0 # Deep clone is required for versioning on git commit height
 
-    - name: Setup .NET ${{ matrix.dotnet-version }}
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}
+        dotnet-version: 6.0.x
+
+    - name: Setup .NET 7
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
 
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
@@ -42,6 +46,12 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Build
+      run: dotnet build --configuration Release
+
+    - name: Build native binaries
+      run: dotnet publish --configuration Release --framework net7.0
+
+    - name: Build packages
       run: dotnet pack --configuration Release
 
     # Uncomment to enable an SSH session for debugging
@@ -53,7 +63,7 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ runner.os }}-dotnet${{ matrix.dotnet-version }}-packages
+        name: ${{ runner.os }}-packages
         path: |
           out/pkg/*.nupkg
           out/pkg/*.tgz
@@ -61,20 +71,20 @@ jobs:
     - name: Test
       env:
         TRACE_NODE_API_HOST: 1
-      run: dotnet test --configuration Release --logger trx --results-directory "test-${{ matrix.dotnet-version }}-node${{ matrix.node-version }}"
+      run: dotnet test --configuration Release --logger trx --results-directory "test-node${{ matrix.node-version }}"
 
     - name: Upload test logs
       uses: actions/upload-artifact@v3
       with:
-        name: test-logs-${{ runner.os }}-dotnet${{ matrix.dotnet-version }}-node${{ matrix.node-version }}
+        name: test-logs-${{ runner.os }}-node${{ matrix.node-version }}
         path: out/obj/Release/**/*.log
       if: ${{ always() }}
 
     - name: Publish test results
       uses: dorny/test-reporter@v1
       with:
-        name: test (${{ runner.os }}, dotnet${{ matrix.dotnet-version }}, node${{ matrix.node-version }})
-        path: test-${{ matrix.dotnet-version }}-node${{ matrix.node-version }}/*.trx
+        name: test (${{ runner.os }}, node${{ matrix.node-version }})
+        path: test-node${{ matrix.node-version }}/*.trx
         reporter: dotnet-trx
       if: ${{ always() }} # Run this step even when there are test failures
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,15 @@ jobs:
           out/pkg/*.nupkg
           out/pkg/*.tgz
 
-    - name: Test
+    - name: Test .NET 6
       env:
         TRACE_NODE_API_HOST: 1
-      run: dotnet test --configuration Release --logger trx --results-directory "test-node${{ matrix.node-version }}"
+      run: dotnet test -f net6.0 --configuration Release --logger trx --results-directory "test-dotnet6-node${{ matrix.node-version }}"
+
+    - name: Test .NET 7
+      env:
+        TRACE_NODE_API_HOST: 1
+      run: dotnet test -f net7.0 --configuration Release --logger trx --results-directory "test-dotnet7-node${{ matrix.node-version }}"
 
     - name: Upload test logs
       uses: actions/upload-artifact@v3
@@ -84,7 +89,7 @@ jobs:
       uses: dorny/test-reporter@v1
       with:
         name: test (${{ runner.os }}, node${{ matrix.node-version }})
-        path: test-node${{ matrix.node-version }}/*.trx
+        path: test-dotnet*-node${{ matrix.node-version }}/*.trx
         reporter: dotnet-trx
       if: ${{ always() }} # Run this step even when there are test failures
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
+    <PublishAot Condition=" '$(TargetFramework)' == 'net7.0' ">true</PublishAot>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <BaseOutputPath>$(MSBuildThisFileDirectory)out/</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)bin/$(Configuration)/$(MSBuildProjectName)/</OutputPath>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.119" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.4.0" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="NuGet.Frameworks" Version="6.4.0" />
   </ItemGroup>
 </Project>

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -11,17 +11,23 @@ from re-using a previously-loaded (possibly outdated) version of the source gene
 
 ## Build Packages
 ```bash
+dotnet publish -f net7.0
 dotnet pack
 ```
 This produces both nuget and npm packages (for the current platform only) in the `out/pkg`
-directory.
+directory. Binaries for the `net7.0` target framework must be built and published first
+so that the Node API .NET native AOT host can be packaged.
 
 ## Test
 ```bash
+dotnet publish -f net7.0
 dotnet test
 ```
 
-Or to run a subset of test cases that match a filter:
+Binaries for the `net7.0` target framework must be built and published first
+because tests require the Node API .NET native AOT host.
+
+Use the `--filter` option to run a subset of test cases:
 ```bash
 dotnet test --filter "DisplayName~aot"
 ```

--- a/examples/aot-module/README.md
+++ b/examples/aot-module/README.md
@@ -5,8 +5,9 @@ depend on the .NET runtime. The `example.js` script loads that _native_ module a
 and calls a method on it. The script has access to type definitions and doc-comments for the
 module's APIs via the auto-generated `.d.ts` file.
 
-| Command             | Explanation
-|---------------------|--------------------------------------------------
-| `dotnet pack ../..` | Build NodeApi .NET & npm packages.
-| `dotnet publish`    | Install NodeApi .NET packages into example project; build example project and compile to native binary.
-| `node example.js`   | Run example JS code that calls the example module.
+| Command                          | Explanation
+|----------------------------------|--------------------------------------------------
+| `dotnet publish -f net7.0 ../..` | Build NodeApi .NET native AOT host.
+| `dotnet pack ../..`              | Build NodeApi .NET & npm packages.
+| `dotnet publish`                 | Install NodeApi .NET packages into example project; build example project and compile to native binary.
+| `node example.js`                | Run example JS code that calls the example module.

--- a/examples/dotnet-dynamic/README.md
+++ b/examples/dotnet-dynamic/README.md
@@ -2,8 +2,9 @@
 ## Minimal Example of dynamically invoking .NET APIs
 The `example.js` script loads .NET  and calls `Console.WriteLine()`.
 
-| Command             | Explanation
-|---------------------|--------------------------------------------------
-| `dotnet pack ../..` | Build NodeApi .NET & npm packages.
-| `npm install`       | Install `node-api-dotnet` npm package into the example project.
-| `node example.js`   | Run example JS code that uses that package to dynamically invoke a .NET API.
+| Command                          | Explanation
+|----------------------------------|--------------------------------------------------
+| `dotnet publish -f net7.0 ../..` | Build NodeApi .NET host.
+| `dotnet pack ../..`              | Build NodeApi .NET & npm packages.
+| `npm install`                    | Install `node-api-dotnet` npm package into the example project.
+| `node example.js`                | Run example JS code that uses that package to dynamically invoke a .NET API.

--- a/examples/dotnet-module/README.md
+++ b/examples/dotnet-module/README.md
@@ -4,9 +4,10 @@ The `Example.cs` class defines a Node.js add-on module that runs on .NET. The `e
 loads that .NET module and calls a method on it. The script has access to type definitions and
 doc-comments for the module's APIs via the auto-generated `.d.ts` file.
 
-| Command             | Explanation
-|---------------------|--------------------------------------------------
-| `dotnet pack ../..` | Build NodeApi .NET & npm packages.
-| `npm install`       | Install NodeApi npm package into example project.
-| `dotnet build`      | Install NodeApi .NET packages into example project; build example project.
-| `node example.js`   | Run example JS code that calls the example module.
+| Command                          | Explanation
+|----------------------------------|--------------------------------------------------
+| `dotnet publish -f net7.0 ../..` | Build NodeApi .NET host.
+| `dotnet pack ../..`              | Build NodeApi .NET & npm packages.
+| `npm install`                    | Install NodeApi npm package into example project.
+| `dotnet build`                   | Install NodeApi .NET packages into example project; build example project.
+| `node example.js`                | Run example JS code that calls the example module.

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
@@ -73,7 +73,7 @@ internal static class JSInterfaceMarshaller
             }
         }
 
-        Type implementationType = typeBuilder.CreateType();
+        Type implementationType = typeBuilder.CreateType()!;
 
         // TODO: Get implementation delegates from the marshaller and assign to static properties.
 

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -27,7 +26,7 @@ internal static class ExpressionExtensions
         => ToCS(
             expression,
             path: expression.Name ?? string.Empty,
-            variables: ImmutableHashSet<string>.Empty);
+            variables: new HashSet<string>());
 
     /// <summary>
     /// Recursively traverses an expression tree and builds C# code from the expressions.
@@ -41,7 +40,7 @@ internal static class ExpressionExtensions
     private static string ToCS(
         Expression expression,
         string path,
-        ImmutableHashSet<string> variables)
+        HashSet<string> variables)
     {
         path += "/" + expression?.NodeType.ToString() ?? string.Empty;
 
@@ -169,7 +168,7 @@ internal static class ExpressionExtensions
     private static string WithParentheses(
         Expression expression,
         string path,
-        ImmutableHashSet<string> variables)
+        HashSet<string> variables)
     {
         string cs = ToCS(expression, path, variables);
 
@@ -188,7 +187,7 @@ internal static class ExpressionExtensions
     private static string FormatBlock(
         BlockExpression block,
         string path,
-        ImmutableHashSet<string> variables)
+        HashSet<string> variables)
     {
         StringBuilder s = new();
         s.Append("{\n");
@@ -206,7 +205,7 @@ internal static class ExpressionExtensions
     }
 
     private static string FormatStatement(
-        Expression expression, bool isReturn, string path, ref ImmutableHashSet<string> variables)
+        Expression expression, bool isReturn, string path, ref HashSet<string> variables)
     {
         string s = string.Empty;
 
@@ -216,7 +215,7 @@ internal static class ExpressionExtensions
             if (assignment.Left is ParameterExpression variable &&
                 !variables.Contains(variable.Name!))
             {
-                variables = variables.Add(variable.Name!);
+                variables = new HashSet<string>(variables.Union(new[] { variable.Name! }));
                 s += FormatType(variable.Type) + " " + s;
             }
         }
@@ -289,7 +288,7 @@ internal static class ExpressionExtensions
         MethodInfo method,
         IReadOnlyCollection<Expression> arguments,
         string path,
-        ImmutableHashSet<string> variables)
+        HashSet<string> variables)
         => (method.IsGenericMethod
             ? "<" + string.Join(", ", method.GetGenericArguments().Select(FormatType)) + ">"
             : string.Empty) + FormatArgs(arguments, path, variables);
@@ -297,6 +296,6 @@ internal static class ExpressionExtensions
     private static string FormatArgs(
         IEnumerable<Expression> arguments,
         string path,
-        ImmutableHashSet<string> variables)
+        HashSet<string> variables)
         => "(" + string.Join(", ", arguments.Select((a) => ToCS(a, path, variables))) + ")";
 }

--- a/src/NodeApi.Generator/NodeApi.Generator.csproj
+++ b/src/NodeApi.Generator/NodeApi.Generator.csproj
@@ -14,12 +14,13 @@
 
   <ItemGroup>
     <!-- Package the generator and dependencies in the analyzer directory of the nuget package -->
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\$(AssemblyName).dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\$(AssemblyName).runtimeconfig.json" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\Microsoft.JavaScript.NodeApi.dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\Microsoft.JavaScript.NodeApi.DotNetHost.dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\Microsoft.CodeAnalysis.dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\System.Reflection.MetadataLoadContext.dll" />
+    <!-- Use the .NET 6 targeted assembly as the analyzer for broader compatibility. (There's no difference in functionality.) -->
+    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\$(AssemblyName).dll" />
+    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\$(AssemblyName).runtimeconfig.json" />
+    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.dll" />
+    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.DotNetHost.dll" />
+    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
+    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
     <None Pack="true" PackagePath="build\$(AssemblyName).props" Include="NodeApi.Generator.props" />
     <None Pack="true" PackagePath="build\$(AssemblyName).targets" Include="NodeApi.Generator.targets" />
   </ItemGroup>

--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -110,7 +110,7 @@ internal static class SymbolExtensions
         {
             enumBuilder.DefineLiteral(fieldSymbol.Name, fieldSymbol.ConstantValue);
         }
-        return enumBuilder.CreateType();
+        return enumBuilder.CreateType()!;
     }
 
     private static Type BuildSymbolicObjectType(
@@ -189,7 +189,7 @@ internal static class SymbolExtensions
             => type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance) ??
                 throw new MissingMemberException(
                     $"Property {name} not found on attribute {type.Name}.");
-        return typeBuilder.CreateType();
+        return typeBuilder.CreateType()!;
     }
 
     private static ConstructorBuilder BuildSymbolicConstructor(

--- a/src/NodeApi/DotNetHost/HostFxr.cs
+++ b/src/NodeApi/DotNetHost/HostFxr.cs
@@ -1,7 +1,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -143,11 +142,8 @@ internal static partial class HostFxr
         */
     }
 
-    // Note this is CORECLR_DELEGATE_CALLTYPE, which is stdcall on Windows.
-    // See https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h
     // The returned function pointer must be converted to a specific delegate via
     // Marshal.GetDelegateForFunctionPointer().
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public unsafe delegate hostfxr_status load_assembly_and_get_function_pointer(
         byte* assemblyPath, // UTF-16 on Windows, UTF-8 elsewhere
         byte* typeName,     // UTF-16 on Windows, UTF-8 elsewhere
@@ -163,7 +159,7 @@ internal static partial class HostFxr
     {
         nint funcHandle = NativeLibrary.GetExport(
             Handle, nameof(hostfxr_initialize_for_runtime_config));
-        var funcDelegate = (delegate* unmanaged[Cdecl]<
+        var funcDelegate = (delegate* unmanaged[Cdecl]< // HOSTFXR_CALLTYPE = cdecl
                 byte*, hostfxr_initialize_parameters*, hostfxr_handle*, hostfxr_status>)funcHandle;
         hostfxr_handle outContextHandle;
         hostfxr_status status = funcDelegate(
@@ -175,14 +171,18 @@ internal static partial class HostFxr
     public static unsafe hostfxr_status hostfxr_get_runtime_delegate(
         hostfxr_handle hostContextHandle,
         hostfxr_delegate_type delegateType,
-        [MarshalAs(UnmanagedType.FunctionPtr)] out load_assembly_and_get_function_pointer function)
+        out load_assembly_and_get_function_pointer function)
     {
         nint funcHandle = NativeLibrary.GetExport(Handle, nameof(hostfxr_get_runtime_delegate));
-        var funcDelegate = (delegate* unmanaged[Cdecl]<
+        var funcDelegate = (delegate* unmanaged[Cdecl]< // HOSTFXR_CALLTYPE = cdecl
                 hostfxr_handle, hostfxr_delegate_type, nint*, hostfxr_status>)funcHandle;
         nint outFunction;
         hostfxr_status status = funcDelegate(hostContextHandle, delegateType, &outFunction);
-        var outFunctionDelegate = (delegate* unmanaged[Cdecl]<
+
+        // Wrap the unmanaged delegate with a managed delegate.
+        // Note this is CORECLR_DELEGATE_CALLTYPE, which is stdcall on Windows.
+        // See https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h
+        var outFunctionDelegate = (delegate* unmanaged[Stdcall]<
             byte*, byte*, byte*, nint, nint, nint*, hostfxr_status>)outFunction;
         function = status != hostfxr_status.Success ? default! :
             (assemblyPath, typeName, methodName, delegateType, reserved, outFunctionPointer)
@@ -194,7 +194,8 @@ internal static partial class HostFxr
     public static unsafe hostfxr_status hostfxr_close(hostfxr_handle hostContextHandle)
     {
         nint funcHandle = NativeLibrary.GetExport(Handle, nameof(hostfxr_close));
-        var funcDelegate = (delegate* unmanaged[Cdecl]<hostfxr_handle, hostfxr_status>)funcHandle;
+        var funcDelegate = (delegate* unmanaged[Cdecl]< // HOSTFXR_CALLTYPE = cdecl
+            hostfxr_handle, hostfxr_status>)funcHandle;
         return funcDelegate(hostContextHandle);
     }
 

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -43,7 +43,7 @@ internal partial class NativeHost : IDisposable
         using JSValueScope scope = new(JSValueScopeType.RootNoContext, env);
         try
         {
-            JSNativeApi.Interop.Initialize(NativeLibrary.GetMainProgramHandle());
+            JSNativeApi.Interop.Initialize();
 
             NativeHost host = new();
 
@@ -153,7 +153,7 @@ internal partial class NativeHost : IDisposable
                 methodNameBytes,
                 delegateType: -1 /* UNMANAGEDCALLERSONLY_METHOD */,
                 reserved: default,
-                out initializeModulePointer);
+                &initializeModulePointer);
         }
 
         CheckStatus(status, "Failed to load managed host assembly.");

--- a/src/NodeApi/Interop/IJSObjectUnwrapOfT.cs
+++ b/src/NodeApi/Interop/IJSObjectUnwrapOfT.cs
@@ -1,6 +1,0 @@
-namespace Microsoft.JavaScript.NodeApi.Interop;
-
-public interface IJSObjectUnwrap<T> where T : class
-{
-    static abstract T? Unwrap(JSCallbackArgs args);
-}

--- a/src/NodeApi/Interop/JSAsyncScope.cs
+++ b/src/NodeApi/Interop/JSAsyncScope.cs
@@ -66,7 +66,7 @@ public struct JSAsyncScope : IDisposable
 {
     private readonly JSSynchronizationContext _syncContext;
 
-    public bool IsDisposed { get; private set; }
+    public bool IsDisposed { get; private set; } = false;
 
     public JSAsyncScope()
     {

--- a/src/NodeApi/Interop/JSClassBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSClassBuilderOfT.cs
@@ -3,10 +3,7 @@ using System.Linq;
 
 namespace Microsoft.JavaScript.NodeApi.Interop;
 
-public class JSClassBuilder<T>
-  : JSPropertyDescriptorList<JSClassBuilder<T>, T>
-  , IJSObjectUnwrap<T>
-  where T : class
+public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> where T : class
 {
     private readonly JSCallbackDescriptor? _constructorDescriptor;
 
@@ -15,7 +12,7 @@ public class JSClassBuilder<T>
     public delegate T Constructor();
     public delegate T ConstructorWithArgs(JSCallbackArgs args);
 
-    public JSClassBuilder(string className)
+    public JSClassBuilder(string className) : base(Unwrap)
     {
         ClassName = className;
     }
@@ -38,12 +35,13 @@ public class JSClassBuilder<T>
     }
 
     public JSClassBuilder(string className, JSCallbackDescriptor constructorDescriptor)
+        : base(Unwrap)
     {
         ClassName = className;
         _constructorDescriptor = constructorDescriptor;
     }
 
-    static T? IJSObjectUnwrap<T>.Unwrap(JSCallbackArgs args)
+    private static new T? Unwrap(JSCallbackArgs args)
     {
         return (T?)args.ThisArg.Unwrap();
     }

--- a/src/NodeApi/Interop/JSContext.cs
+++ b/src/NodeApi/Interop/JSContext.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using static Microsoft.JavaScript.NodeApi.Interop.JSCollectionProxies;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi;
 using napi_env = Microsoft.JavaScript.NodeApi.JSNativeApi.Interop.napi_env;
@@ -90,7 +89,7 @@ public sealed class JSContext : IDisposable
     public JSContext(napi_env env)
     {
         // TODO: Move this Initialize call to the creators of JSContext
-        JSNativeApi.Interop.Initialize(NativeLibrary.GetMainProgramHandle());
+        JSNativeApi.Interop.Initialize();
 
         _env = env;
         SetInstanceData(env, this);

--- a/src/NodeApi/Interop/JSModuleBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSModuleBuilderOfT.cs
@@ -8,12 +8,13 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 /// </summary>
 /// <typeparam name="T">Either <see cref="JSContext" /> or a custom module class that
 /// wraps a <see cref="JSContext"/> instance.</typeparam>
-public class JSModuleBuilder<T>
-  : JSPropertyDescriptorList<JSModuleBuilder<T>, T>
-  , IJSObjectUnwrap<T>
-  where T : class
+public class JSModuleBuilder<T> : JSPropertyDescriptorList<JSModuleBuilder<T>, T> where T : class
 {
-    static T? IJSObjectUnwrap<T>.Unwrap(JSCallbackArgs _)
+    public JSModuleBuilder() : base(Unwrap)
+    {
+    }
+
+    private static new T? Unwrap(JSCallbackArgs _)
     {
         return (T?)JSContext.Current.Module;
     }

--- a/src/NodeApi/Interop/JSThreadSafeFunction.cs
+++ b/src/NodeApi/Interop/JSThreadSafeFunction.cs
@@ -43,7 +43,7 @@ public class JSThreadSafeFunction
                                  (napi_value)asyncResourceName,
                                  (nuint)maxQueueSize,
                                  (nuint)initialThreadCount,
-                                 thread_finalize_data: nint.Zero,
+                                 thread_finalize_data: default,
                                  new napi_finalize(&FinalizeFunctionData),
                                  (nint)functionDataHandle,
                                  (jsCaller != null)
@@ -117,7 +117,7 @@ public class JSThreadSafeFunction
     // This API may only be called from the main thread.
     public void Ref()
     {
-        if (_tsfn.Handle != nint.Zero)
+        if (_tsfn.Handle != default)
         {
             if (++_refCount == 1)
             {
@@ -129,7 +129,7 @@ public class JSThreadSafeFunction
     // This API may only be called from the main thread.
     public void Unref()
     {
-        if (_tsfn.Handle != nint.Zero)
+        if (_tsfn.Handle != default)
         {
             if (--_refCount == 0)
             {
@@ -207,7 +207,7 @@ public class JSThreadSafeFunction
             using JSValueScope scope = new(JSValueScopeType.Callback, env);
 
             object? callbackData = null;
-            if (data != nint.Zero)
+            if (data != default)
             {
                 GCHandle dataHandle = GCHandle.FromIntPtr(data);
                 callbackData = dataHandle.Target!;
@@ -236,7 +236,7 @@ public class JSThreadSafeFunction
         {
             using JSValueScope scope = new(JSValueScopeType.Callback, env);
 
-            if (data != nint.Zero)
+            if (data != default)
             {
                 GCHandle dataHandle = GCHandle.FromIntPtr(data);
                 object dataObject = dataHandle.Target!;
@@ -256,7 +256,7 @@ public class JSThreadSafeFunction
                     throw new ArgumentException("Unexpected data parameter");
                 }
             }
-            else if (jsCallback.Handle != nint.Zero)
+            else if (jsCallback.Handle != default)
             {
                 ((JSValue)jsCallback).Call();
             }

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -10,7 +10,7 @@ namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSErrorType { Error, TypeError, RangeError, SyntaxError }
 
-file record struct JSErrorInfo(string? Message, napi_status Status)
+internal record struct JSErrorInfo(string? Message, napi_status Status)
 {
     public static unsafe JSErrorInfo GetLastErrorInfo()
     {
@@ -37,8 +37,8 @@ file record struct JSErrorInfo(string? Message, napi_status Status)
 
 public struct JSError
 {
-    private string? _message;
-    private readonly JSReference? _errorRef;
+    private string? _message = null;
+    private readonly JSReference? _errorRef = null;
 
     private const string ErrorWrapValue = "4bda9e7e-4913-4dbc-95de-891cbf66598e-errorVal";
     private const string DefaultMessage = "Error in native callback";

--- a/src/NodeApi/JSExportAttribute.cs
+++ b/src/NodeApi/JSExportAttribute.cs
@@ -56,7 +56,10 @@ public class JSExportAttribute : Attribute
     /// <param name="name">Name of the item as exported to JavaScript.</param>
     public JSExportAttribute(string name)
     {
-        ArgumentException.ThrowIfNullOrEmpty(name);
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
 
         Name = name;
     }

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -12,7 +12,7 @@ namespace Microsoft.JavaScript.NodeApi;
 public readonly partial struct JSProxy : IEquatable<JSValue>
 {
     private readonly JSValue _value;
-    private readonly JSValue _revoke;
+    private readonly JSValue _revoke = default;
 
     public static explicit operator JSProxy(JSValue value) => new(value);
     public static implicit operator JSValue(JSProxy proxy) => proxy._value;

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -65,7 +65,7 @@ public class JSReference : IDisposable
         ThrowIfDisposed();
         if (!IsWeak)
         {
-            napi_reference_unref((napi_env)_context, _handle, nint.Zero).ThrowIfFailed();
+            napi_reference_unref((napi_env)_context, _handle, default).ThrowIfFailed();
             IsWeak = true;
         }
     }
@@ -74,7 +74,7 @@ public class JSReference : IDisposable
         ThrowIfDisposed();
         if (IsWeak)
         {
-            napi_reference_ref((napi_env)_context, _handle, nint.Zero).ThrowIfFailed();
+            napi_reference_ref((napi_env)_context, _handle, default).ThrowIfFailed();
             IsWeak = true;
         }
     }

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -10,8 +10,8 @@ namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSValue : IEquatable<JSValue>
 {
-    private readonly napi_value _handle;
-    private readonly JSValueScope? _scope;
+    private readonly napi_value _handle = default;
+    private readonly JSValueScope? _scope = null;
 
     public readonly JSValueScope Scope =>
         _scope ?? JSValueScope.Current ?? throw new InvalidOperationException("No current scope");
@@ -33,7 +33,7 @@ public readonly struct JSValue : IEquatable<JSValue>
     }
 
     public napi_value? Handle
-        => !Scope.IsDisposed ? (_handle.Handle != nint.Zero ? _handle : Undefined._handle) : null;
+        => !Scope.IsDisposed ? (_handle.Handle != default(nint) ? _handle : Undefined._handle) : null;
 
     public napi_value GetCheckedHandle()
         => Handle ?? throw new InvalidOperationException(
@@ -199,7 +199,7 @@ public readonly struct JSValue : IEquatable<JSValue>
             Env,
             (nint)valueHandle,
             new napi_finalize(&FinalizeGCHandle),
-            nint.Zero,
+            default,
             out napi_value result)
             .ThrowIfFailed(result);
     }
@@ -337,8 +337,8 @@ public readonly struct JSValue : IEquatable<JSValue>
     public static explicit operator napi_value(JSValue value) => value.GetCheckedHandle();
     public static implicit operator JSValue(napi_value handle) => new(handle);
 
-    public static explicit operator napi_value(JSValue? value) => value?.Handle ?? new napi_value(nint.Zero);
-    public static implicit operator JSValue?(napi_value handle) => handle.Handle != nint.Zero ? new JSValue(handle) : (JSValue?)null;
+    public static explicit operator napi_value(JSValue? value) => value?.Handle ?? new napi_value(default);
+    public static implicit operator JSValue?(napi_value handle) => handle.Handle != default ? new JSValue(handle) : (JSValue?)null;
 
     private static JSValue ValueOrNull<T>(T? value, Func<T, JSValue> convert) where T : struct
         => value.HasValue ? convert(value.Value) : JSValue.Null;

--- a/src/NodeApi/JSValueScope.cs
+++ b/src/NodeApi/JSValueScope.cs
@@ -60,7 +60,7 @@ public sealed class JSValueScope : IDisposable
                 => napi_open_escapable_handle_scope(
                     _env, out napi_escapable_handle_scope handleScope)
                    .ThrowIfFailed(handleScope).Handle,
-            _ => nint.Zero,
+            _ => default,
         };
     }
 

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -20,9 +20,9 @@ public static partial class JSNativeApi
 
     public static unsafe void AddGCHandleFinalizer(this JSValue thisValue, nint handle)
     {
-        if (handle != nint.Zero)
+        if (handle != default)
         {
-            napi_add_finalizer(Env, (napi_value)thisValue, handle, new napi_finalize(&FinalizeGCHandle), nint.Zero, null).ThrowIfFailed();
+            napi_add_finalizer(Env, (napi_value)thisValue, handle, new napi_finalize(&FinalizeGCHandle), default, null).ThrowIfFailed();
         }
     }
 
@@ -86,7 +86,7 @@ public static partial class JSNativeApi
         if (buffer.IsEmpty)
         {
             return napi_get_value_string_latin1(
-                Env, (napi_value)thisValue, nint.Zero, 0, out nuint result)
+                Env, (napi_value)thisValue, default, 0, out nuint result)
                 .ThrowIfFailed((int)result);
         }
 
@@ -113,7 +113,7 @@ public static partial class JSNativeApi
         if (buffer.IsEmpty)
         {
             return napi_get_value_string_utf8(
-                Env, (napi_value)thisValue, nint.Zero, 0, out nuint result)
+                Env, (napi_value)thisValue, default, 0, out nuint result)
                 .ThrowIfFailed((int)result);
         }
 
@@ -140,7 +140,7 @@ public static partial class JSNativeApi
         if (buffer.IsEmpty)
         {
             return napi_get_value_string_utf16(
-                Env, (napi_value)thisValue, nint.Zero, 0, out nuint result)
+                Env, (napi_value)thisValue, default, 0, out nuint result)
                 .ThrowIfFailed((int)result);
         }
 
@@ -239,10 +239,10 @@ public static partial class JSNativeApi
         => napi_strict_equals(Env, (napi_value)thisValue, (napi_value)other, out c_bool result).ThrowIfFailed((bool)result);
 
     public static unsafe JSValue Call(this JSValue thisValue)
-        => napi_call_function(Env, (napi_value)JSValue.Undefined, (napi_value)thisValue, 0, nint.Zero, out napi_value result).ThrowIfFailed(result);
+        => napi_call_function(Env, (napi_value)JSValue.Undefined, (napi_value)thisValue, 0, default, out napi_value result).ThrowIfFailed(result);
 
     public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg)
-        => napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, 0, nint.Zero, out napi_value result).ThrowIfFailed(result);
+        => napi_call_function(Env, (napi_value)thisArg, (napi_value)thisValue, 0, default, out napi_value result).ThrowIfFailed(result);
 
     public static unsafe JSValue Call(this JSValue thisValue, JSValue thisArg, JSValue arg0)
     {
@@ -316,7 +316,7 @@ public static partial class JSNativeApi
     }
 
     public static unsafe JSValue CallAsConstructor(this JSValue thisValue)
-        => napi_new_instance(Env, (napi_value)thisValue, 0, nint.Zero, out napi_value result)
+        => napi_new_instance(Env, (napi_value)thisValue, 0, default, out napi_value result)
             .ThrowIfFailed(result);
 
     public static unsafe JSValue CallAsConstructor(this JSValue thisValue, JSValue arg0)
@@ -474,7 +474,7 @@ public static partial class JSNativeApi
             (napi_value)wrapper,
             (nint)valueHandle,
             new napi_finalize(&FinalizeGCHandle),
-            nint.Zero,
+            default,
             null).ThrowIfFailed();
         return wrapper;
     }
@@ -497,7 +497,7 @@ public static partial class JSNativeApi
             (napi_value)wrapper,
             (nint)valueHandle,
             new napi_finalize(&FinalizeGCHandle),
-            nint.Zero,
+            default,
             &weakRef).ThrowIfFailed();
         wrapperWeakRef = new JSReference(weakRef, isWeak: true);
         return wrapper;
@@ -734,7 +734,7 @@ public static partial class JSNativeApi
             (napi_value)thisValue,
             (nint)finalizeHandle,
             new napi_finalize(&CallFinalizeAction),
-            nint.Zero,
+            default,
             null).ThrowIfFailed();
     }
 
@@ -748,7 +748,7 @@ public static partial class JSNativeApi
             (napi_value)thisValue,
             (nint)finalizeHandle,
             new napi_finalize(&CallFinalizeAction),
-            nint.Zero,
+            default,
             &reference).ThrowIfFailed();
         finalizerRef = new JSReference(reference, isWeak: true);
     }
@@ -794,7 +794,7 @@ public static partial class JSNativeApi
     internal static unsafe void SetInstanceData(napi_env env, object? data)
     {
         napi_get_instance_data(env, out nint handlePtr).ThrowIfFailed();
-        if (handlePtr != nint.Zero)
+        if (handlePtr != default)
         {
             // Current napi_set_instance_data implementation does not call finalizer when we replace existing instance data.
             // It means that we only remove the GC root, but do not call Dispose.
@@ -815,7 +815,7 @@ public static partial class JSNativeApi
     internal static object? GetInstanceData(napi_env env)
     {
         napi_get_instance_data(env, out nint data).ThrowIfFailed();
-        return (data != nint.Zero) ? GCHandle.FromIntPtr(data).Target : null;
+        return (data != default) ? GCHandle.FromIntPtr(data).Target : null;
     }
 
     public static void DetachArrayBuffer(this JSValue thisValue)
@@ -1007,7 +1007,7 @@ public static partial class JSNativeApi
         {
             napi_property_descriptor* descriptorPtr = &descriptorsPtr[i];
             descriptorPtr->name = (napi_value)descriptor.Name;
-            descriptorPtr->utf8name = nint.Zero;
+            descriptorPtr->utf8name = default;
             descriptorPtr->method = descriptor.Method == null ? default : methodCallback;
             descriptorPtr->getter = descriptor.Getter == null ? default : getterCallback;
             descriptorPtr->setter = descriptor.Setter == null ? default : setterCallback;
@@ -1019,7 +1019,7 @@ public static partial class JSNativeApi
             }
             else
             {
-                handlesToFinalize[i] = descriptorPtr->data = nint.Zero;
+                handlesToFinalize[i] = descriptorPtr->data = default;
             }
             i++;
         }

--- a/src/NodeApi/NodeApi.csproj
+++ b/src/NodeApi/NodeApi.csproj
@@ -5,11 +5,9 @@
     <RootNamespace>Microsoft.JavaScript.NodeApi</RootNamespace>
     <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PublishAot>true</PublishAot>
     <NativeLib>Shared</NativeLib>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SelfContained>false</SelfContained>
-    <BeforePack>Publish</BeforePack><!-- The npm package depends on published files. -->
     <PublishNodeModule>true</PublishNodeModule>
   </PropertyGroup>
 

--- a/src/node-api-dotnet/pack.js
+++ b/src/node-api-dotnet/pack.js
@@ -14,7 +14,7 @@ if (!configuration || rids.length === 0) {
 }
 
 const assemblyName = 'Microsoft.JavaScript.NodeApi';
-const targetFrameworks = ['net7.0']; // AOT binaries use the first TFM in this list.
+const targetFrameworks = ['net7.0', 'net6.0']; // AOT binaries use the first TFM in this list.
 
 const fs = require('fs');
 const path = require('path');

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -1,3 +1,5 @@
+#if NET7_0_OR_GREATER
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -62,10 +64,10 @@ public class NativeAotTests
         // TestCases/Directory.Build.{props,targets}
         File.WriteAllText(projectFilePath, "<Project Sdk=\"Microsoft.NET.Sdk\">\n</Project>\n");
 
-        string runtimeIdentifier = GetCurrentPlatformRuntimeIdentifier();
         var properties = new Dictionary<string, string>
         {
-            ["RuntimeIdentifier"] = runtimeIdentifier,
+            ["TargetFramework"] = GetCurrentFrameworkTarget(),
+            ["RuntimeIdentifier"] = GetCurrentPlatformRuntimeIdentifier(),
             ["Configuration"] = Configuration,
         };
 
@@ -95,3 +97,5 @@ public class NativeAotTests
         // Reference the generated type definitions from the C#?
     }
 }
+
+#endif // NET7_0_OR_GREATER

--- a/test/NodeApi.Test.csproj
+++ b/test/NodeApi.Test.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-		<RootNamespace>NodeApi.Test</RootNamespace>
-		<AssemblyName>NodeApi.Test</AssemblyName>
+    <RootNamespace>Microsoft.JavaScript.NodeApi.Test</RootNamespace>
+    <AssemblyName>Microsoft.JavaScript.NodeApi.Test</AssemblyName>
+    <IsPublishable>false</IsPublishable>
+    <PublishAot>false</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestCases/Directory.Build.props
+++ b/test/TestCases/Directory.Build.props
@@ -2,12 +2,10 @@
     <Import Project="../../Directory.Build.props" />
 
     <PropertyGroup>
-        <PublishAot>true</PublishAot>
         <NativeLib>Shared</NativeLib>
         <BaseIntermediateOutputPath>$(BaseOutputPath)obj/$(Configuration)/TestCases/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
         <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
         <OutputPath>$(BaseOutputPath)bin/$(Configuration)/TestCases/$(MSBuildProjectName)/</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>CS1591</NoWarn>
 

--- a/test/TestCases/Directory.Build.props
+++ b/test/TestCases/Directory.Build.props
@@ -7,7 +7,7 @@
         <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
         <OutputPath>$(BaseOutputPath)bin/$(Configuration)/TestCases/$(MSBuildProjectName)/</OutputPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>CS1591;IDE0060</NoWarn>
+        <NoWarn>CS1591</NoWarn>
 
         <!-- Always write *.NodeApi.g.cs in the obj/ directory. -->
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/test/TestCases/Directory.Build.props
+++ b/test/TestCases/Directory.Build.props
@@ -7,7 +7,7 @@
         <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
         <OutputPath>$(BaseOutputPath)bin/$(Configuration)/TestCases/$(MSBuildProjectName)/</OutputPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>CS1591</NoWarn>
+        <NoWarn>CS1591;IDE0060</NoWarn>
 
         <!-- Always write *.NodeApi.g.cs in the obj/ directory. -->
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -43,9 +43,6 @@ public static class ComplexTypes
 
     public static IDictionary<int, string> Dictionary { get; set; } = new Dictionary<int, string>();
 
-    public static IReadOnlyDictionary<int, string> ReadOnlyDictionary { get; set; }
-        = new Dictionary<int, string>().AsReadOnly();
-
     public static IDictionary<string, IList<ClassObject>> ObjectListDictionary { get; set; }
         = new Dictionary<string, IList<ClassObject>>();
 

--- a/test/TestCases/node-addon-api/basic_types/array.cs
+++ b/test/TestCases/node-addon-api/basic_types/array.cs
@@ -20,11 +20,11 @@ public class TestBasicTypesArray : TestHelper, ITestObject
         return JSValue.Undefined;
     }
 
-    public static JSObject Init() => new()
+    public JSObject Init() => new()
     {
-        Method(CreateArray),
-        Method(GetLength),
-        Method(Get),
-        Method(Set),
+        Method(CreateArray, nameof(CreateArray)),
+        Method(GetLength, nameof(GetLength)),
+        Method(Get, nameof(Get)),
+        Method(Set, nameof(Set)),
     };
 }

--- a/test/TestCases/node-addon-api/basic_types/boolean.cs
+++ b/test/TestCases/node-addon-api/basic_types/boolean.cs
@@ -10,9 +10,9 @@ public class TestBasicTypesBoolean : TestHelper, ITestObject
     private static JSValue CreateBooleanFromPrimitive(JSCallbackArgs args)
         => (bool)args[0];
 
-    public static JSObject Init() => new()
+    public JSObject Init() => new()
     {
-        Method(CreateBoolean),
-        Method(CreateBooleanFromPrimitive),
+        Method(CreateBoolean, nameof(CreateBoolean)),
+        Method(CreateBooleanFromPrimitive, nameof(CreateBooleanFromPrimitive)),
     };
 }

--- a/test/TestCases/node-addon-api/basic_types/number.cs
+++ b/test/TestCases/node-addon-api/basic_types/number.cs
@@ -2,6 +2,8 @@ using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;
 
+#pragma warning disable IDE0060 // Unused parameter 'args'
+
 public class TestBasicTypesNumber : TestHelper, ITestObject
 {
     private static JSValue ToInt32(JSCallbackArgs args) => (int)args[0];

--- a/test/TestCases/node-addon-api/basic_types/number.cs
+++ b/test/TestCases/node-addon-api/basic_types/number.cs
@@ -19,21 +19,21 @@ public class TestBasicTypesNumber : TestHelper, ITestObject
     private static JSValue OperatorFloat(JSCallbackArgs args) => (float)args[0] == (float)args[0].GetValueDouble();
     private static JSValue OperatorDouble(JSCallbackArgs args) => (double)args[0] == args[0].GetValueDouble();
 
-    public static JSObject Init() => new()
+    public JSObject Init() => new()
     {
-        Method(ToInt32),
-        Method(ToUInt32),
-        Method(ToInt64),
-        Method(ToFloat),
-        Method(ToDouble),
-        Method(MinFloat),
-        Method(MaxFloat),
-        Method(MinDouble),
-        Method(MaxDouble),
-        Method(OperatorInt32),
-        Method(OperatorUInt32),
-        Method(OperatorInt64),
-        Method(OperatorFloat),
-        Method(OperatorDouble),
+        Method(ToInt32, nameof(ToInt32)),
+        Method(ToUInt32, nameof(ToUInt32)),
+        Method(ToInt64, nameof(ToInt64)),
+        Method(ToFloat, nameof(ToFloat)),
+        Method(ToDouble, nameof(ToDouble)),
+        Method(MinFloat, nameof(MinFloat)),
+        Method(MaxFloat, nameof(MaxFloat)),
+        Method(MinDouble, nameof(MinDouble)),
+        Method(MaxDouble, nameof(MaxDouble)),
+        Method(OperatorInt32, nameof(OperatorInt32)),
+        Method(OperatorUInt32, nameof(OperatorUInt32)),
+        Method(OperatorInt64, nameof(OperatorInt64)),
+        Method(OperatorFloat, nameof(OperatorFloat)),
+        Method(OperatorDouble, nameof(OperatorDouble)),
     };
 }

--- a/test/TestCases/node-addon-api/basic_types/value.cs
+++ b/test/TestCases/node-addon-api/basic_types/value.cs
@@ -32,32 +32,32 @@ public class TestBasicTypesValue : TestHelper, ITestObject
     private static JSValue CreateExternal(JSCallbackArgs _) => JSValue.CreateExternal(1);
 
 
-    public static JSObject Init() => new()
+    public JSObject Init() => new()
     {
-        Method(IsUndefined),
-        Method(IsNull),
-        Method(IsBoolean),
-        Method(IsNumber),
-        Method(IsString),
-        Method(IsSymbol),
-        Method(IsArray),
-        Method(IsArrayBuffer),
-        Method(IsTypedArray),
-        Method(IsObject),
-        Method(IsFunction),
-        Method(IsPromise),
-        Method(IsDataView),
-        Method(IsExternal),
-        Method(ToBoolean),
-        Method(ToNumber),
-        Method(ToString),
-        Method(ToObject),
+        Method(IsUndefined, nameof(IsUndefined)),
+        Method(IsNull, nameof(IsNull)),
+        Method(IsBoolean, nameof(IsBoolean)),
+        Method(IsNumber, nameof(IsNumber)),
+        Method(IsString, nameof(IsString)),
+        Method(IsSymbol, nameof(IsSymbol)),
+        Method(IsArray, nameof(IsArray)),
+        Method(IsArrayBuffer, nameof(IsArrayBuffer)),
+        Method(IsTypedArray, nameof(IsTypedArray)),
+        Method(IsObject, nameof(IsObject)),
+        Method(IsFunction, nameof(IsFunction)),
+        Method(IsPromise, nameof(IsPromise)),
+        Method(IsDataView, nameof(IsDataView)),
+        Method(IsExternal, nameof(IsExternal)),
+        Method(ToBoolean, nameof(ToBoolean)),
+        Method(ToNumber, nameof(ToNumber)),
+        Method(ToString, nameof(ToString)),
+        Method(ToObject, nameof(ToObject)),
 
-        Method(StrictlyEquals),
+        Method(StrictlyEquals, nameof(StrictlyEquals)),
 
-        Method(CreateDefaultValue),
-        Method(CreateEmptyValue),
-        Method(CreateNonEmptyValue),
-        Method(CreateExternal),
+        Method(CreateDefaultValue, nameof(CreateDefaultValue)),
+        Method(CreateEmptyValue, nameof(CreateEmptyValue)),
+        Method(CreateNonEmptyValue, nameof(CreateNonEmptyValue)),
+        Method(CreateExternal, nameof(CreateExternal)),
     };
 }

--- a/test/TestCases/node-addon-api/binding.cs
+++ b/test/TestCases/node-addon-api/binding.cs
@@ -18,14 +18,14 @@ public class Binding
     public JSValue Object => GetOrCreate<TestObject>();
     public JSValue ObjectFreezeSeal => GetOrCreate<TestObjectFreezeSeal>();
 
-    private JSValue GetOrCreate<T>() where T : class, ITestObject
+    private JSValue GetOrCreate<T>() where T : class, ITestObject, new()
     {
         if (_testObjects.TryGetValue(typeof(T), out JSReference? testRef))
         {
             return testRef.GetValue() ?? JSValue.Undefined;
         }
 
-        JSValue obj = T.Init();
+        JSValue obj = new T().Init();
         _testObjects.Add(typeof(T), new JSReference(obj));
         return obj;
     }
@@ -33,14 +33,12 @@ public class Binding
 
 public interface ITestObject
 {
-    static abstract JSObject Init();
+    abstract JSObject Init();
 }
 
 public abstract class TestHelper
 {
-    public static KeyValuePair<JSValue, JSValue> Method(
-        JSCallback callback,
-        [CallerArgumentExpression(nameof(callback))] string? callbackName = null)
+    public static KeyValuePair<JSValue, JSValue> Method(JSCallback callback, string callbackName)
     {
         string name = callbackName ?? string.Empty;
         name = name.Substring(name.IndexOf('.') + 1);

--- a/test/TestCases/node-addon-api/object/object.cs
+++ b/test/TestCases/node-addon-api/object/object.cs
@@ -4,6 +4,8 @@ using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;
 
+#pragma warning disable IDE0060 // Unused parameter 'args'
+
 public partial class TestObject : TestHelper, ITestObject
 {
     private static bool s_testValue = true;

--- a/test/TestCases/node-addon-api/object/object.cs
+++ b/test/TestCases/node-addon-api/object/object.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using Microsoft.JavaScript.NodeApi;
 
@@ -115,7 +116,7 @@ public partial class TestObject : TestHelper, ITestObject
         obj["0.0f"] = 0.0f;
         obj["0.0"] = 0.0;
         obj["-1"] = -1;
-        obj["foo2"] = "foo"u8;
+        obj["foo2"] = new ReadOnlySpan<byte>(new byte[] { (byte)'f', (byte)'o', (byte)'o' });
         obj["foo4"] = "foo";
         obj["circular"] = obj;
         obj["circular2"] = obj;
@@ -154,61 +155,61 @@ public partial class TestObject : TestHelper, ITestObject
         return obj.InstanceOf(constructor);
     }
 
-    public static JSObject Init() => new()
+    public JSObject Init() => new()
     {
-        Method(GetPropertyNames),
-        Method(DefineProperties),
-        Method(DefineValueProperty),
+        Method(GetPropertyNames, nameof(GetPropertyNames)),
+        Method(DefineProperties, nameof(DefineProperties)),
+        Method(DefineValueProperty, nameof(DefineValueProperty)),
 
-        Method(GetPropertyWithNapiValue),
-        Method(GetPropertyWithNapiWrapperValue),
-        Method(GetPropertyWithLatin1StyleString),
-        Method(GetPropertyWithUtf8StyleString),
-        Method(GetPropertyWithCSharpStyleString),
-        Method(GetPropertyWithUInt32),
+        Method(GetPropertyWithNapiValue, nameof(GetPropertyWithNapiValue)),
+        Method(GetPropertyWithNapiWrapperValue, nameof(GetPropertyWithNapiWrapperValue)),
+        Method(GetPropertyWithLatin1StyleString, nameof(GetPropertyWithLatin1StyleString)),
+        Method(GetPropertyWithUtf8StyleString, nameof(GetPropertyWithUtf8StyleString)),
+        Method(GetPropertyWithCSharpStyleString, nameof(GetPropertyWithCSharpStyleString)),
+        Method(GetPropertyWithUInt32, nameof(GetPropertyWithUInt32)),
 
-        Method(SetPropertyWithNapiValue),
-        Method(SetPropertyWithNapiWrapperValue),
-        Method(SetPropertyWithLatin1StyleString),
-        Method(SetPropertyWithUtf8StyleString),
-        Method(SetPropertyWithCSharpStyleString),
-        Method(SetPropertyWithUInt32),
+        Method(SetPropertyWithNapiValue, nameof(SetPropertyWithNapiValue)),
+        Method(SetPropertyWithNapiWrapperValue, nameof(SetPropertyWithNapiWrapperValue)),
+        Method(SetPropertyWithLatin1StyleString, nameof(SetPropertyWithLatin1StyleString)),
+        Method(SetPropertyWithUtf8StyleString, nameof(SetPropertyWithUtf8StyleString)),
+        Method(SetPropertyWithCSharpStyleString, nameof(SetPropertyWithCSharpStyleString)),
+        Method(SetPropertyWithUInt32, nameof(SetPropertyWithUInt32)),
 
-        Method(DeletePropertyWithNapiValue),
-        Method(DeletePropertyWithNapiWrapperValue),
-        Method(DeletePropertyWithLatin1StyleString),
-        Method(DeletePropertyWithUtf8StyleString),
-        Method(DeletePropertyWithCSharpStyleString),
-        Method(DeletePropertyWithUInt32),
+        Method(DeletePropertyWithNapiValue, nameof(DeletePropertyWithNapiValue)),
+        Method(DeletePropertyWithNapiWrapperValue, nameof(DeletePropertyWithNapiWrapperValue)),
+        Method(DeletePropertyWithLatin1StyleString, nameof(DeletePropertyWithLatin1StyleString)),
+        Method(DeletePropertyWithUtf8StyleString, nameof(DeletePropertyWithUtf8StyleString)),
+        Method(DeletePropertyWithCSharpStyleString, nameof(DeletePropertyWithCSharpStyleString)),
+        Method(DeletePropertyWithUInt32, nameof(DeletePropertyWithUInt32)),
 
-        Method(HasOwnPropertyWithNapiValue),
-        Method(HasOwnPropertyWithNapiWrapperValue),
-        Method(HasOwnPropertyWithLatin1StyleString),
-        Method(HasOwnPropertyWithUtf8StyleString),
-        Method(HasOwnPropertyWithCSharpStyleString),
+        Method(HasOwnPropertyWithNapiValue, nameof(HasOwnPropertyWithNapiValue)),
+        Method(HasOwnPropertyWithNapiWrapperValue, nameof(HasOwnPropertyWithNapiWrapperValue)),
+        Method(HasOwnPropertyWithLatin1StyleString, nameof(HasOwnPropertyWithLatin1StyleString)),
+        Method(HasOwnPropertyWithUtf8StyleString, nameof(HasOwnPropertyWithUtf8StyleString)),
+        Method(HasOwnPropertyWithCSharpStyleString, nameof(HasOwnPropertyWithCSharpStyleString)),
 
-        Method(HasPropertyWithNapiValue),
-        Method(HasPropertyWithNapiWrapperValue),
-        Method(HasPropertyWithLatin1StyleString),
-        Method(HasPropertyWithUtf8StyleString),
-        Method(HasPropertyWithCSharpStyleString),
-        Method(HasPropertyWithUInt32),
+        Method(HasPropertyWithNapiValue, nameof(HasPropertyWithNapiValue)),
+        Method(HasPropertyWithNapiWrapperValue, nameof(HasPropertyWithNapiWrapperValue)),
+        Method(HasPropertyWithLatin1StyleString, nameof(HasPropertyWithLatin1StyleString)),
+        Method(HasPropertyWithUtf8StyleString, nameof(HasPropertyWithUtf8StyleString)),
+        Method(HasPropertyWithCSharpStyleString, nameof(HasPropertyWithCSharpStyleString)),
+        Method(HasPropertyWithUInt32, nameof(HasPropertyWithUInt32)),
 
-        Method(CreateObjectUsingMagic),
-        Method(Sum),
-        Method(Increment),
+        Method(CreateObjectUsingMagic, nameof(CreateObjectUsingMagic)),
+        Method(Sum, nameof(Sum)),
+        Method(Increment, nameof(Increment)),
 
-        Method(AddFinalizer),
+        Method(AddFinalizer, nameof(AddFinalizer)),
 
-        Method(InstanceOf),
+        Method(InstanceOf, nameof(InstanceOf)),
 
-        Method(SubscriptGetWithLatin1StyleString),
-        Method(SubscriptGetWithUtf8StyleString),
-        Method(SubscriptGetWithCSharpStyleString),
-        Method(SubscriptGetAtIndex),
-        Method(SubscriptSetWithLatin1StyleString),
-        Method(SubscriptSetWithUtf8StyleString),
-        Method(SubscriptSetWithCSharpStyleString),
-        Method(SubscriptSetAtIndex),
+        Method(SubscriptGetWithLatin1StyleString, nameof(SubscriptGetWithLatin1StyleString)),
+        Method(SubscriptGetWithUtf8StyleString, nameof(SubscriptGetWithUtf8StyleString)),
+        Method(SubscriptGetWithCSharpStyleString, nameof(SubscriptGetWithCSharpStyleString)),
+        Method(SubscriptGetAtIndex, nameof(SubscriptGetAtIndex)),
+        Method(SubscriptSetWithLatin1StyleString, nameof(SubscriptSetWithLatin1StyleString)),
+        Method(SubscriptSetWithUtf8StyleString, nameof(SubscriptSetWithUtf8StyleString)),
+        Method(SubscriptSetWithCSharpStyleString, nameof(SubscriptSetWithCSharpStyleString)),
+        Method(SubscriptSetAtIndex, nameof(SubscriptSetAtIndex)),
     };
 }

--- a/test/TestCases/node-addon-api/object/object_freeze_seal.cs
+++ b/test/TestCases/node-addon-api/object/object_freeze_seal.cs
@@ -18,9 +18,9 @@ public partial class TestObjectFreezeSeal : TestHelper, ITestObject
         return true;
     }
 
-    public static JSObject Init() => new()
+    public JSObject Init() => new()
     {
-        Method(Freeze),
-        Method(Seal),
+        Method(Freeze, nameof(Freeze)),
+        Method(Seal, nameof(Seal)),
     };
 }


### PR DESCRIPTION
This was more complicated than I expected, mostly due to the way the .NET 6 tests must still depend on the .NET 7 native host, because AOT compilation doesn't work with .NET 6.

 - Use `NativeLibrary.GetExport()` to bind the `HostFxr` function calls. The delegates are not cached because they are only called once each per process, when starting .NET.
 - Use P/Invoke to get the current module handle because `NativeLibrary.GetMainProgramHandle()` is not available in .NET 6.
 - Use alternative string marshaling code because `Utf8StringMarshaller` is not available in .NET 6.
 - Replace `nint.Zero` with `default` because the former is not available in .NET 6.
 - Set `LangVersion=10` to support compiling code with .NET 6 SDK (without AOT support).
   - This was required so that `net6.0` tests can drive MSBuild to build the auto-generated test projects.
   - We were using three C# 11 language features:
      - Static `Unwrap` interface method - replaced with a delegate parameter to the base class constructor.
      - Implicit default initialization of struct fields - easily initialized explicitly.
      - `CallerArgumentName` in tests code - replaced with explicit `nameof()`.
 - Update `pack.js` script for npm package to include `net6.0` target assemblies.
 - Update various parts of the test runner to support running tests against both `net6.0` and `net7.0` targets.
 - Update publish/pack MSBuild properties to support multi-targeting. Unfortunately it's no longer possible to have `dotnet pack` automatically publish first. So the examples all require an additional setup command; I updated the READMEs.
 - Update `build.yml` so the GH actions install both .NET 6 and 7 and run tests against both.