### PR TITLE
Add Microsoft copyright.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -152,6 +152,9 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
+# License header
+file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/examples/aot-module/Example.cs
+++ b/examples/aot-module/Example.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.JavaScript.NodeApi.Examples;
 
 /// <summary>

--- a/examples/aot-module/example.js
+++ b/examples/aot-module/example.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const Example = require('./bin/aot-module').Example;
 
 // Call a method exported by the .NET module.

--- a/examples/dotnet-dynamic/example.js
+++ b/examples/dotnet-dynamic/example.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const dotnet = require('node-api-dotnet');
 const Console = dotnet.Console;
 Console.WriteLine('Hello from .NET!');

--- a/examples/dotnet-module/Example.cs
+++ b/examples/dotnet-module/Example.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.JavaScript.NodeApi.Examples;
 
 /// <summary>

--- a/examples/dotnet-module/example.js
+++ b/examples/dotnet-module/example.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const dotnet = require('node-api-dotnet');
 
 /** @type {import('./bin/dotnet-module').Example} */

--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Concurrent;
 using System.Linq;

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/NodeApi.DotNetHost/JSMarshallerException.cs
+++ b/src/NodeApi.DotNetHost/JSMarshallerException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Reflection;
 

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/NodeApi.DotNetHost/TypeExtensions.cs
+++ b/src/NodeApi.DotNetHost/TypeExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NodeApi.Generator/Program.cs
+++ b/src/NodeApi.Generator/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi.Generator;

--- a/src/NodeApi.Generator/SourceBuilder.cs
+++ b/src/NodeApi.Generator/SourceBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NodeApi/DotNetHost/HostFxr.cs
+++ b/src/NodeApi/DotNetHost/HostFxr.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/src/NodeApi/Interop/JSAsyncScope.cs
+++ b/src/NodeApi/Interop/JSAsyncScope.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Threading;
 

--- a/src/NodeApi/Interop/JSCallbackDescriptor.cs
+++ b/src/NodeApi/Interop/JSCallbackDescriptor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi.Interop;

--- a/src/NodeApi/Interop/JSCallbackOverload.cs
+++ b/src/NodeApi/Interop/JSCallbackOverload.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/NodeApi/Interop/JSClassBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSClassBuilderOfT.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Linq;
 

--- a/src/NodeApi/Interop/JSCollectionExtensions.cs
+++ b/src/NodeApi/Interop/JSCollectionExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/NodeApi/Interop/JSCollectionProxies.cs
+++ b/src/NodeApi/Interop/JSCollectionProxies.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 

--- a/src/NodeApi/Interop/JSContext.cs
+++ b/src/NodeApi/Interop/JSContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/NodeApi/Interop/JSInterface.cs
+++ b/src/NodeApi/Interop/JSInterface.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.JavaScript.NodeApi.Interop;
 

--- a/src/NodeApi/Interop/JSModuleAttribute.cs
+++ b/src/NodeApi/Interop/JSModuleAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi.Interop;

--- a/src/NodeApi/Interop/JSModuleBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSModuleBuilderOfT.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Linq;
 

--- a/src/NodeApi/Interop/JSPropertyDescriptorListOfT.cs
+++ b/src/NodeApi/Interop/JSPropertyDescriptorListOfT.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/NodeApi/Interop/JSStructBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSStructBuilderOfT.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Threading;
 

--- a/src/NodeApi/Interop/JSThreadSafeFunction.cs
+++ b/src/NodeApi/Interop/JSThreadSafeFunction.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/NodeApi/JSArray.Enumerator.cs
+++ b/src/NodeApi/JSArray.Enumerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NodeApi/JSCallback.cs
+++ b/src/NodeApi/JSCallback.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.JavaScript.NodeApi;
 

--- a/src/NodeApi/JSCallbackArgs.cs
+++ b/src/NodeApi/JSCallbackArgs.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Runtime.InteropServices;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.JavaScript.NodeApi.Interop;

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;

--- a/src/NodeApi/JSException.cs
+++ b/src/NodeApi/JSException.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi;

--- a/src/NodeApi/JSExportAttribute.cs
+++ b/src/NodeApi/JSExportAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi;

--- a/src/NodeApi/JSIterable.Enumerator.cs
+++ b/src/NodeApi/JSIterable.Enumerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NodeApi/JSMap.Enumerator.cs
+++ b/src/NodeApi/JSMap.Enumerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/NodeApi/JSObject.Enumerator.cs
+++ b/src/NodeApi/JSObject.Enumerator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/NodeApi/JSPromiseExtensions.cs
+++ b/src/NodeApi/JSPromiseExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Threading.Tasks;
 
 namespace Microsoft.JavaScript.NodeApi;

--- a/src/NodeApi/JSPropertyAttributes.cs
+++ b/src/NodeApi/JSPropertyAttributes.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi;

--- a/src/NodeApi/JSPropertyDescriptor.cs
+++ b/src/NodeApi/JSPropertyDescriptor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi;

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.JavaScript.NodeApi.Interop;

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/NodeApi/JSSymbol.cs
+++ b/src/NodeApi/JSSymbol.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;

--- a/src/NodeApi/JSTypedArrayType.cs
+++ b/src/NodeApi/JSTypedArrayType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.JavaScript.NodeApi;
 
 // Matches to napi_typedarray_type

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;

--- a/src/NodeApi/JSValueScope.cs
+++ b/src/NodeApi/JSValueScope.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Threading;
 using Microsoft.JavaScript.NodeApi.Interop;

--- a/src/NodeApi/JSValueType.cs
+++ b/src/NodeApi/JSValueType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSValueType : int

--- a/src/NodeApi/Native/JSKeyCollectionMode.cs
+++ b/src/NodeApi/Native/JSKeyCollectionMode.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSKeyCollectionMode : int

--- a/src/NodeApi/Native/JSKeyConversion.cs
+++ b/src/NodeApi/Native/JSKeyConversion.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSKeyConversion : int

--- a/src/NodeApi/Native/JSKeyFilter.cs
+++ b/src/NodeApi/Native/JSKeyFilter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi;

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Definitions from Node.JS js_native_api.h and js_native_api_types.h
 
 using System;

--- a/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
+++ b/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Definitions from Node.JS node_api.h and node_api_types.h
 
 using System;

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/node-api-dotnet/index.d.ts
+++ b/src/node-api-dotnet/index.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // APIs defined here are implemented by Microsoft.JavaScript.NodeApi.DotNetHost.
 
 /**

--- a/src/node-api-dotnet/index.js
+++ b/src/node-api-dotnet/index.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 const assemblyName = 'Microsoft.JavaScript.NodeApi';
 

--- a/src/node-api-dotnet/pack.js
+++ b/src/node-api-dotnet/pack.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const nodeMajorVersion = process.versions.node.split('.')[0];
 if (nodeMajorVersion < 18) {
   console.error('Node.js version 18 or later is required.');

--- a/test/HostedClrTests.cs
+++ b/test/HostedClrTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #if NET7_0_OR_GREATER
 
 using System;

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/TestCases/common/index.js
+++ b/test/TestCases/common/index.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /* Test helpers ported from test/common/index.js in Node.js project. */
 'use strict';
 const assert = require('assert');

--- a/test/TestCases/edgejs-perf/Edge.Performance.cs
+++ b/test/TestCases/edgejs-perf/Edge.Performance.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Ported from https://github.com/agracio/edge-js/blob/master/performance/performance.cs
 
 using System;

--- a/test/TestCases/edgejs-perf/measure-latency.js
+++ b/test/TestCases/edgejs-perf/measure-latency.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Ported from https://github.com/agracio/edge-js/blob/master/performance/marshal_clr2v8.js
 
 // If using the test runner, the measurement results can be found in:

--- a/test/TestCases/napi-dotnet-init/ModuleInitializer.cs
+++ b/test/TestCases/napi-dotnet-init/ModuleInitializer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using Microsoft.JavaScript.NodeApi.Interop;
 

--- a/test/TestCases/napi-dotnet-init/custom_export.js
+++ b/test/TestCases/napi-dotnet-init/custom_export.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 
 process.env['TEST_DOTNET_MODULE_INIT_EXPORT'] = 'test';

--- a/test/TestCases/napi-dotnet-init/custom_init.js
+++ b/test/TestCases/napi-dotnet-init/custom_init.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 
 const binding = require('../common').binding;

--- a/test/TestCases/napi-dotnet/Another.cs
+++ b/test/TestCases/napi-dotnet/Another.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi.TestCases;

--- a/test/TestCases/napi-dotnet/AsyncMethods.cs
+++ b/test/TestCases/napi-dotnet/AsyncMethods.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Threading.Tasks;
 

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 

--- a/test/TestCases/napi-dotnet/Counter.cs
+++ b/test/TestCases/napi-dotnet/Counter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Threading;
 

--- a/test/TestCases/napi-dotnet/Hello.cs
+++ b/test/TestCases/napi-dotnet/Hello.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi.TestCases;

--- a/test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/test/TestCases/napi-dotnet/ModuleClass.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using Microsoft.JavaScript.NodeApi.Interop;
 

--- a/test/TestCases/napi-dotnet/ModuleExports.cs
+++ b/test/TestCases/napi-dotnet/ModuleExports.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.JavaScript.NodeApi.TestCases;

--- a/test/TestCases/napi-dotnet/async_methods.js
+++ b/test/TestCases/napi-dotnet/async_methods.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 const common = require('../common');
 

--- a/test/TestCases/napi-dotnet/complex_types.js
+++ b/test/TestCases/napi-dotnet/complex_types.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 
 /** @type {import('./napi-dotnet')} */

--- a/test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 
 const dotnetHost = process.env.TEST_DOTNET_HOST_PATH;

--- a/test/TestCases/napi-dotnet/hello.js
+++ b/test/TestCases/napi-dotnet/hello.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 
 /** @type {import('./napi-dotnet')} */

--- a/test/TestCases/napi-dotnet/module_class.js
+++ b/test/TestCases/napi-dotnet/module_class.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 
 /** @type {import('./napi-dotnet')} */

--- a/test/TestCases/napi-dotnet/multi_instance.js
+++ b/test/TestCases/napi-dotnet/multi_instance.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const assert = require('assert');
 const { Worker, isMainThread, parentPort } = require('worker_threads');
 

--- a/test/TestCases/node-addon-api/basic_types/array.cs
+++ b/test/TestCases/node-addon-api/basic_types/array.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/basic_types/array.js
+++ b/test/TestCases/node-addon-api/basic_types/array.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 const assert = require('assert');
 

--- a/test/TestCases/node-addon-api/basic_types/boolean.cs
+++ b/test/TestCases/node-addon-api/basic_types/boolean.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/basic_types/boolean.js
+++ b/test/TestCases/node-addon-api/basic_types/boolean.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/basic_types/number.cs
+++ b/test/TestCases/node-addon-api/basic_types/number.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/basic_types/number.js
+++ b/test/TestCases/node-addon-api/basic_types/number.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /* eslint-disable no-lone-blocks */
 'use strict';
 

--- a/test/TestCases/node-addon-api/basic_types/value.cs
+++ b/test/TestCases/node-addon-api/basic_types/value.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/basic_types/value.js
+++ b/test/TestCases/node-addon-api/basic_types/value.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/binding.cs
+++ b/test/TestCases/node-addon-api/binding.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/test/TestCases/node-addon-api/object/delete_property.cs
+++ b/test/TestCases/node-addon-api/object/delete_property.cs
@@ -1,4 +1,6 @@
-using System;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/object/delete_property.js
+++ b/test/TestCases/node-addon-api/object/delete_property.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/finalizer.cs
+++ b/test/TestCases/node-addon-api/object/finalizer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/object/finalizer.js
+++ b/test/TestCases/node-addon-api/object/finalizer.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/get_property.cs
+++ b/test/TestCases/node-addon-api/object/get_property.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/object/get_property.js
+++ b/test/TestCases/node-addon-api/object/get_property.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/has_own_property.cs
+++ b/test/TestCases/node-addon-api/object/has_own_property.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/object/has_own_property.js
+++ b/test/TestCases/node-addon-api/object/has_own_property.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/has_property.cs
+++ b/test/TestCases/node-addon-api/object/has_property.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/object/has_property.js
+++ b/test/TestCases/node-addon-api/object/has_property.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/object.cs
+++ b/test/TestCases/node-addon-api/object/object.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Runtime.CompilerServices;
 using Microsoft.JavaScript.NodeApi;

--- a/test/TestCases/node-addon-api/object/object.js
+++ b/test/TestCases/node-addon-api/object/object.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/object_freeze_seal.cs
+++ b/test/TestCases/node-addon-api/object/object_freeze_seal.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/object/object_freeze_seal.js
+++ b/test/TestCases/node-addon-api/object/object_freeze_seal.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/set_property.cs
+++ b/test/TestCases/node-addon-api/object/set_property.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using Microsoft.JavaScript.NodeApi;
 

--- a/test/TestCases/node-addon-api/object/set_property.js
+++ b/test/TestCases/node-addon-api/object/set_property.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/object/subscript_operator.cs
+++ b/test/TestCases/node-addon-api/object/subscript_operator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.JavaScript.NodeApi;
 
 namespace Microsoft.JavaScript.NodeApiTest;

--- a/test/TestCases/node-addon-api/object/subscript_operator.js
+++ b/test/TestCases/node-addon-api/object/subscript_operator.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 'use strict';
 
 const assert = require('assert');

--- a/test/TestCases/node-addon-api/testUtil.js
+++ b/test/TestCases/node-addon-api/testUtil.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Run each test function in sequence,
 // with an async delay and GC call between each.
 


### PR DESCRIPTION
Mostly a mechanical change: add to all source files the required Microsoft copyright header.